### PR TITLE
Smoother netplay / spectating

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -1052,7 +1052,12 @@ function Stack.PdP(self)
             -- if a timer runs out and the routine can't
             -- figure out what flag it is, tell brandon.
             -- No seriously, email him or something.
-            error("something terrible happened")
+            error("something terrible happened\n"
+              .. "panel.state was " .. tostring(panel.state) .. " when a timer expired?!\n"
+              .. "panel.is_swapping_from_left = " .. tostring(panel.is_swapping_from_left) .. "\n"
+              .. "panel.dont_swap = " .. tostring(panel.dont_swap) .. "\n"
+              .. "panel.chaining = " .. tostring(panel.chaining)
+              )
           end
         -- the timer-expiring action has completed
         end

--- a/engine.lua
+++ b/engine.lua
@@ -558,8 +558,22 @@ end
 
 --foreign_run is for a stack that belongs to another client.
 function Stack.foreign_run(self)
-  local times_to_run = min(string.len(self.input_buffer),
-      self.max_runs_per_frame)
+  -- Decide how many frames of input we should run.
+  local times_to_run = 0
+  local buffer_len = string.len(self.input_buffer)
+
+  -- If we're way behind, run at max speed.
+  if buffer_len >= 15 then
+    times_to_run = self.max_runs_per_frame
+  -- When we're closer, run fewer per frame, so things are less choppy.
+  -- This might have a side effect of being a little farther behind on average,
+  -- since we don't always run at top speed until the buffer is empty.
+  elseif buffer_len >= 10 then
+    times_to_run = 2
+  elseif buffer_len >= 1 then
+    times_to_run = 1
+  end
+
   if self.play_to_end then
     if string.len(self.input_buffer) < 4 then
       self.play_to_end = nil

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -386,7 +386,9 @@ function main_character_select()
       end
       gprint("Waiting for room initialization...", 300, 280)
       wait()
-      do_messages()
+      if not do_messages() then
+        return main_dumb_transition, {main_select_mode, "Disconnected from server.\n\nReturning to main menu...", 60, 300}
+      end
       retries = retries + 1
     end
     -- if room_number_last_spectated and retries >= retry_limit and currently_spectating then
@@ -400,12 +402,14 @@ function main_character_select()
         -- end
         -- gprint("Lost connection.  Trying to rejoin...", 300, 280)
         -- wait()
-        -- do_messages()
+        -- if not do_messages() then
+        --   return main_dumb_transition, {main_select_mode, "Disconnected from server.\n\nReturning to main menu...", 60, 300}
+        -- end
         -- retries = retries + 1
       -- end
     -- end
     if not global_initialize_room_msg then
-      return main_dumb_transition, {main_select_mode, "Failed to connect.\n\nReturning to main menu", 60, 300}
+      return main_dumb_transition, {main_select_mode, "Room initialization failed.\n\nReturning to main menu...", 60, 300}
     end
     msg = global_initialize_room_msg
     global_initialize_room_msg = nil
@@ -729,7 +733,9 @@ function main_character_select()
           end
           for i=1,30 do
             gprint(to_print,300, 280)
-            do_messages()
+            if not do_messages() then
+              return main_dumb_transition, {main_select_mode, "Disconnected from server.\n\nReturning to main menu...", 60, 300}
+            end
             wait()
           end
           local game_start_timeout = 0
@@ -743,7 +749,9 @@ function main_character_select()
             print("P1.gpanel_buffer = "..P1.gpanel_buffer)
             print("P2.gpanel_buffer = "..P2.gpanel_buffer)
             gprint(to_print,300, 280)
