### PR TITLE
Return user to main menu instead of crashing game

### DIFF
--- a/mainloop.lua
+++ b/mainloop.lua
@@ -166,6 +166,7 @@ do
       {loc("mm_1_vs"), main_local_vs_yourself_setup},
       --{loc("mm_2_vs_online", "burke.ro"), main_net_vs_setup, {"burke.ro"}},
       {loc("mm_2_vs_online", ""), main_net_vs_setup, {"18.188.43.50"}},
+      {loc("mm_2_vs_online", "Shosoul's Server"), main_net_vs_setup, {"149.28.227.184"}},
       --{loc("mm_2_vs_online", "betaserver.panelattack.com"), main_net_vs_setup, {"betaserver.panelattack.com"}},
       --{loc("mm_2_vs_online", "(USE ONLY WITH OTHER CLIENTS ON THIS TEST BUILD 025beta)"), main_net_vs_setup, {"18.188.43.50"}},
       --{loc("mm_2_vs_online", "This test build is for offline-use only"), main_select_mode},
@@ -854,7 +855,9 @@ function main_net_vs_setup(ip, network_port)
   server_queue = ServerQueue()
   gprint(loc("lb_set_connect"), unpack(main_menu_screen_pos))
   wait()
-  network_init(ip, network_port)
+  if not network_init(ip, network_port) then
+    return main_dumb_transition, {main_select_mode, loc("ss_disconnect") .. "\n\n" .. loc("ss_return"), 60, 300}
+  end
   local timeout_counter = 0
   while not connection_is_ready() do
     gprint(loc("lb_connecting"), unpack(main_menu_screen_pos))

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -166,7 +166,6 @@ do
       {loc("mm_1_vs"), main_local_vs_yourself_setup},
       --{loc("mm_2_vs_online", "burke.ro"), main_net_vs_setup, {"burke.ro"}},
       {loc("mm_2_vs_online", ""), main_net_vs_setup, {"18.188.43.50"}},
-      {loc("mm_2_vs_online", "Shosoul's Server"), main_net_vs_setup, {"149.28.227.184"}},
       --{loc("mm_2_vs_online", "betaserver.panelattack.com"), main_net_vs_setup, {"betaserver.panelattack.com"}},
       --{loc("mm_2_vs_online", "(USE ONLY WITH OTHER CLIENTS ON THIS TEST BUILD 025beta)"), main_net_vs_setup, {"18.188.43.50"}},
       --{loc("mm_2_vs_online", "This test build is for offline-use only"), main_select_mode},

--- a/network.lua
+++ b/network.lua
@@ -195,7 +195,8 @@ function network_init(ip, network_port)
   TCP_sock:settimeout(7)
   if not TCP_sock:connect(ip, network_port or 49569) then --for official server
     --if not TCP_sock:connect(ip,59569) then --for beta server
-    error(loc("nt_conn_timeout"))
+    --error(loc("nt_conn_timeout"))
+    return false
   end
   TCP_sock:settimeout(0)
   got_H = false
@@ -214,6 +215,7 @@ function network_init(ip, network_port)
   }
   sent_json.character_display_name = sent_json.character_is_random and "" or characters[config.character].display_name
   json_send(sent_json)
+  return true
 end
 
 function connection_is_ready()


### PR DESCRIPTION
It doesn't make much sense to crash the game as a result of being unable to connect to the server, returning to the main menu is much more appropriate, in my opinion.