### PR TITLE
Topped out animations

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -864,8 +864,13 @@ function Stack.PdP(self)
         self.danger_col[idx] = false
       end
     end
-    if self.danger and self.stop_time == 0 then
-      self.danger_timer = self.danger_timer - 1
+    if self.danger then
+      if self.panels_in_top_row and self.speed ~= 0 and self.mode ~= "puzzle" then
+        -- Player has topped out, panels hold the "flattened" frame
+        self.danger_timer = 15
+      elseif self.stop_time == 0 then
+        self.danger_timer = self.danger_timer - 1
+      end
       if self.danger_timer < 0 then
         self.danger_timer = 17
       end

--- a/engine.lua
+++ b/engine.lua
@@ -865,7 +865,7 @@ function Stack.PdP(self)
       end
     end
     if self.danger then
-      if self.panels_in_top_row and self.speed ~= 0 and self.mode ~= "puzzle" then
+      if self.panels_in_top_row and self.speed ~= 0 and self.match.mode ~= "puzzle" then
         -- Player has topped out, panels hold the "flattened" frame
         self.danger_timer = 15
       elseif self.stop_time == 0 then


### PR DESCRIPTION
Prior to this change, panels always "jumped" when they were in a danger zone, even if the user was topped out. Now, they will "flatten" themselves like they would in the original games if the user is topped out.