### PR TITLE
Fix potential crash

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -1563,7 +1563,7 @@ function Stack.PdP(self)
             local normalMusic = {musics_to_use["normal_music"], musics_to_use["normal_music_start"]}
             local dangerMusic = {musics_to_use["danger_music"], musics_to_use["danger_music_start"]}
               
-            if #currently_playing_tracks == 0 then
+            if not self.fade_music_clock or #currently_playing_tracks == 0 then
               self.fade_music_clock = fadeLength
               find_and_add_music(musics_to_use, "normal_music")
               find_and_add_music(musics_to_use, "danger_music")


### PR DESCRIPTION
If for some reason tracks are playing but dynamic music hasn't started yet, we wouldn't set our base case and could crash on nil. Seen once while spectating.