### PR TITLE
Networking Code Improvements

### DIFF
--- a/character.lua
+++ b/character.lua
@@ -346,7 +346,7 @@ end
 function Character.graphics_init(self,full,yields)
   local character_images = full and other_images or basic_images
   for _,image_name in ipairs(character_images) do
-    print(image_name)
+    --print(image_name)
     self.images[image_name] = load_img_from_supported_extensions(self.path.."/"..image_name)
     if not self.images[image_name] and defaulted_images[image_name] and not self:is_bundle() then
       if image_name == "burst" or image_name == "fade" then
@@ -354,7 +354,7 @@ function Character.graphics_init(self,full,yields)
       else
         self.images[image_name] = default_character.images[image_name]
       end
-      print("MISSING!")
+      --print("MISSING!")
     end
     if yields then coroutine.yield() end
   end

--- a/consts.lua
+++ b/consts.lua
@@ -10,6 +10,9 @@ legacy_canvas_height = 612
 
 global_background_color = { 0.1, 0.1, 0.1 }
 
+SERVER_QUEUE_CAPACITY = 2000 -- max entries in the network queue
+SERVER_QUEUE_EXPIRATION_LENGTH = 30 -- time in seconds
+
 mouse_pointer_timeout = 1.5 --seconds
 RATING_SPREAD_MODIFIER = 400
 

--- a/globals.lua
+++ b/globals.lua
@@ -12,7 +12,8 @@ this_frame_keys = {}
 this_frame_released_keys = {}
 this_frame_unicodes = {}
 this_frame_messages = {}
-server_queue = ServerQueue(20)
+
+server_queue = ServerQueue(SERVER_QUEUE_CAPACITY)
 
 score_mode = SCOREMODE_TA
 
@@ -118,6 +119,7 @@ current_use_music_from = "stage" -- either "stage" or "characters", no other val
 function warning(msg)
 	err = "=================================================================\n["..os.date("%x %X").."]\nError: "..msg..debug.traceback("").."\n"
 	love.filesystem.append("warnings.txt", err)
+	print(err)
 	if display_warning_message then
 		display_warning_message = false
 		local loc_warning = "You've had a bug. Please report this on Discord with file:"

--- a/main.lua
+++ b/main.lua
@@ -59,6 +59,9 @@ function love.update(dt)
   if not status then
     error(err..'\n'..debug.traceback(mainloop))
   end
+  if server_queue and server_queue:size() > 0 then
+    print("Queue Size: " .. server_queue:size() .. " Data:" .. server_queue:to_short_string())
+  end
   this_frame_messages = {}
 
   update_music()

--- a/select_screen.lua
+++ b/select_screen.lua
@@ -160,6 +160,12 @@ function select_screen.main()
              {"__Empty", "__Empty", "__Empty", "__Empty", "__Empty", "__Empty", "__Empty", "__Empty", "__Leave"}}
   local map = {}
   if select_screen.character_select_mode == "2p_net_vs" then
+    P1 = nil
+    P2 = nil
+    -- Clear all old data messages from the previous game
+    server_queue:pop_all_with("P", "O", "U", "I", "Q", "R")
+    print("Reseting player stacks")
+
     local opponent_connected = false
     local retries, retry_limit = 0, 250
     while not global_initialize_room_msg and retries < retry_limit do
@@ -192,6 +198,7 @@ function select_screen.main()
       -- end
     -- end
     if not global_initialize_room_msg then
+      warning(loc("ss_init_fail").."\n")
       return main_dumb_transition, {main_select_mode, loc("ss_init_fail").."\n\n"..loc("ss_return"), 60, 300}
     end
     msg = global_initialize_room_msg
@@ -245,12 +252,7 @@ function select_screen.main()
     else
       match_type = "Casual"
     end
-    if currently_spectating then
-      P1 = {panel_buffer="", gpanel_buffer=""}
-      print("we reset P1 buffers at start of main_character_select()")
-    end
-    P2 = {panel_buffer="", gpanel_buffer=""}
-    print("we reset P2 buffers at start of main_character_select()")
+
     print("current_server_supports_ranking: "..tostring(current_server_supports_ranking))
 
     if current_server_supports_ranking then
@@ -845,10 +847,10 @@ function select_screen.main()
           op_win_count = 0
           return main_dumb_transition, {main_net_vs_lobby, "", 0, 0}
         end
-        if msg.match_start or replay_of_match_so_far then
+        if (msg.match_start or replay_of_match_so_far) and msg.player_settings and msg.opponent_settings then
           print("currently_spectating: "..tostring(currently_spectating))
