### PR TITLE
Pause and unpause the music when the game is paused or unpaused

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -1382,7 +1382,7 @@ function Stack.PdP(self)
     end
   end
   --Play Sounds / music
-  if not music_mute and not (P1 and P1.play_to_end) and not (P2 and P2.play_to_end) then
+  if not music_mute and not game_is_paused and not (P1 and P1.play_to_end) and not (P2 and P2.play_to_end) then
 
     if self.do_countdown then 
       if SFX_Go_Play == 1 then

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -328,6 +328,10 @@ function Stack.handle_pause(self)
   if keys[k.pause] or this_frame_keys[k.pause] then
     game_is_paused = not game_is_paused
     self.wait_for_not_pausing = true
+
+    if game_is_paused then
+      stop_the_music()
+    end
   end
 
 end


### PR DESCRIPTION
Because the music continuing to play when the game is paused is rather annoying.

I'd love to make other usability improvements to the pause screen as well (e.g. adding a pause menu; it's a little annoying to have to run your stack up in order to exit a level, or being unable to adjust the volume), but this will do for starters.

I'm not sure what the contribution guidelines are for this repo. I verified that pausing and unpausing still work correctly with these changes in all 1P modes.