### PR TITLE
Revert garbage spawns

### DIFF
--- a/consts.lua
+++ b/consts.lua
@@ -1,7 +1,7 @@
 require("util")
 
 -- The values in this file are constants (except in this file perhaps) and are expected never to change during the game, not to be confused with globals!
-VERSION = "043"
+VERSION = "044"
 
 canvas_width = 1280
 canvas_height = 720

--- a/engine.lua
+++ b/engine.lua
@@ -1369,6 +1369,7 @@ function Stack.PdP(self)
     local next_garbage_block_width, next_garbage_block_height, _metal, from_chain = unpack(self.garbage_q:peek())
     local drop_it = 
       not self.panels_in_top_row
+      and not self:has_falling_garbage()
       and (
         (from_chain and next_garbage_block_height > 1) or
         (self.n_active_panels == 0 and
@@ -1622,7 +1623,7 @@ end
 
 -- drops a width x height garbage.
 function Stack.drop_garbage(self, width, height, metal)
-  local spawn_row = self.height + 3
+  local spawn_row = self.height + 1
 
   -- Do one last check for panels in the way.
   for i = spawn_row, #self.panels do
@@ -1637,6 +1638,8 @@ function Stack.drop_garbage(self, width, height, metal)
       end
     end
   end
+
+  print(string.format("Dropping garbage on player %d - height %d  width %d  %s", self.player_number, height, width, metal and "Metal" or ""))
 
   for i = self.height + 1, spawn_row + height - 1 do
     if not self.panels[i] then

--- a/server.lua
+++ b/server.lua
@@ -23,7 +23,7 @@ local PLAYING = "playing" -- room states
 local sep = package.config:sub(1, 1) --determines os directory separator (i.e. "/" or "\")
 
 
-local VERSION = "043"
+local VERSION = "044"
 local type_to_length = {H=4, E=4, F=4, P=8, I=2, L=2, Q=8, U=2}
 local INDEX = 1
 local connections = {}


### PR DESCRIPTION
Version 043 was changed to incorrectly spawn garbage in row 15 and not
wait for all garbage to fall before dropping more.  This has been
reverted, so garbage spawns in row 13 and waits for all garbage to fall
before dropping more.

Requires a server update, again.