### PR TITLE
Fix going away

### DIFF
--- a/mainloop.lua
+++ b/mainloop.lua
@@ -1787,8 +1787,8 @@ function game_over_transition(next_func, text, winnerSFX, timemax)
           set_music_fade_percentage((fadeMusicLength - t) / fadeMusicLength)
         else
           if t == fadeMusicLength + 1 then
-            stop_the_music()
             set_music_fade_percentage(1) -- reset the music back to normal config volume
+            stop_the_music()
           end
         end
 


### PR DESCRIPTION
In the previous fix I was worried about turning the music back on before stopping it, but its safe to do since we immediately stop it before the engine does anything.

The bug was the music was removed from the global list before it was set back to normal percentage.