### PR TITLE
fixes #5

### DIFF
--- a/mainloop.lua
+++ b/mainloop.lua
@@ -115,7 +115,7 @@ do
         {"2P fakevs at burke.ro", main_net_vs_setup, {"burke.ro"}},
 		{"2P fakevs at Jon's server (US-East, beta for spectating and ranking)", main_net_vs_setup, {"18.188.43.50"}},
 		{"2P fakevs at domi1819.xyz (Europe, beta for spectating and ranking)", main_net_vs_setup, {"domi1819.xyz"}},
-		--{"2P fakevs at localhost (development-use only)", main_net_vs_setup, {"localhost"}},
+		{"2P fakevs at localhost (development-use only)", main_net_vs_setup, {"localhost"}},
         {"2P fakevs local game", main_local_vs_setup},
         {"Replay of 1P endless", main_replay_endless},
         {"Replay of 1P puzzle", main_replay_puzzle},

--- a/server.lua
+++ b/server.lua
@@ -179,7 +179,7 @@ Room = class(function(self, a, b)
     if a.user_id and leaderboard.players[a.user_id] and leaderboard.players[a.user_id].rating then
       a_rating = round(leaderboard.players[a.user_id].rating)
     end
-    if a.user_id and leaderboard.players[b.user_id] and leaderboard.players[a.user_id].rating then
+    if b.user_id and leaderboard.players[b.user_id] and leaderboard.players[b.user_id].rating then
       b_rating = round(leaderboard.players[b.user_id].rating)
     end
     self.ratings = {{old=a_rating or DEFAULT_RATING, new=a_rating or DEFAULT_RATING, difference=0},


### PR DESCRIPTION
fixed a bug in server where we were trying at access  player "a"'s rating where it should have been player "b"'s.

It looks like this caused an error trying to access a player's rating (index a nil value) because we didn't check if a user_id or a if that user exists on the leaderboard before getting the rating for that user_id exists before we tried to use it.

I think it's fixed now.
These tests ran as expected, though I didn't try them before this fix was applied

Bob asks for a match with Alice
Alice asks for a match (accepts)
Alice gets player_number 1
Bob gets player_number 2
Bob leaves
Alice asks Bob for a match
Bob Accepts
Bob gets player_number 1
Alice gets player_number 2
Alice wins a ranked match and gets the points for it.
Alice leaves
Bob asks Alice for a match
alice gets player_number 1
bob gets player_number 2
bob wins and gets the points
Alice wins and gets the points.