### PR TITLE
Bugfix reversed player ratings

### DIFF
--- a/mainloop.lua
+++ b/mainloop.lua
@@ -122,7 +122,7 @@ do
         --{"2P vs online at burke.ro", main_net_vs_setup, {"burke.ro"}},
         {"2P vs online at Jon's server", main_net_vs_setup, {"18.188.43.50"}},
         --{"2P vs online at domi1819.xyz (Europe, beta for spectating and ranking)", main_net_vs_setup, {"domi1819.xyz"}},
-        {"2P vs online at localhost (development-use only)", main_net_vs_setup, {"localhost"}},
+        --{"2P vs online at localhost (development-use only)", main_net_vs_setup, {"localhost"}},
         {"2P vs local game", main_local_vs_setup},
         {"Replay of 1P endless", main_replay_endless},
         {"Replay of 1P puzzle", main_replay_puzzle},
@@ -288,6 +288,8 @@ function main_net_vs_room()
   global_op_state = msg.b_menu_state
   if msg.your_player_number then
     my_player_number = msg.your_player_number
+  elseif currently_spectating then
+    my_player_number = 1
   elseif my_player_number and my_player_number ~= 0 then
     print("We assumed our player number is still "..my_player_number)
   else
@@ -297,6 +299,8 @@ function main_net_vs_room()
   end
   if msg.op_player_number then
     op_player_number = msg.op_player_number or op_player_number
+  elseif currently_spectating then
+    op_player_number = 2
   elseif op_player_number and op_player_number ~= 0 then
     print("We assumed op player number is still "..op_player_number)
   else

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -122,7 +122,7 @@ do
         --{"2P vs online at burke.ro", main_net_vs_setup, {"burke.ro"}},
         {"2P vs online at Jon's server", main_net_vs_setup, {"18.188.43.50"}},
         --{"2P vs online at domi1819.xyz (Europe, beta for spectating and ranking)", main_net_vs_setup, {"domi1819.xyz"}},
-        --{"2P vs online at localhost (development-use only)", main_net_vs_setup, {"localhost"}},
+        {"2P vs online at localhost (development-use only)", main_net_vs_setup, {"localhost"}},
         {"2P vs local game", main_local_vs_setup},
         {"Replay of 1P endless", main_replay_endless},
         {"Replay of 1P puzzle", main_replay_puzzle},
@@ -288,15 +288,22 @@ function main_net_vs_room()
   global_op_state = msg.b_menu_state
   if msg.your_player_number then
     my_player_number = msg.your_player_number
+  elseif my_player_number and my_player_number ~= 0 then
+    print("We assumed our player number is still "..my_player_number)
   else
+    error("We never heard from the server as to what player number we are")
+    print("Error: The server never told us our player number.  Assuming it is 1")
     my_player_number = 1
   end
   if msg.op_player_number then
-    op_player_number = msg.op_player_number
+    op_player_number = msg.op_player_number or op_player_number
+  elseif op_player_number and op_player_number ~= 0 then
+    print("We assumed op player number is still "..op_player_number)
   else
+    error("We never heard from the server as to what player number we are")
+    print("Error: The server never told us our player number.  Assuming it is 2")
     op_player_number = 2
   end
-    
     if msg.win_counts then
       update_win_counts(msg.win_counts)
     end
@@ -617,6 +624,8 @@ function main_net_vs_lobby()
   local willing_players = {} -- set
   local spectatable_rooms = {}
   local k = K[1]
+  my_player_number = nil
+  op_player_number = nil
   local notice = {[true]="Select a player name to ask for a match.", [false]="You are all alone in the lobby :("}  
   local leaderboard_string = ""
   local my_rank

--- a/network.lua
+++ b/network.lua
@@ -108,7 +108,7 @@ function network_init(ip)
   end
   TCP_sock:settimeout(0)
   got_H = false
-  net_send("H020")
+  net_send("H021")
   assert(config.name and config.level and config.character)
   json_send({name=config.name, level=config.level, character=config.character})
 end

--- a/network.lua
+++ b/network.lua
@@ -79,7 +79,7 @@ local process_message = {
   L=function(s) P2_level = ({["0"]=10})[s] or (s+0) end,
   --G=function(s) got_opponent = true end,
   H=function(s) got_H = true end,
-  N=function(s) error("Server told us to upgrade the game at burke.ro/panel.zip or the TetrisAttackOnline Discord") end,
+  N=function(s) error("Server told us to upgrade the game at burke.ro/panel.zip (for burke.ro server) or the TetrisAttackOnline Discord (for Jon's Server)") end,
   P=function(s) P1.panel_buffer = P1.panel_buffer..s end,
   O=function(s) P2.panel_buffer = P2.panel_buffer..s end,
   U=function(s) P1.input_buffer = P1.input_buffer..s end,  -- used for P1's inputs when spectating.

--- a/server.lua
+++ b/server.lua
@@ -21,7 +21,7 @@ local PLAYING = "playing" -- room states
 local DEFAULT_RATING = 1500
 
 
-local VERSION = "020"
+local VERSION = "021"
 local type_to_length = {H=4, E=4, F=4, P=8, I=2, L=2, Q=8, U=2}
 local INDEX = 1
 local connections = {}


### PR DESCRIPTION

let clients assume their player number should be what the server said it was at room creation,

rather than, "I'm player 1 and he's player 2" if the server doesn't specify on subsequent games.

The server no longer specifies your player number again in between games.