### PR TITLE
Default VSync to off

### DIFF
--- a/globals.lua
+++ b/globals.lua
@@ -76,7 +76,7 @@ config = {
 
 	ranked                        = true,
 
-	vsync                         = true,
+	vsync                         = false,
 
 	use_music_from                = "either",
 	-- Level (2P modes / 1P vs yourself mode)

--- a/options.lua
+++ b/options.lua
@@ -263,7 +263,7 @@ function options.main(starting_idx)
     --[[2]] {"master_volume", "op_vol", config.master_volume, "numeric", 0, 100, normal_music_for_sound_option, true, nil, true},
     --[[3]] {"sfx_volume", "op_vol_sfx", config.SFX_volume, "numeric", 0, 100, themes[config.theme].sounds.cur_move, true},
     --[[4]] {"music_volume", "op_vol_music", config.music_volume, "numeric", 0, 100, normal_music_for_sound_option, true, nil, true},
-    --[[5]] {"vsync", "op_vsync", on_off_text[config.vsync], "bool", true, nil, nil, false},
+    --[[5]] {"vsync", "op_vsync", on_off_text[config.vsync], "bool", false, nil, nil, false},
     --[[6]] {"debug", "op_debug", on_off_text[config.debug_mode], "bool", false, nil, nil, false},
     --[[7]] {
       "replays",


### PR DESCRIPTION
It seems with various OSs + gpus + love we can't guarantee love.update to be called at 60fps always with v sync turned on, but for some reason it seems to be more consistent with vsync turned off.

This will cause missed inputs whenever it happens, and isn't very obvious to the user what's going on.

Therefore we should default vsync to off. The opposite problem IS obvious. The screen refreshing in a weird way. If that bothers the user, it will be much more obvious what to do, go turn vsync on.