### PR TITLE
hide warnings, add 2 new options on game updater

### DIFF
--- a/auto_updater/README.txt
+++ b/auto_updater/README.txt
@@ -1,5 +1,5 @@
 Here is the process to publish the auto_updater: 
-- configure CHECK_INTERVAL and UPDATER_NAME in main.lua
+- configure UPDATER_NAME in main.lua
 - configure updater_config.lua with the server_url
 - copy the last version of the game here in this folder "any-name.love"
 - make the exe auto_updater, publish with a name like "panel.zip" or "panel-beta.zip", ...

--- a/auto_updater/_config.lua
+++ b/auto_updater/_config.lua
@@ -1,5 +1,7 @@
 updater_config = {
     auto_update= true,
+    launch_check_interval= 6 * 3600, -- in seconds (default 6h) will check for updates at launch if interval has passed (it will always check for updates ingame in background)
+    launch_check_timeout= 0.4, -- in seconds (default 400ms) time before aborting the check for updates request at launch, it will always take all the time needed ingame in background
     server_url= "http://panelattack.com/updates",
     force_version= "", -- ex: "panel-2019-11-17.love"
 }

--- a/auto_updater/game_updater.lua
+++ b/auto_updater/game_updater.lua
@@ -43,8 +43,8 @@ function GameUpdater.async(self, function_name, ...)
 end
 
 -- returns thread channel [async returns sorted list of all versions available on the server]
-function GameUpdater.async_download_available_versions(self, timeout, max_size)
-  return self:async("download_available_versions", self.config.server_url, timeout, max_size, self.timestamp_file)
+function GameUpdater.async_download_available_versions(self, max_size)
+  return self:async("download_available_versions", self.config.server_url, self.config.launch_check_timeout, max_size, self.timestamp_file)
 end
 
 -- returns thread channel [async returns bool download success]

--- a/auto_updater/main.lua
+++ b/auto_updater/main.lua
@@ -1,11 +1,9 @@
 require("game_updater")
 
 -- CONSTANTS
-local CHECK_INTERVAL = 6 * 3600 -- * 6 hours hours to seconds
 local UPDATER_NAME = "panel" -- you should name the distributed auto updater zip the same as this
 -- use a different name for the different versions of the updater
 -- ex: "panel" for the release, "panel-beta" for the main beta, "panel-exmode" for testing the EX Mode
-local TIMEOUT = 0.4 -- 500ms for the tcp socket to respond
 local MAX_REQ_SIZE = 100000 -- 100kB
 
 -- GLOBALS
@@ -33,12 +31,12 @@ function love.load()
   -- should we check for an update?
   if GAME_UPDATER.config.auto_update and not (
     GAME_UPDATER.check_timestamp ~= nil 
-    and os.time() < GAME_UPDATER.check_timestamp + CHECK_INTERVAL 
+    and os.time() < GAME_UPDATER.check_timestamp + GAME_UPDATER.config.launch_check_interval 
     and local_version
     and (GAME_UPDATER.config.force_version == "" or GAME_UPDATER.config.force_version == local_version)) then
 
     -- Check for a version online
-    wait_all_versions = GAME_UPDATER:async_download_available_versions(TIMEOUT, MAX_REQ_SIZE)
+    wait_all_versions = GAME_UPDATER:async_download_available_versions(MAX_REQ_SIZE)
   end
 
   next_step = "check_versions"

--- a/globals.lua
+++ b/globals.lua
@@ -46,6 +46,9 @@ SFX_GameOver_Play = 0
 global_my_state = nil
 global_op_state = nil
 
+-- Warning messages
+display_warning_message = false
+
 -- game can be paused while playing on local
 game_is_paused = false
 
@@ -69,9 +72,9 @@ config = {
 	character                     = random_character_special_value,
 	stage                         = random_stage_special_value,
 
-	ranked 						  = true,
+	ranked                        = true,
 
-	vsync						  = true,
+	vsync                         = true,
 
 	use_music_from                = "either",
 	-- Level (2P modes / 1P vs yourself mode)
@@ -103,12 +106,11 @@ config = {
 
 current_use_music_from = "stage" -- either "stage" or "characters", no other values!
 
-is_first_warning = true
 function warning(msg)
 	err = "=================================================================\n["..os.date("%x %X").."]\nError: "..msg..debug.traceback("").."\n"
 	love.filesystem.append("warnings.txt", err)
-	if is_first_warning then
-		is_first_warning = false
+	if display_warning_message then
+		display_warning_message = false
 		local loc_warning = "You've had a bug. Please report this on Discord with file:"
 		if loc ~= nil then
 			local str = loc("warning_msg")


### PR DESCRIPTION
Players will have to redowload a packaged auto updater if they want to have these new options (but not mandatory)

If you want the game to always check for updates at startup set launch_check_interval to 0.
If you have a really slow connection, you can set launch_check_timeout a bit higher. For example 1.5s to give it more time to wait for the server to respond.