### PR TITLE
Garbage hover time fix (and other bugfixes)

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -986,7 +986,7 @@ function Stack.PdP(self)
             if panel.combo_size == panel.combo_index then
               self.panels_cleared = self.panels_cleared + 1
               if self.mode == "vs" and self.panels_cleared % level_to_metal_panel_frequency[self.level] == 0 then
-                self.metal_panels_queued = self.metal_panels_queued + 1
+                self.metal_panels_queued = min(self.metal_panels_queued + 1, level_to_metal_panel_cap[self.level])
               end
               SFX_Pop_Play = 1
               self.poppedPanelIndex = panel.combo_index
@@ -1003,7 +1003,7 @@ function Stack.PdP(self)
                   * self.FRAMECOUNT_POP
               self.panels_cleared = self.panels_cleared + 1
               if self.mode == "vs" and self.panels_cleared % level_to_metal_panel_frequency[self.level] == 0 then
-                self.metal_panels_queued = self.metal_panels_queued + 1
+                self.metal_panels_queued = min(self.metal_panels_queued + 1, level_to_metal_panel_cap[self.level])
               end
               SFX_Pop_Play = 1
               self.poppedPanelIndex = panel.combo_index

--- a/engine.lua
+++ b/engine.lua
@@ -685,7 +685,7 @@ function Stack.PdP(self)
 
   -- determine whether to play danger music
     -- Changed this to play danger when something in top 3 rows
-    -- and to play casual when nothing in top 4 rows
+    -- and to play casual when nothing in top 3 rows
     if not self.danger_music then
         -- currently playing casual
         for _, prow in pairs({panels[self.height], panels[self.height-1], panels[self.height-2]}) do
@@ -700,7 +700,7 @@ function Stack.PdP(self)
     else
         --currently playing danger
         local toggle_back = true
-        for _, prow in pairs({panels[self.height], panels[self.height-1], panels[self.height-2], panels[self.height-3]}) do
+        for _, prow in pairs({panels[self.height], panels[self.height-1], panels[self.height-2]}) do
             for idx=1, width do
                 if prow[idx].color ~= 0 then
                     toggle_back = false

--- a/engine.lua
+++ b/engine.lua
@@ -462,6 +462,8 @@ function Panel.clear_flags(self)
   self.is_swapping_from_left = nil
   self.dont_swap = nil
   self.chaining = nil
+  -- Animation timer for "bounce" after falling from garbage.
+  self.fell_from_garbage = nil
   self.state = "normal"
 end
 
@@ -820,6 +822,7 @@ function Stack.PdP(self)
               panel:clear()
               panel.color, panel.chaining = color, chaining
               self:set_hoverers(row,col,self.FRAMECOUNT_GPHOVER,true,true)
+              panel.fell_from_garbage = 12
             else
               panel.state = "normal"
             end
@@ -1032,6 +1035,15 @@ function Stack.PdP(self)
             error("something terrible happened")
           end
         -- the timer-expiring action has completed
+        end
+      end
+      -- Advance the fell-from-garbage bounce timer, or clear it and stop animating if the panel isn't hovering or falling.
+      if cntinue then
+      elseif panel.fell_from_garbage then
+        if panel.state ~= "hovering" and panel.state ~= "falling" then
+          panel.fell_from_garbage = nil
+        else
+          panel.fell_from_garbage = panel.fell_from_garbage - 1
         end
       end
     end

