### PR TITLE
Fix server queue pop and add tests

### DIFF
--- a/ServerQueueTests.lua
+++ b/ServerQueueTests.lua
@@ -1,7 +1,4 @@
 
-if os.getenv("LOCAL_LUA_DEBUGGER_VSCODE") == "1" then
-    require("lldebugger").start()
-  end
 
 local queue = ServerQueue()
 

--- a/ServerQueueTests.lua
+++ b/ServerQueueTests.lua
@@ -1,0 +1,34 @@
+
+if os.getenv("LOCAL_LUA_DEBUGGER_VSCODE") == "1" then
+    require("lldebugger").start()
+  end
+
+local queue = ServerQueue()
+
+assert(queue:size() == 0)
+
+queue:push(1)
+assert(queue:size() == 1)
+assert(queue:top() == 1)
+assert(queue:size() == 1)
+assert(queue:pop() == 1)
+assert(queue:size() == 0)
+
+
+local table1 = {test="a"}
+local table2 = {bob="a"}
+local table3 = {alice="a"}
+queue:push(table1)
+queue:push(table2)
+queue:push(table3)
+
+local results = queue:pop_all_with("bob")
+assert(results[1] == table2)
+assert(queue:top() == table1)
+assert(queue:size() == 2)
+
+assert(queue:pop_next_with("alice") == table3)
+assert(queue:size() == 1)
+assert(queue:pop_next_with("test") == table1)
+assert(queue:size() == 0)
+

--- a/consts.lua
+++ b/consts.lua
@@ -10,9 +10,6 @@ legacy_canvas_height = 612
 
 global_background_color = { 0.1, 0.1, 0.1 }
 
-SERVER_QUEUE_CAPACITY = 2000 -- max entries in the network queue
-SERVER_QUEUE_EXPIRATION_LENGTH = 30 -- time in seconds
-
 mouse_pointer_timeout = 1.5 --seconds
 RATING_SPREAD_MODIFIER = 400 -- rating players must be within to play ranked
 

--- a/globals.lua
+++ b/globals.lua
@@ -13,7 +13,7 @@ this_frame_released_keys = {}
 this_frame_unicodes = {}
 this_frame_messages = {}
 
-server_queue = ServerQueue(SERVER_QUEUE_CAPACITY)
+server_queue = ServerQueue()
 
 score_mode = SCOREMODE_TA
 

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -84,6 +84,9 @@ function fmainloop()
   love.filesystem.createDirectory("themes")
   love.filesystem.createDirectory("stages")
 
+  -- Run all unit tests now that we have everything loaded
+  require("ServerQueueTests")
+  
   --check for game updates
   if GAME_UPDATER_CHECK_UPDATE_INGAME then
     wait_game_update = GAME_UPDATER:async_download_latest_version()
@@ -838,7 +841,7 @@ function main_net_vs_setup(ip, network_port)
   end
   P1, P1_level, P2_level, got_opponent = nil
   P2 = {panel_buffer = "", gpanel_buffer = ""}
-  server_queue = ServerQueue(SERVER_QUEUE_CAPACITY)
+  server_queue = ServerQueue()
   gprint(loc("lb_set_connect"), unpack(main_menu_screen_pos))
   wait()
   network_init(ip, network_port)

--- a/server_queue.lua
+++ b/server_queue.lua
@@ -1,21 +1,19 @@
 
 -- Tracks a queue data structure.
--- Also provides a capacity and drops messages with an error if that capacity is exceeded.
--- Also provides a time expiration for messages
 -- Values are tracked via incrementing ID keys, when something is nilled it is tracked as an "empty"
 ServerQueue =
   class(
-  function(self, capacity)
-    if not capacity then
-      error("ServerQueue: you need to specify a capacity")
-    end
-    self.capacity = capacity
-    self.data = {}
-    self.first = 0
-    self.last = -1
-    self.empties = 0
+  function(self)
+    self:clear()
   end
 )
+
+function ServerQueue.clear(self)
+  self.data = {}
+  self.first = 0
+  self.last = -1
+  self.empties = 0
+end
 
 function ServerQueue.to_string(self)
   return "QUEUE: " .. dump(self)
@@ -30,9 +28,7 @@ function ServerQueue.to_short_string(self)
       local msg = self.data[i]
       if msg ~= nil then
         for type, data in pairs(msg) do
-          if type ~= "_expiration" then
-            returnString = returnString .. type .. " "
-          end
+          returnString = returnString .. type .. " "
         end
       end
     end
@@ -41,31 +37,12 @@ function ServerQueue.to_short_string(self)
   return returnString
 end
 
-function ServerQueue.has_expired(self, msg)
-  if os.time() > msg._expiration then
-    str = "ServerQueue: a message has expired (" .. (os.time() - msg._expiration) .. ")\n"
-    for k, v in pairs(msg) do
-      str = str .. k .. ", "
-    end
-    warning(str .. "\n" .. self:to_string())
-    return true
-  end
-  return false
-end
 
 -- push a server message in queue
 function ServerQueue.push(self, msg)
   local last = self.last + 1
   self.last = last
-  msg._expiration = os.time() + SERVER_QUEUE_EXPIRATION_LENGTH -- add an expiration date in seconds
   self.data[last] = msg
-  if self:size() > self.capacity then
-    local first = self.first
-    local str = "ServerQueue: the queue ran out of room\n"
-    warning(str .. "\n" .. self:to_string())
-    self.data[first] = nil
-    self.first = first + 1
-  end
 end
 
 -- pop oldest server message in queue
@@ -73,23 +50,12 @@ function ServerQueue.pop(self)
   local first = self.first
   local ret = nil
 
-  while ret == nil do
-    if first >= self.last then
-      first = 0
-      self.last = -1
+  for i = self.first, self.last do
+    ret = self.data[first]
+    self.data[first] = nil
+    first = first + 1
+    if ret then
       break
-    else
-      ret = self.data[first]
-      self.data[first] = nil
-      if ret == nil then
-        self.empties = self.empties - 1
-      else
-        if self:has_expired(ret) then
-          self:remove(first)
-          ret = nil
-        end
-      end
-      first = first + 1
     end
   end
 
@@ -114,9 +80,7 @@ function ServerQueue.pop_next_with(self, ...)
         if msg[select(j, ...)] ~= nil then
           --print("POP "..select(j, ...))
           self:remove(i)
-          if not self:has_expired(msg) then
-            return msg
-          end
+          return msg
         end
       end
     elseif still_empty then
@@ -141,9 +105,7 @@ function ServerQueue.pop_all_with(self, ...)
             --print("POP "..select(j, ...))
             ret[#ret + 1] = msg
             self:remove(i)
-            if not self:has_expired(msg) then
-              break
-            end
+            break
           end
         end
       elseif still_empty then
@@ -170,6 +132,9 @@ function ServerQueue.top(self)
 end
 
 function ServerQueue.size(self)
+  if self.last < self.first then
+    return 0
+  end
   return self.last - self.first - self.empties + 1
 end
 
@@ -179,15 +144,4 @@ function ServerQueue.check_empty(self)
     self.last = -1
     self.empties = 0
   end
-end
-
-function ServerQueue.clear(self)
-  if self.first >= self.last then
-    for i = self.first, self.last do
-      self.data[i] = nil
-    end
-  end
-  self.first = 0
-  self.last = -1
-  self.empties = 0
 end


### PR DESCRIPTION
The server queue class had a couple bugs.
• The first pop on the first entry failed
• The time expirations had bugs for different pop cases and we didn't recover if we dropped various server messages anyways
• Same thing for the capacity
• Thus I removed both
• added unit tests