### PR TITLE
Patch: Spectator Room Bug

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -91,6 +91,8 @@ function create_room(a, b)
   lobby_changed = true
   clear_proposals(a.name)
   clear_proposals(b.name)
+  a.room = nil
+  b.room = nil
   local new_room = Room(a, b)
   local a_msg, b_msg = {create_room = true}, {create_room = true}
   a_msg.your_player_number = 1


### PR DESCRIPTION
As player Dekrates put it, this bug was triggered by the following:
- two players join the server and spectate the same match
- these two players then decide to stop spectating and play vs each other
- they will have the same rating points as the players they just spectated
- after the first match of them finishes everyone gets thrown out of their matches/lobbies
- can be circumvented by going back to menu before starting the match that would cause the crash

The problem was that the server only would increment the room number if the players were not in a room. However, when leaving spectator, the game did not clear that room status from the spectators. Therefore, the game believed the players were already in a room and did not increment the room number. This overwrote the previous room, leaving those players in a room that no longer existed. This patch fixes this bug by always clearing the room status of both players before a new room is created.