--- a/engine.lua
+++ b/engine.lua
@@ -30,18 +30,19 @@ Stack = class(function(s, which, mode, speed, difficulty, player_number)
       local level = speed or 5
       s.character = (type(difficulty) == "string") and difficulty or s.character
       s.level = level
-      speed = level_to_starting_speed[level]
-      --difficulty = level_to_difficulty[level]
-      s.speed_times = {15*60, idx=1, delta=15*60}
-      s.max_health = level_to_hang_time[level]
-      s.FRAMECOUNT_HOVER  = level_to_hover[s.level]
-      s.FRAMECOUNT_FLASH  = level_to_flash[s.level]
-      s.FRAMECOUNT_FACE   = level_to_face[s.level]
-      s.FRAMECOUNT_POP    = level_to_pop[s.level]
-      s.combo_constant    = level_to_combo_constant[s.level]
-      s.combo_coefficient = level_to_combo_coefficient[s.level]
-      s.chain_constant    = level_to_chain_constant[s.level]
-      s.chain_coefficient = level_to_chain_coefficient[s.level]
+      speed                = level_to_starting_speed[level]
+      --difficulty           = level_to_difficulty[level]
+      s.speed_times        = {15*60, idx=1, delta=15*60}
+      s.max_health         = level_to_hang_time[level]
+      s.FRAMECOUNT_HOVER   = level_to_hover[s.level]
+      s.FRAMECOUNT_GPHOVER = level_to_garbage_panel_hover[s.level]
+      s.FRAMECOUNT_FLASH   = level_to_flash[s.level]
+      s.FRAMECOUNT_FACE    = level_to_face[s.level]
+      s.FRAMECOUNT_POP     = level_to_pop[s.level]
+      s.combo_constant     = level_to_combo_constant[s.level]
+      s.combo_coefficient  = level_to_combo_coefficient[s.level]
+      s.chain_constant     = level_to_chain_constant[s.level]
+      s.chain_coefficient  = level_to_chain_coefficient[s.level]
       if s.mode == "2ptime" then
         s.NCOLORS = level_to_ncolors_time[level]
       else
@@ -818,7 +819,7 @@ function Stack.PdP(self)
               local color, chaining = panel.color, panel.chaining
               panel:clear()
               panel.color, panel.chaining = color, chaining
-              self:set_hoverers(row,col,5,true,true)
+              self:set_hoverers(row,col,self.FRAMECOUNT_GPHOVER,true,true)
             else
               panel.state = "normal"
             end
@@ -1718,7 +1719,7 @@ function Stack.check_matches(self)
 
   local pre_stop_time = self.FRAMECOUNT_MATCH +
       self.FRAMECOUNT_POP * (combo_size + garbage_size)
-  local garbage_match_time = self.FRAMECOUNT_MATCH + garbage_bounce_time +
+  local garbage_match_time = self.FRAMECOUNT_MATCH +
       self.FRAMECOUNT_POP * (combo_size + garbage_size)
   garbage_index=garbage_size-1
   combo_index=combo_size
@@ -1731,7 +1732,6 @@ function Stack.check_matches(self)
         panel.timer = garbage_match_time + 1
         panel.initial_time = garbage_match_time
         panel.pop_time = self.FRAMECOUNT_POP * garbage_index
-            + garbage_bounce_time
         panel.pop_index = min(max(garbage_size - garbage_index,1),10)
         panel.y_offset = panel.y_offset - 1
         panel.height = panel.height - 1

--- a/globals.lua
+++ b/globals.lua
@@ -16,8 +16,7 @@ bounce_table = {1, 1, 1, 1,
                 3, 3, 3,
                 4, 4, 4}
 
-garbage_bounce_table = {
-                        2, 2, 2,
+garbage_bounce_table = {2, 2, 2,
                         3, 3, 3,
                         4, 4, 4,
                         1, 1}

--- a/globals.lua
+++ b/globals.lua
@@ -121,6 +121,8 @@ level_to_ncolors_vs            = {  5,  5,  5,  5,  5,  5,  5,  5,  6,  6}
 level_to_ncolors_time          = {  5,  5,  6,  6,  6,  6,  6,  6,  6,  6}
 -- How long panels will hover if not supported by anything, in frames.
 level_to_hover                 = { 12, 12, 11, 10,  9,  6,  5,  4,  3,  6}
+-- How long newly-transformed panels from garbage will hover before falling, in frames.
+level_to_garbage_panel_hover   = { 40, 35, 30, 25, 20, 15, 12,  9,  6,  3}
 -- How long panels flash for before popping, in frames.
 level_to_flash                 = { 44, 44, 42, 42, 38, 36, 34, 32, 30, 28}
 -- How long panels remain in their "face" frame before popping, in frames.

--- a/globals.lua
+++ b/globals.lua
@@ -122,7 +122,7 @@ level_to_ncolors_time          = {  5,  5,  6,  6,  6,  6,  6,  6,  6,  6}
 -- How long panels will hover if not supported by anything, in frames.
 level_to_hover                 = { 12, 12, 11, 10,  9,  6,  5,  4,  3,  6}
 -- How long newly-transformed panels from garbage will hover before falling, in frames.
-level_to_garbage_panel_hover   = { 40, 35, 30, 25, 20, 15, 12,  9,  6,  3}
+level_to_garbage_panel_hover   = { 41, 36, 31, 26, 21, 16, 13, 10,  7,  4}
 -- How long panels flash for before popping, in frames.
 level_to_flash                 = { 44, 44, 42, 42, 38, 36, 34, 32, 30, 28}
 -- How long panels remain in their "face" frame before popping, in frames.

--- a/globals.lua
+++ b/globals.lua
@@ -109,20 +109,36 @@ panels_to_next_speed =
 -- A level is a speed, a difficulty, and an amount of time
 -- that can be spent at the top of the screen without dying.
 -- level also determines the number of colors
-level_to_starting_speed    = {  1,  5,  9, 13, 17, 21, 25, 29, 27, 32}
 --level_to_difficulty        = {  1,  1,  2,  2,  2,  2,  2,  3,  3,  3}
-level_to_hang_time         = {121,100, 80, 65, 50, 40, 30, 20, 10,  1}
-level_to_ncolors_vs        = {  5,  5,  5,  5,  5,  5,  5,  5,  6,  6}
-level_to_ncolors_time      = {  5,  5,  6,  6,  6,  6,  6,  6,  6,  6}
-level_to_hover             = { 12, 12, 11, 10,  9,  6,  5,  4,  3,  6}
-level_to_pop               = {  9,  9,  8,  8,  8,  8,  8,  7,  7,  7}
-level_to_flash             = { 44, 44, 42, 42, 38, 36, 34, 32, 30, 28}
-level_to_face              = { 15, 14, 14, 13, 12, 11, 10, 10,  9,  8}
-level_to_combo_constant    = {-20,-16,-12, -8, -3,  2,  7, 12, 17, 22}
-level_to_combo_coefficient = { 20, 18, 16, 14, 12, 10,  8,  6,  4,  2}
-level_to_chain_constant    = { 80, 77, 74, 71, 68, 65, 62, 60, 58, 56}
-level_to_chain_coefficient = { 20, 18, 16, 14, 12, 10,  8,  6,  4,  2}
 
+-- What speed level you start on.
+level_to_starting_speed        = {  1,  5,  9, 13, 17, 21, 25, 29, 27, 32}
+-- How long you can spend at the top of the screen without dying, in frames ("Health").
+level_to_hang_time             = {121,101, 81, 66, 51, 41, 31, 21, 11,  1}
+-- How many colors of panels can spawn in VS mode, not including metal panels.
+level_to_ncolors_vs            = {  5,  5,  5,  5,  5,  5,  5,  5,  6,  6}
+-- How many colors of panels can spawn in time trial mode.
+level_to_ncolors_time          = {  5,  5,  6,  6,  6,  6,  6,  6,  6,  6}
+-- How long panels will hover if not supported by anything, in frames.
+level_to_hover                 = { 12, 12, 11, 10,  9,  6,  5,  4,  3,  6}
+-- How long panels flash for before popping, in frames.
+level_to_flash                 = { 44, 44, 42, 42, 38, 36, 34, 32, 30, 28}
+-- How long panels remain in their "face" frame before popping, in frames.
+-- (They actually stay in their face frame for five frames longer than the numbers in this table for some reason...
+--  This makes timings accurate with Tetris Attack / Panel de Pon SFC.)
+level_to_face                  = { 20, 18, 17, 16, 15, 14, 13, 12, 11, 10}
+-- How long panels take to pop after finishing their "face" frame, in frames.
+level_to_pop                   = {  9,  9,  8,  8,  8,  8,  8,  7,  7,  7}
+-- How long the stack stops when you clear combos, in frames.
+level_to_combo_constant        = {-20,-16,-12, -8, -3,  2,  7, 12, 17, 22}
+level_to_combo_coefficient     = { 20, 18, 16, 14, 12, 10,  8,  6,  4,  2}
+-- How long the stack stops when you clear chains, in frames.
+level_to_chain_constant        = { 80, 77, 74, 71, 68, 65, 62, 60, 58, 56}
+level_to_chain_coefficient     = { 20, 18, 16, 14, 12, 10,  8,  6,  4,  2}
+-- How many panels you have to pop to earn a metal panel in your next row.
+level_to_metal_panel_frequency = { 12, 14, 16, 19, 23, 26, 29, 33, 37, 41}
+-- How many panels you can have at most in your metal panel queue.
+level_to_metal_panel_cap       = { 21, 18, 18, 15, 15, 12,  9,  6,  6,  3}
 
 
 -- Stage clear seems to use a variant of vs mode's speed system,
@@ -231,8 +247,6 @@ panel_color_to_number = { ["A"]=1, ["B"]=2, ["C"]=3, ["D"]=4, ["E"]=5, ["F"]=6, 
                           ["1"]=1, ["2"]=2, ["3"]=3, ["4"]=4, ["5"]=5, ["6"]=6, ["7"]=7, ["8"]=8,
                           ["0"]=0}
                                 
---how many panels you have to pop to earn a metal panel in your next row.
-level_to_metal_panel_frequency = {12, 14, 16, 19, 23, 26, 29, 33, 37, 41}
             
 -- win counters
 my_win_count = 0

--- a/graphics.lua
+++ b/graphics.lua
@@ -283,9 +283,8 @@ function Stack.render(self)
                   draw(imgs.pop, draw_x, draw_y, 0, 16/popped_w, 16/popped_h)
                 end
               elseif panel.y_offset == -1 then
-                local p_w, p_h = IMG_panels[panel.color][garbage_bounce_table[panel.timer] or 1]:getDimensions()
-                draw(IMG_panels[panel.color][
-                    garbage_bounce_table[panel.timer] or 1], draw_x, draw_y, 0, 16/p_w, 16/p_h)
+                local p_w, p_h = IMG_panels[panel.color][1]:getDimensions()
+                draw(IMG_panels[panel.color][1], draw_x, draw_y, 0, 16/p_w, 16/p_h)
               end
             elseif flash_time % 2 == 1 then
               if panel.metal then
@@ -333,6 +332,8 @@ function Stack.render(self)
             end
           elseif panel.state == "dimmed" then
             draw_frame = 7
+          elseif panel.fell_from_garbage then
+            draw_frame = garbage_bounce_table[panel.fell_from_garbage] or 1
           elseif self.danger_col[col] then
             draw_frame = danger_bounce_table[
               wrap(1,self.danger_timer+1+floor((col-1)/2),#danger_bounce_table)]


### PR DESCRIPTION
This fixes the issues where garbage hovered for too long on high levels and not long enough on low levels by adding in proper hover timings for panels generated from matched garbage blocks by level.  A demonstration video of what it looks like is at https://youtu.be/crGtP69HCBw.

I also fixed a minor danger music-related bug where danger music would start playing when your field was 10 rows tall but wouldn't stop until you cleared back down to 8 rows tall; fixed what seemed like off-by-one errors in the max health table (all the values except lv1 and lv10 were one lower than they should have been); and also implemented proper caps on the metal/shock panel queue per level.

All these changes should make Panel Attack more closely match Tetris Attack / Panel de Pon SFC's timings and behaviours.  Unfortunately, I assume it probably means old replays won't sync properly, and online probably also won't sync with old versions.