-          local fake_P1 = P1
-          local fake_P2 = P2
+          local fake_P1 = {panel_buffer="", gpanel_buffer=""}
+          local fake_P2 = {panel_buffer="", gpanel_buffer=""}
           refresh_based_on_own_mods(msg.opponent_settings)
           refresh_based_on_own_mods(msg.player_settings, true)
           refresh_based_on_own_mods(msg) -- for stage only, other data are meaningless to us
@@ -917,6 +919,7 @@ function select_screen.main()
             if not do_messages() then
               return main_dumb_transition, {main_select_mode, loc("ss_disconnect").."\n\n"..loc("ss_return"), 60, 300}
             end
+            process_all_data_messages()
             wait()
           end
           local game_start_timeout = 0
@@ -933,8 +936,10 @@ function select_screen.main()
             if not do_messages() then
               return main_dumb_transition, {main_select_mode, loc("ss_disconnect").."\n\n"..loc("ss_return"), 60, 300}
             end
+            process_all_data_messages()
             wait()
             if game_start_timeout > 250 then
+              warning(loc("pl_time_out").."\n")
               return main_dumb_transition, {main_select_mode,
                               loc("pl_time_out").."\n"
                               .."\n".."msg.match_start = "..(tostring(msg.match_start) or "nil")

--- a/server_queue.lua
+++ b/server_queue.lua
@@ -8,16 +8,28 @@ ServerQueue = class(function(self, capacity)
   end)
 
 function ServerQueue.to_string(self)
-  ret = "QUEUE: "
-  for k,v in pairs(self.data) do
-    ret = ret.."\n"..k..": {"
-    for a,b in pairs(v) do
-      ret = ret..a..", "
+  return "QUEUE: " .. dump(self)
+end
+
+
+function ServerQueue.to_short_string(self)
+  local returnString = ""
+
+  if self.first <= self.last then
+    local still_empty = true
+    for i=self.first,self.last do
+      local msg = self.data[i]
+      if msg ~= nil then
+        for type,data in pairs(msg) do
+          if type ~= "_expiration" then
+            returnString = returnString .. type .. " "
+          end
+        end
+      end
     end
-    ret = ret.."}"
   end
 
-  return ret
+  return returnString
 end
 
 function ServerQueue.has_expired(self, msg)
@@ -36,10 +48,12 @@ end
 function ServerQueue.push(self, msg)
   local last = self.last + 1
   self.last = last
-  msg._expiration = os.time() + 5 -- add an expiration date of 5s
+  msg._expiration = os.time() + SERVER_QUEUE_EXPIRATION_LENGTH -- add an expiration date in seconds
   self.data[last] = msg
   if self:size() > self.capacity then
     local first = self.first
+    local str = "ServerQueue: the queue ran out of room\n"
+    warning(str.."\n"..self:to_string())
     self.data[first] = nil
     self.first = first + 1
   end

--- a/sound.lua
+++ b/sound.lua
@@ -40,7 +40,7 @@ function stop_all_audio()
 end
 
 function stop_the_music()
-  print("musics have been stopped")
+  --print("musics have been stopped")
   for k, v in pairs(currently_playing_tracks) do
     v:stop()
     currently_playing_tracks[k] = nil

--- a/util.lua
+++ b/util.lua
@@ -241,3 +241,16 @@ function get_directory_contents(path)
 
   return results
 end
+
+function dump(o)
+  if type(o) == 'table' then
+     local s = '{ '
+     for k,v in pairs(o) do
+        if type(k) ~= 'number' then k = '"'..k..'"' end
+        s = s .. '['..k..'] = ' .. dump(v) .. ','
+     end
+     return s .. '} '
+  else
+     return tostring(o)
+  end
+end


### PR DESCRIPTION
This fixes issue #227 and #186

The order the messages come through from the server is very important, if we drop some of those messages, or process them for the wrong game, we can get in a corrupted state.

To fix this:
• Revamped the network code to put all messages in the same queue, that way we can wait to process player input / panel data till a game is in progress
• Throw out old player input / panel messages when a new game is initialized
• Process player input / panel messages only while a game is running
• To fix #186, continue to process network messages while replaying the game, so we don't get disconnected.

Other Improvements:
• Commented out noisy prints
• Added constants for the server queue length and time and increased them
• Increased cases that are filed as warnings and print to stdout as well
• Improved logging
• If at the game over screen and a new match starts, immediately go to it.