### PR TITLE
Don't restore lobby selection if the lobby menu is new

### DIFF
--- a/mainloop.lua
+++ b/mainloop.lua
@@ -729,7 +729,8 @@ function main_net_vs_lobby()
       lobby_menu:add_button(loc("lb_back"), exitLobby, exitLobby)
 
       -- Restore the lobby selection
-      if oldLobbyMenu then
+      -- (If the lobby only had 2 buttons it was before we got lobby info so don't restore the selection)
+      if oldLobbyMenu and #oldLobbyMenu.buttons > 2 then
         if oldLobbyMenu.active_idx == #oldLobbyMenu.buttons then
           lobby_menu:set_active_idx(#lobby_menu.buttons)
         elseif oldLobbyMenu.active_idx == #oldLobbyMenu.buttons - 1 and #lobby_menu.buttons >= 2 then

--- a/network.lua
+++ b/network.lua
@@ -111,7 +111,7 @@ function queue_message(type, data)
     local dataMessage = {}
     dataMessage[type] = data
     if printNetworkMessageForType(type) then
-      print("Queuing: " .. type .. " with data:" .. data)
+      --print("Queuing: " .. type .. " with data:" .. data)
     end
     server_queue:push(dataMessage)
   elseif type == "L" then
@@ -135,7 +135,7 @@ function queue_message(type, data)
       return
     end
     if printNetworkMessageForType(type) then
-      print("Queuing: " .. type .. " with data:" .. dump(current_message))
+      --print("Queuing: " .. type .. " with data:" .. dump(current_message))
     end
     server_queue:push(current_message)
   end


### PR DESCRIPTION
(If the lobby only had 2 buttons it was before we got lobby info so don't restore the selection)
Also reduce some verbose printing