### PR TITLE
Log Dropped Frames, create render method on match

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -7,6 +7,7 @@ Game =
     self.scores = require("scores")
     self.match = nil
     self.focused = true
+    self.droppedFrames = 0
   end
 )
 

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -107,7 +107,12 @@ function variable_step(f)
       this_frame_keys = {}
       this_frame_released_keys = {}
       this_frame_unicodes = {}
+
       leftover_time = leftover_time - 1 / 60
+      if leftover_time >= 1 / 60 then
+        GAME.droppedFrames = GAME.droppedFrames + 1
+        print("Dropped Frame, total is: " .. GAME.droppedFrames)
+      end
     end
   end
 end
@@ -419,11 +424,7 @@ function main_endless(...)
   make_local_gpanels(P1, "000000")
   P1:starting_state()
   while true do
-    if game_is_paused then
-      draw_pause()
-    else
-      P1:render()
-    end
+    GAME.match:render()
     wait()
     local ret = nil
     if P1:game_ended() then
@@ -469,11 +470,7 @@ function main_time_attack(...)
   P1:starting_state()
   P2 = nil
   while true do
-    if game_is_paused then
-      draw_pause()
-    else
-      P1:render()
-    end
+    GAME.match:render()
     wait()
     local ret = nil
     if P1:game_ended() then
@@ -939,8 +936,7 @@ function main_net_vs()
     end
     -- don't spend time rendering when catching up to a current match in replays
     if not (P1 and P1.play_to_end) and not (P2 and P2.play_to_end) then
-      P1:render()
-      P2:render()
+      GAME.match:render()
       wait()
     end
 
@@ -1043,12 +1039,7 @@ function main_local_vs()
   pick_use_music_from()
   local end_text = nil
   while true do
-    if game_is_paused then
-      draw_pause()
-    else
-      P1:render()
-      P2:render()
-    end
+    GAME.match:render()
     wait()
     variable_step(
       function()
@@ -1100,11 +1091,7 @@ function main_local_vs_yourself()
   use_current_stage()
   pick_use_music_from()
   while true do
-    if game_is_paused then
-      draw_pause()
-    else
-      P1:render()
-    end
+    GAME.match:render()
     wait()
     local ret = nil
     variable_step(
@@ -1192,12 +1179,8 @@ function main_replay_vs()
     debug_mouse_panel = nil
     gprint(my_name or "", P1.score_x, P1.score_y - 28)
     gprint(op_name or "", P2.score_x, P2.score_y - 28)
-    P1:render()
-    P2:render()
+    GAME.match:render()
     draw_debug_mouse_panel()
-    if game_is_paused then
-      draw_pause()
-    end
     wait()
     local ret = nil
     variable_step(
@@ -1277,10 +1260,7 @@ function main_replay_endless()
   P2 = nil
   local run = true
   while true do
-    P1:render()
-    if game_is_paused then
-      draw_pause()
-    end
+    GAME.match:render()
     wait()
     local ret = nil
     variable_step(
@@ -1332,11 +1312,8 @@ function main_replay_puzzle()
   local run = true
   while true do
     debug_mouse_panel = nil
-    P1:render()
+    GAME.match:render()
     draw_debug_mouse_panel()
-    if game_is_paused then
-      draw_pause()
-    end
     wait()
     local ret = nil
     variable_step(
@@ -1394,11 +1371,7 @@ function make_main_puzzle(puzzles)
     replay.puzzle = puzzles[awesome_idx]
     replay.in_buf = ""
     while true do
-      if game_is_paused then
-        draw_pause()
-      else
-        P1:render()
-      end
+      GAME.match:render()
       wait()
       local ret = nil
       variable_step(
@@ -1769,12 +1742,7 @@ function game_over_transition(next_func, text, winnerSFX, timemax)
   end
 
   while true do
-    if P1 then
-      P1:render()
-    end
-    if P2 then
-      P2:render()
-    end
+    GAME.match:render()
     gprint(text, (canvas_width - font:getWidth(text)) / 2, (canvas_height - font:getHeight(text)) / 2)
     gprint(button_text, (canvas_width - font:getWidth(button_text)) / 2, ((canvas_height - font:getHeight(button_text)) / 2) + 30)
     wait()

--- a/match.lua
+++ b/match.lua
@@ -13,7 +13,7 @@ Match =
 
 function Match.render(self)
 
-  if GAME.droppedFrames > 10 then
+  if GAME.droppedFrames > 10 and config.show_fps then
     gprint("Dropped Frames: " .. GAME.droppedFrames, 1, 12)
   end
 

--- a/match.lua
+++ b/match.lua
@@ -6,5 +6,34 @@ Match =
     self.P1 = nil
     self.P2 = nil
     self.mode = mode
+    GAME.droppedFrames = 0
   end
 )
+
+
+function Match.render(self)
+
+  if GAME.droppedFrames > 10 then
+    gprint("Dropped Frames: " .. GAME.droppedFrames, 1, 12)
+  end
+
+  if game_is_paused then
+    draw_pause()
+  else
+    -- Don't allow rendering if either player is loading for spectating
+    local renderingAllowed = true
+    if P1 and P1.play_to_end then
+      renderingAllowed = false
+    end
+    if P2 and P2.play_to_end then
+      renderingAllowed = false
+    end
+
+    if P1 and renderingAllowed then
+      P1:render()
+    end
+    if P2 and renderingAllowed then
+      P2:render()
+    end
+  end
+end


### PR DESCRIPTION
When more than one game loop is run in a row the following negative side effects happen:
1. If this is a local game, the player can't input between those frame simulations.
2. The game doesn't render the first frame.

We need to avoid doing more than 1/60th of a second of work in the loop or we will hit this.

To start, lets log when this happens and display it onscreen when it happens a lot so we can diagnose how common this is.