### PR TITLE
Overlapping garbage fix

### DIFF
--- a/consts.lua
+++ b/consts.lua
@@ -1,7 +1,7 @@
 require("util")
 
 -- The values in this file are constants (except in this file perhaps) and are expected never to change during the game, not to be confused with globals!
-VERSION = "042"
+VERSION = "043"
 
 canvas_width = 1280
 canvas_height = 720

--- a/engine.lua
+++ b/engine.lua
@@ -1369,14 +1369,15 @@ function Stack.PdP(self)
     local next_garbage_block_width, next_garbage_block_height, _metal, from_chain = unpack(self.garbage_q:peek())
     local drop_it = 
       not self.panels_in_top_row
-      --and not self:has_falling_garbage()
       and (
         (from_chain and next_garbage_block_height > 1) or
         (self.n_active_panels == 0 and
         self.prev_active_panels == 0) 
       )
     if drop_it and self.garbage_q:len() > 0 then
-      self:drop_garbage(unpack(self.garbage_q:pop()))
+      if self:drop_garbage(unpack(self.garbage_q:peek())) then
+        self.garbage_q:pop()
+      end
     end
   end
   --Play Sounds / music
@@ -1666,6 +1667,8 @@ function Stack.drop_garbage(self, width, height, metal)
       end
     end
   end
+
+  return true
 end
 
 -- prepare to send some garbage!
@@ -1784,8 +1787,6 @@ function Stack.check_matches(self)
   local first_panel_col = 0
   local combo_index, garbage_index = 0, 0
   local combo_size, garbage_size = 0, 0
-  local something = 0
-  local whatever = 0
   local panels = self.panels
   local q, garbage = Queue(), {}
   local seen, seenm = {}, {}
@@ -1996,12 +1997,12 @@ function Stack.check_matches(self)
       --EnqueueConfetti(first_panel_col<<4+P1StackPosX+4,
       --          first_panel_row<<4+P1StackPosY+self.displacement-9);
     end
-    something = self.chain_counter
+    local chain_bonus = self.chain_counter
     if(score_mode == SCOREMODE_TA) then
       if(self.chain_counter>13) then
-        something=0
+        chain_bonus = 0
       end
-      self.score = self.score + score_chain_TA[something]
+      self.score = self.score + score_chain_TA[chain_bonus]
     end
     if((combo_size>3) or is_chain) then
       local stop_time

--- a/engine.lua
+++ b/engine.lua
@@ -1365,10 +1365,12 @@ function Stack.PdP(self)
     local next_garbage_block_width, next_garbage_block_height, _metal, from_chain = unpack(self.garbage_q:peek())
     local cols = self.garbage_cols[next_garbage_block_width]
     local spawn_col = cols[cols.idx]
-    local spawn_row = #self.panels
-    for idx=spawn_col, spawn_col+next_garbage_block_width-1 do
-      if prow[idx]:dangerous() then 
-        garbage_fits_in_populated_top_row = nil
+    local spawn_row = #self.panels + 1
+    for row_idx = top_row, spawn_row - 1 do
+      for col_idx = spawn_col, spawn_col + next_garbage_block_width - 1 do
+        if panels[row_idx][col_idx]:dangerous() then
+          garbage_fits_in_populated_top_row = nil
+        end
       end
     end
     local drop_it = 
@@ -1625,13 +1627,16 @@ end
 
 -- drops a width x height garbage.
 function Stack.drop_garbage(self, width, height, metal)
-  local spawn_row = #self.panels
-  for i=#self.panels+1,#self.panels+height+1 do
+  print("Dropping garbage...")
+  print("Width " .. tostring(width) .. " Height " .. tostring(height) .. " Metal " .. tostring(metal))
+  local spawn_row = #self.panels + 1
+  for i = spawn_row, spawn_row + height do
     self.panels[i] = {}
     for j=1,self.width do
       self.panels[i][j] = Panel()
     end
   end
+  print("New Stack size = " .. tostring(#self.panels))
   local cols = self.garbage_cols[width]
   local spawn_col = cols[cols.idx]
   cols.idx = wrap(1, cols.idx+1, #cols)

--- a/engine.lua
+++ b/engine.lua
@@ -81,8 +81,7 @@ Stack = class(function(s, which, mode, panels_dir, speed, difficulty, player_num
     s.panels = {}
     s.width = 6
     s.height = 12
-    -- Garbage spawns 3 rows above the playfield, so make sure there are enough rows generated for it.
-    for i=0,s.height+3 do
+    for i=0,s.height do
       s.panels[i] = {}
       for j=1,s.width do
         s.panels[i][j] = Panel()
@@ -1638,9 +1637,6 @@ function Stack.drop_garbage(self, width, height, metal)
     end
   end
 
-  print("Dropping garbage...")
-  print("spawn_row = " .. tostring(spawn_row))
-  print("Width " .. tostring(width) .. " Height " .. tostring(height) .. " Metal " .. tostring(metal))
   for i = self.height + 1, spawn_row + height - 1 do
     if not self.panels[i] then
       self.panels[i] = {}
@@ -1649,8 +1645,6 @@ function Stack.drop_garbage(self, width, height, metal)
       end
     end
   end
-
-  print("New Stack size = " .. tostring(#self.panels))
 
   local cols = self.garbage_cols[width]
   local spawn_col = cols[cols.idx]

--- a/server.lua
+++ b/server.lua
@@ -23,7 +23,7 @@ local PLAYING = "playing" -- room states
 local sep = package.config:sub(1, 1) --determines os directory separator (i.e. "/" or "\")
 
 
-local VERSION = "042"
+local VERSION = "043"
 local type_to_length = {H=4, E=4, F=4, P=8, I=2, L=2, Q=8, U=2}
 local INDEX = 1
 local connections = {}


### PR DESCRIPTION
This fixes garbage blocks spawning overlapping one another by preventing garbage spawns if garbage is in the way, and also changing how garbage spawns slightly.  This will probably require a server version update, since gameplay logic is slightly changing.

There are also some unrelated code cleanup fixes in here from other patches I was working on (in Panel:dangerous() and Stack:check_matches() ).