### PR TITLE
Fix network issues where game doesn't initialize when spectating

### DIFF
--- a/mainloop.lua
+++ b/mainloop.lua
@@ -702,6 +702,7 @@ function main_net_vs_lobby()
     if not do_messages() then
       return main_dumb_transition, {main_select_mode, loc("ss_disconnect").."\n\n"..loc("ss_return"), 60, 300}
     end
+    drop_old_data_messages() -- We are in the lobby, we shouldn't have any game data messages
   end
 end
 
@@ -877,7 +878,7 @@ function main_net_vs()
     if not do_messages() then
       return main_dumb_transition, {main_select_mode, loc("ss_disconnect").."\n\n"..loc("ss_return"), 60, 300}
     end
-    process_all_data_messages()
+    process_all_data_messages() -- main game play processing
 
     --print(P1.CLOCK, P2.CLOCK)
     if (P1 and P1.play_to_end) or (P2 and P2.play_to_end) then

--- a/network.lua
+++ b/network.lua
@@ -129,6 +129,31 @@ function queue_message(type, data)
   end
 end
 
+function drop_old_data_messages()
+  while true do
+    local message = server_queue:top()
+    if not message then
+      break
+    end
+
+    if not message["P"] and
+       not message["O"] and
+       not message["U"] and
+       not message["I"] and
+       not message["Q"] and
+       not message["R"] then
+      break -- Found a "J" message. Stop. Future data is for next game
+    else
+      local msg = server_queue:pop() -- old data, drop it
+      for type,data in pairs(msg) do
+        if type ~= "_expiration" then
+          print("Dropping: " .. type)
+        end
+      end
+    end
+  end
+end
+
 function process_all_data_messages()
   local messages = server_queue:pop_all_with("P", "O", "U", "I", "Q", "R")
   for _,msg in ipairs(messages) do

--- a/select_screen.lua
+++ b/select_screen.lua
@@ -162,8 +162,7 @@ function select_screen.main()
   if select_screen.character_select_mode == "2p_net_vs" then
     P1 = nil
     P2 = nil
-    -- Clear all old data messages from the previous game
-    server_queue:pop_all_with("P", "O", "U", "I", "Q", "R")
+    drop_old_data_messages() -- Starting a new game, clear all old data messages from the previous game
     print("Reseting player stacks")
 
     local opponent_connected = false
@@ -932,7 +931,7 @@ function select_screen.main()
             if not do_messages() then
               return main_dumb_transition, {main_select_mode, loc("ss_disconnect").."\n\n"..loc("ss_return"), 60, 300}
             end
-            process_all_data_messages()
+            process_all_data_messages() -- process data to get initial panel stacks setup
             wait()
           end
           local game_start_timeout = 0
@@ -949,7 +948,7 @@ function select_screen.main()
             if not do_messages() then
               return main_dumb_transition, {main_select_mode, loc("ss_disconnect").."\n\n"..loc("ss_return"), 60, 300}
             end
-            process_all_data_messages()
+            process_all_data_messages() -- process data to get initial panel stacks setup
             wait()
             if game_start_timeout > 250 then
               warning(loc("pl_time_out").."\n")


### PR DESCRIPTION
Together with @shosoul we were able to determine that we were deleting game network data for the next game when cleaning
up the previous game.

We only want to delete all game messages prior to the "new game" network message.

Added a method to do that and added it to a couple places.
Also documented each network processing spot.
Tested with simulated network latency and was able to repro before and not afterwards.