### PR TITLE
Replay browser QOL

### DIFF
--- a/mainloop.lua
+++ b/mainloop.lua
@@ -1105,7 +1105,7 @@ function main_replay_vs()
     local ret = nil
     variable_step(function()
       if menu_escape(K[1]) then
-        ret = {main_dumb_transition, {main_select_mode, "", 0, 0}}
+        ret = {main_dumb_transition, {replay_browser.main, "", 0, 0}}
       end
       if menu_enter(K[1]) then
         run = not run
@@ -1197,7 +1197,7 @@ function main_replay_endless()
         if P1.game_over then
         -- TODO: proper game over.
           local end_text = loc("rp_score", P1.score, frames_to_time_string(P1.game_stopwatch, true))
-          ret = {game_over_transition, {main_select_mode, end_text, P1:pick_win_sfx()}}
+          ret = {game_over_transition, {replay_browser.main, end_text, P1:pick_win_sfx()}}
         end
         P1:run()
         P1:handle_pause()
@@ -1250,9 +1250,9 @@ function main_replay_puzzle()
         if P1.n_active_panels == 0 and
             P1.prev_active_panels == 0 then
           if P1:puzzle_done() then
-            ret = {main_dumb_transition, {main_select_mode, loc("pl_you_win"), 30, -1, P1:pick_win_sfx()}}
+            ret = {main_dumb_transition, {replay_browser.main, loc("pl_you_win"), 30, -1, P1:pick_win_sfx()}}
           elseif P1.puzzle_moves == 0 then
-            ret = {main_dumb_transition, {main_select_mode, loc("pl_you_lose"), 30, -1}}
+            ret = {main_dumb_transition, {replay_browser.main, loc("pl_you_lose"), 30, -1}}
           end
         end
         P1:run()

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -51,7 +51,6 @@ function fmainloop()
   read_conf_file()
   local x, y, display = love.window.getPosition()
   love.window.setPosition( config.window_x or x, config.window_y or y, config.display or display )
-  love.window.setFullscreen(config.fullscreen or false)
   love.window.setVSync( config.vsync and 1 or 0 )
   gprint("Loading localization...", unpack(main_menu_screen_pos))
   wait()
@@ -1794,13 +1793,8 @@ end
 
 function love.quit()
   love.audio.stop()
-  if love.window.getFullscreen() == true then
-    null, null, config.display = love.window.getPosition()
-  else
-    config.window_x, config.window_y, config.display = love.window.getPosition()
-    config.window_x = math.max(config.window_x, 0)
-    config.window_y = math.max(config.window_y, 30) --don't let 'y' be zero, or the title bar will not be visible on next launch.
-  end
-  config.fullscreen = love.window.getFullscreen()
+  config.window_x, config.window_y, config.display = love.window.getPosition()
+  config.window_x = math.max(config.window_x, 0)
+  config.window_y = math.max(config.window_y, 30) --don't let 'y' be zero, or the title bar will not be visible on next launch.
   write_conf_file()
 end

--- a/replay_browser.lua
+++ b/replay_browser.lua
@@ -215,4 +215,10 @@ function replay_browser.main()
 
 end
 
+function set_replay_browser_path(path)
+  local newpath = string.sub(path, (string.len(replay_browser.base_path) + 1))
+  print(newpath)
+  replay_browser.current_path = newpath
+end
+
 return replay_browser

--- a/save.lua
+++ b/save.lua
@@ -112,7 +112,6 @@ function read_conf_file() pcall(function()
   if type(read_data.window_x) == "number" then config.window_x = read_data.window_x end
   if type(read_data.window_y) == "number" then config.window_y = read_data.window_y end
   if type(read_data.display) == "number" then config.display = read_data.display end
-  if type(read_data.fullscreen) == "boolean" then config.fullscreen = read_data.fullscreen end
 
   file:close()
 end) end

--- a/save.lua
+++ b/save.lua
@@ -133,6 +133,7 @@ function write_replay_file(path, filename) pcall(function()
   if path and filename then
     love.filesystem.createDirectory(path)
     file = love.filesystem.newFile(path.."/"..filename)
+    set_replay_browser_path(path)
   else
     file = love.filesystem.newFile("replay.txt")
   end


### PR DESCRIPTION
At the end of a replay, instead of returning to the main menu, the game now returns back to the replay browser.

In addition, after completing an endless, puzzle, or versus game, the browser will automatically open up to the replay browser to the most recently played game.