### PR TITLE
Better MultiBar Stop Time Indication

### DIFF
--- a/graphics.lua
+++ b/graphics.lua
@@ -619,17 +619,17 @@ function Stack.render(self)
       -- Multibar
 
       if self.maxShake > 0 and self.shake_time >= self.pre_stop_time + self.stop_time then
-        multi_shake_bar = self.shake_time * (themes[config.theme].images.IMG_multibar_shake_bar:getHeight() / self.maxShake)
+        multi_shake_bar = self.shake_time * (themes[config.theme].images.IMG_multibar_shake_bar:getHeight() / self.maxShake) * 3
       else
         multi_shake_bar = 0
       end
       if self.maxStop > 0 and self.shake_time < self.pre_stop_time + self.stop_time then
-        multi_stop_bar = self.stop_time * (themes[config.theme].images.IMG_multibar_stop_bar:getHeight() / self.maxStop)
+        multi_stop_bar = self.stop_time * (themes[config.theme].images.IMG_multibar_stop_bar:getHeight() / self.maxStop) * 1.5
       else
         multi_stop_bar = 0
       end
       if self.maxPrestop > 0 and self.shake_time < self.pre_stop_time + self.stop_time then
-        multi_prestop_bar = self.pre_stop_time * (themes[config.theme].images.IMG_multibar_prestop_bar:getHeight() / self.maxPrestop)
+        multi_prestop_bar = self.pre_stop_time * (themes[config.theme].images.IMG_multibar_prestop_bar:getHeight() / self.maxPrestop) * 1.5
       else
         multi_prestop_bar = 0
       end

--- a/graphics.lua
+++ b/graphics.lua
@@ -618,17 +618,17 @@ function Stack.render(self)
 
       -- Multibar
 
-      if self.maxShake > 0 then
+      if self.maxShake > 0 and self.shake_time >= self.pre_stop_time + self.stop_time then
         multi_shake_bar = self.shake_time * (themes[config.theme].images.IMG_multibar_shake_bar:getHeight() / self.maxShake)
       else
         multi_shake_bar = 0
       end
-      if self.maxStop > 0 then
+      if self.maxStop > 0 and self.shake_time < self.pre_stop_time + self.stop_time then
         multi_stop_bar = self.stop_time * (themes[config.theme].images.IMG_multibar_stop_bar:getHeight() / self.maxStop)
       else
         multi_stop_bar = 0
       end
-      if self.maxPrestop > 0 then
+      if self.maxPrestop > 0 and self.shake_time < self.pre_stop_time + self.stop_time then
         multi_prestop_bar = self.pre_stop_time * (themes[config.theme].images.IMG_multibar_prestop_bar:getHeight() / self.maxPrestop)
       else
         multi_prestop_bar = 0


### PR DESCRIPTION
The Stop Time Bars stack on top of each other to indicate remaining stop time. However, the bars have the potential to have more than one shrink at a time, causing... stop bar _visual jank_. This change makes it so that this will not be the case by displaying only the prestop + stop bar together, or only the shake bar alone if the shake frames are greater than or equal to the sum of the prestop and stop frames.