-            do_messages()
+            if not do_messages() then
+              return main_dumb_transition, {main_select_mode, "Disconnected from server.\n\nReturning to main menu...", 60, 300}
+            end
             wait()
             if game_start_timeout > 250 then
               return main_dumb_transition, {main_select_mode,
@@ -936,7 +944,9 @@ function main_character_select()
       return main_dumb_transition, {main_local_vs_yourself, "Game is starting...", 30, 30}
     end
     if character_select_mode == "2p_net_vs" then
-      do_messages()
+      if not do_messages() then
+        return main_dumb_transition, {main_select_mode, "Disconnected from server.\n\nReturning to main menu...", 60, 300}
+      end
     end
   end
 end
@@ -1164,7 +1174,9 @@ function main_net_vs_lobby()
       print("#items: "..#items.."  idx_old: "..prev_act_idx.."  idx_new: "..active_idx.."  active_back: "..tostring(active_back))
       prev_act_idx = active_idx
     end
-    do_messages()
+    if not do_messages() then
+      return main_dumb_transition, {main_select_mode, "Disconnected from server.\n\nReturning to main menu...", 60, 300}
+    end
   end
 end
 
@@ -1224,7 +1236,9 @@ function main_net_vs_setup(ip)
   while not connection_is_ready() do
     gprint("Connecting...", 300, 280)
     wait()
-    do_messages()
+    if not do_messages() then
+      return main_dumb_transition, {main_select_mode, "Disconnected from server.\n\nReturning to main menu...", 60, 300}
+    end
   end
   connected_server_ip = ip
   logged_in = false
@@ -1234,14 +1248,18 @@ function main_net_vs_setup(ip)
   while got_opponent == nil do
     gprint("Waiting for opponent...", 300, 280)
     wait()
-    do_messages()
+    if not do_messages() then
+      return main_dumb_transition, {main_select_mode, "Disconnected from server.\n\nReturning to main menu...", 60, 300}
+    end
   end
   while P1_level == nil or P2_level == nil do
     to_print = (P1_level and "L" or"Choose l") .. "evel: "..my_level..
         "\nOpponent's level: "..(P2_level or "???")
     gprint(to_print, 300, 280)
     wait()
-    do_messages()
+    if not do_messages() then
+      return main_dumb_transition, {main_select_mode, "Disconnected from server.\n\nReturning to main menu...", 60, 300}
+    end
     variable_step(function()
       if P1_level then
       elseif menu_enter(k) then
@@ -1280,14 +1298,18 @@ function main_net_vs_setup(ip)
   end
   for i=1,30 do
     gprint(to_print,300, 280)
-    do_messages()
     wait()
+    if not do_messages() then
+      return main_dumb_transition, {main_select_mode, "Disconnected from server.\n\nReturning to main menu...", 60, 300}
+    end
   end
   while P1.panel_buffer == "" or P2.panel_buffer == ""
     or P1.gpanel_buffer == "" or P2.gpanel_buffer == "" do
     gprint(to_print,300, 280)
-    do_messages()
     wait()
+    if not do_messages() then
+      return main_dumb_transition, {main_select_mode, "Disconnected from server.\n\nReturning to main menu...", 60, 300}
+    end
   end
   P1:starting_state()
   P2:starting_state()
@@ -1350,7 +1372,9 @@ function main_net_vs()
         json_send({leave_room=true})
         return main_net_vs_lobby
       end
-      do_messages()
+      if not do_messages() then
+        return main_dumb_transition, {main_select_mode, "Disconnected from server.\n\nReturning to main menu...", 60, 300}
+      end
     end
 
     print(P1.CLOCK, P2.CLOCK)
@@ -2379,9 +2403,11 @@ function main_dumb_transition(next_func, text, timemin, timemax)
         ret = {next_func}
       end
       t = t + 1
-      if TCP_sock then
-      --  do_messages()
-      end
+      --if TCP_sock then
+      --  if not do_messages() then
+      --    -- do something? probably shouldn't drop back to the main menu transition since we're already here
+      --  end
+      --end
     end)
     if ret then
       return unpack(ret)

--- a/network.lua
+++ b/network.lua
@@ -11,9 +11,12 @@ function flush_socket()
   local junk,err,data = TCP_sock:receive('*a')
   -- lol, if it returned successfully then that's bad!
   if not err then
-    error("the connection closed unexpectedly")
+    -- Return false, so we know things went badly
+    return false
   end
   leftovers = leftovers..data
+  -- When done, return true, so we know things went okay
+  return true
 end
 
 function close_socket()
@@ -123,7 +126,11 @@ function connection_is_ready()
 end
 
 function do_messages()
-  flush_socket()
+  if not flush_socket() then
+    -- Something went wrong while receiving data.
+    -- Bail out and return.
+    return false
+  end
   while true do
     local typ, data = get_message()
     if typ then
@@ -148,6 +155,8 @@ function do_messages()
       break
     end
   end
+  -- Return true when finished successfully.
+  return true
 end
 
 function request_game(name)


### PR DESCRIPTION
Working on porting some of Xkeeper's changes; this changes spectating so it buffers remote inputs a bit smoother, and also fixes #96 so disconnects shouldn't bluescreen the game anymore (they'll dump you back at the main menu instead).