### PR TITLE
Make sure spectate and player names are not stale

### DIFF
--- a/BattleRoom.lua
+++ b/BattleRoom.lua
@@ -7,6 +7,10 @@ BattleRoom =
     self.playerWinCounts[1] = 0
     self.playerWinCounts[2] = 0
     self.mode = mode
+    self.playerNames = {} -- table with player which number -> display name
+    self.playerNames[1] = config.name or loc("player_n", "1")
+    self.playerNames[2] = loc("player_n", "2")
+    self.spectating = false
   end
 )
 

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -13,7 +13,6 @@ local main_endless, make_main_puzzle, main_net_vs_setup, main_select_puzz, main_
 
 local PLAYING = "playing" -- room states
 local CHARACTERSELECT = "character select" -- room states
-currently_spectating = false -- whether or not you are spectating a game
 connection_up_time = 0 -- connection_up_time counts "E" messages, not seconds
 logged_in = 0
 connected_server_ip = nil -- the ip address of the server you are connected to
@@ -26,7 +25,6 @@ leftover_time = 0
 main_menu_screen_pos = {300 + (canvas_width - legacy_canvas_width) / 2, 195 + (canvas_height - legacy_canvas_height) / 2}
 wait_game_update = nil
 has_game_update = false
-local arrow_padding = 12
 local main_menu_last_index = 1
 
 P1_win_quads = {}
@@ -127,7 +125,6 @@ end
 do
   function main_select_mode()
     click_menus = {}
-    currently_spectating = false
     if themes[config.theme].musics["main"] then
       find_and_add_music(themes[config.theme].musics, "main")
     end
@@ -546,6 +543,7 @@ function main_net_vs_lobby()
   local lastPlayerIndex = 0
   local updated = true -- need update when first entering
   local ret = nil
+  local requestedSpectateRoom = nil
 
   local playerRatingMap = nil
   json_send({leaderboard_request = true}) -- Request the leaderboard so we can show ratings
@@ -562,12 +560,12 @@ function main_net_vs_lobby()
             my_user_id = msg.new_user_id
             print("about to write user id file")
             write_user_id_file()
-            login_status_message = loc("lb_user_new", my_name)
+            login_status_message = loc("lb_user_new", config.name)
           elseif msg.name_changed then
             login_status_message = loc("lb_user_update", msg.old_name, msg.new_name)
             login_status_message_duration = 5
           else
-            login_status_message = loc("lb_welcome_back", my_name)
+            login_status_message = loc("lb_welcome_back", config.name)
           end
         elseif msg.login_denied then
           current_server_supports_ranking = true
@@ -595,6 +593,17 @@ function main_net_vs_lobby()
       if msg.create_room or msg.spectate_request_granted then
         global_initialize_room_msg = msg
         GAME.battleRoom = BattleRoom()
+        if msg.spectate_request_granted then
+          if not requestedSpectateRoom then
+            error("expected requested room")
+          end
+          GAME.battleRoom.spectating = true
+          GAME.battleRoom.playerNames[1] = requestedSpectateRoom.a
+          GAME.battleRoom.playerNames[2] = requestedSpectateRoom.b
+        else
+          GAME.battleRoom.playerNames[1] = config.name
+          GAME.battleRoom.playerNames[2] = msg.opponent
+        end
         select_screen.character_select_mode = "2p_net_vs"
         love.window.requestAttention()
         play_optional_sfx(themes[config.theme].sounds.notification)
@@ -683,10 +692,7 @@ function main_net_vs_lobby()
 
       local function requestGameFunction(opponentName)
         return function()
-          my_name = config.name
-          op_name = opponentName
-          currently_spectating = false
-          sent_requests[op_name] = true
+          sent_requests[opponentName] = true
           request_game(opponentName)
           updated = true
         end
@@ -694,9 +700,7 @@ function main_net_vs_lobby()
 
       local function requestSpectateFunction(room)
         return function()
-          my_name = room.a
-          op_name = room.b
-          currently_spectating = true
+          requestedSpectateRoom = room
           request_spectate(room.roomNumber)
         end
       end
@@ -830,8 +834,6 @@ end
 function main_net_vs_setup(ip, network_port)
   if not config.name then
     return main_set_name
-  else
-    my_name = config.name
   end
   while config.name == "defaultname" do
     if main_set_name() == {main_select_mode} and config.name ~= "defaultname" then
@@ -859,7 +861,7 @@ function main_net_vs_setup(ip, network_port)
   return main_net_vs_lobby
 end
 
--- online match
+-- online match in progress
 function main_net_vs()
   --Uncomment below to induce lag
   --STONER_MODE = true
@@ -871,7 +873,7 @@ function main_net_vs()
   pick_use_music_from()
   local k = K[1] --may help with spectators leaving games in progress
   local op_name_y = 40
-  if string.len(my_name) > 12 then
+  if string.len(GAME.battleRoom.playerNames[1]) > 12 then
     op_name_y = 55
   end
   while true do
@@ -901,18 +903,6 @@ function main_net_vs()
         return main_dumb_transition, {main_net_vs_lobby, "", 0, 0} -- someone left the game, quit to lobby
       end
     end
-    --draw graphics
-    gprint((my_name or ""), P1.score_x + themes[config.theme].name_Pos[1], P1.score_y + themes[config.theme].name_Pos[2])
-    gprint((op_name or ""), P2.score_x + themes[config.theme].name_Pos[1], P2.score_y + themes[config.theme].name_Pos[2])
-    draw_label(themes[config.theme].images.IMG_wins, (P1.score_x + themes[config.theme].winLabel_Pos[1]) / GFX_SCALE, (P1.score_y + themes[config.theme].winLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].winLabel_Scale)
-    draw_number(GAME.battleRoom.playerWinCounts[P1.player_number], themes[config.theme].images.IMG_timeNumber_atlas, 12, P1_win_quads, P1.score_x + themes[config.theme].win_Pos[1], P1.score_y + themes[config.theme].win_Pos[2], themes[config.theme].win_Scale, 20 / themes[config.theme].images.timeNumberWidth * themes[config.theme].time_Scale, 26 / themes[config.theme].images.timeNumberHeight * themes[config.theme].time_Scale, "center")
-
-    draw_label(themes[config.theme].images.IMG_wins, (P2.score_x + themes[config.theme].winLabel_Pos[1]) / GFX_SCALE, (P2.score_y + themes[config.theme].winLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].winLabel_Scale)
-    draw_number(GAME.battleRoom.playerWinCounts[P2.player_number], themes[config.theme].images.IMG_timeNumber_atlas, 12, P2_win_quads, P2.score_x + themes[config.theme].win_Pos[1], P2.score_y + themes[config.theme].win_Pos[2], themes[config.theme].win_Scale, 20 / themes[config.theme].images.timeNumberWidth * themes[config.theme].time_Scale, 26 / themes[config.theme].images.timeNumberHeight * themes[config.theme].time_Scale, "center")
-
-    if not config.debug_mode then --this is printed in the same space as the debug details
-      gprint(spectators_string, themes[config.theme].spectators_Pos[1], themes[config.theme].spectators_Pos[2])
-    end
 
     -- don't spend time rendering when catching up to a current match in replays
     if not (P1 and P1.play_to_end) and not (P2 and P2.play_to_end) then
@@ -920,7 +910,7 @@ function main_net_vs()
       wait()
     end
 
-    if currently_spectating and menu_escape(K[1]) then
+    if GAME.battleRoom.spectating and menu_escape(K[1]) then
       print("spectator pressed escape during a game")
       json_send({leave_room = true})
       return main_dumb_transition, {main_net_vs_lobby, "", 0, 0} -- spectator leaving the match
@@ -959,7 +949,7 @@ function main_net_vs()
       local now = os.date("*t", to_UTC(os.time()))
       local sep = "/"
       local path = "replays" .. sep .. "v" .. VERSION .. sep .. string.format("%04d" .. sep .. "%02d" .. sep .. "%02d", now.year, now.month, now.day)
-      local rep_a_name, rep_b_name = my_name, op_name
+      local rep_a_name, rep_b_name = GAME.battleRoom.playerNames[1], GAME.battleRoom.playerNames[2]
       --sort player names alphabetically for folder name so we don't have a folder "a-vs-b" and also "b-vs-a"
       if rep_b_name < rep_a_name then
         path = path .. sep .. rep_b_name .. "-vs-" .. rep_a_name
@@ -981,11 +971,9 @@ function main_net_vs()
       write_replay_file(path, filename)
 
       select_screen.character_select_mode = "2p_net_vs"
-      if currently_spectating then --transition to game over.
-        return game_over_transition, {select_screen.main, end_text, winSFX, 60 * 8}
-      else
-        return game_over_transition, {select_screen.main, end_text, winSFX, 60 * 8}
-      end
+      --transition to game over.
+      return game_over_transition, {select_screen.main, end_text, winSFX, 60 * 8}
+
     end
   end
 end
@@ -993,9 +981,8 @@ end
 -- sets up globals for local vs
 function main_local_vs_setup()
   GAME.battleRoom = BattleRoom()
-  currently_spectating = false
-  my_name = config.name or "Player 1"
-  op_name = "Player 2"
+  GAME.battleRoom.playerNames[1] = loc("player_n", "1")
+  GAME.battleRoom.playerNames[2] = loc("player_n", "2")
   op_state = nil
   my_player_number = 1
   op_player_number = 2
@@ -1041,9 +1028,7 @@ end
 -- sets up globals for vs yourself
 function main_local_vs_yourself_setup()
   GAME.battleRoom = BattleRoom()
-  currently_spectating = false
-  my_name = config.name or loc("player_n", "1")
-  op_name = nil
+  GAME.battleRoom.playerNames[2] = nil
   my_player_number = 1
   op_state = nil
   select_screen.character_select_mode = "1p_vs_yourself"
@@ -1120,8 +1105,8 @@ function main_replay_vs()
   character_loader_load(P1.character)
   character_loader_load(P2.character)
   character_loader_wait()
-  my_name = replay.P1_name or loc("player_n", "1")
-  op_name = replay.P2_name or loc("player_n", "2")
+  GAME.battleRoom.playerNames[1] = replay.P1_name or loc("player_n", "1")
+  GAME.battleRoom.playerNames[2] = replay.P2_name or loc("player_n", "2")
   if replay.ranked then
     match_type = "Ranked"
   else

--- a/match.lua
+++ b/match.lua
@@ -27,13 +27,13 @@ function Match.matchOutcome(self)
     results["outcome_claim"] = 0
   elseif gameResult == -1 then -- opponent wins
     results["winSFX"] = self.P2:pick_win_sfx()
-    results["end_text"] =  loc("ss_p_wins", op_name)
+    results["end_text"] =  loc("ss_p_wins", GAME.battleRoom.playerNames[2])
     -- win_counts will get overwritten by the server in net games
     GAME.battleRoom.playerWinCounts[P2.player_number] = GAME.battleRoom.playerWinCounts[P2.player_number] + 1
     results["outcome_claim"] = P2.player_number
   elseif P2.game_over_clock == self.gameEndedClock then -- client wins
     results["winSFX"] = self.P1:pick_win_sfx()
-    results["end_text"] =  loc("ss_p_wins", my_name)
+    results["end_text"] =  loc("ss_p_wins", GAME.battleRoom.playerNames[1])
     -- win_counts will get overwritten by the server in net games
     GAME.battleRoom.playerWinCounts[P1.player_number] = GAME.battleRoom.playerWinCounts[P1.player_number] + 1
     results["outcome_claim"] = P1.player_number
@@ -66,13 +66,13 @@ function Match.render(self)
   -- Draw VS HUD
   if self.battleRoom then
     -- P1 username
-    gprint((my_name or ""), P1.score_x + themes[config.theme].name_Pos[1], P1.score_y + themes[config.theme].name_Pos[2])
+    gprint((GAME.battleRoom.playerNames[1] or ""), P1.score_x + themes[config.theme].name_Pos[1], P1.score_y + themes[config.theme].name_Pos[2])
     if P2 then
       -- P1 win count graphics
       draw_label(themes[config.theme].images.IMG_wins, (P1.score_x + themes[config.theme].winLabel_Pos[1]) / GFX_SCALE, (P1.score_y + themes[config.theme].winLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].winLabel_Scale)
       draw_number(GAME.battleRoom.playerWinCounts[P1.player_number], themes[config.theme].images.IMG_timeNumber_atlas, 12, P1_win_quads, P1.score_x + themes[config.theme].win_Pos[1], P1.score_y + themes[config.theme].win_Pos[2], themes[config.theme].win_Scale, 20 / themes[config.theme].images.timeNumberWidth * themes[config.theme].time_Scale, 26 / themes[config.theme].images.timeNumberHeight * themes[config.theme].time_Scale, "center")
       -- P2 username
-      gprint((op_name or ""), P2.score_x + themes[config.theme].name_Pos[1], P2.score_y + themes[config.theme].name_Pos[2])
+      gprint((GAME.battleRoom.playerNames[2] or ""), P2.score_x + themes[config.theme].name_Pos[1], P2.score_y + themes[config.theme].name_Pos[2])
       -- P2 win count graphics
       draw_label(themes[config.theme].images.IMG_wins, (P2.score_x + themes[config.theme].winLabel_Pos[1]) / GFX_SCALE, (P2.score_y + themes[config.theme].winLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].winLabel_Scale)
       draw_number(GAME.battleRoom.playerWinCounts[P2.player_number], themes[config.theme].images.IMG_timeNumber_atlas, 12, P2_win_quads, P2.score_x + themes[config.theme].win_Pos[1], P2.score_y + themes[config.theme].win_Pos[2], themes[config.theme].win_Scale, 20 / themes[config.theme].images.timeNumberWidth * themes[config.theme].time_Scale, 26 / themes[config.theme].images.timeNumberHeight * themes[config.theme].time_Scale, "center")

--- a/select_screen.lua
+++ b/select_screen.lua
@@ -182,7 +182,6 @@ function select_screen.main()
       local msg = server_queue:pop_next_with("create_room", "character_select", "spectate_request_granted")
       if msg then
         global_initialize_room_msg = msg
-        GAME.battleRoom = BattleRoom()
       end
       gprint(loc("ss_init"), unpack(main_menu_screen_pos))
       wait()
@@ -204,7 +203,7 @@ function select_screen.main()
 
     if msg.your_player_number then
       my_player_number = msg.your_player_number
-    elseif currently_spectating then
+    elseif GAME.battleRoom.spectating then
       my_player_number = 1
     elseif my_player_number and my_player_number ~= 0 then
       print("We assumed our player number is still " .. my_player_number)
@@ -216,7 +215,7 @@ function select_screen.main()
 
     if msg.op_player_number then
       op_player_number = msg.op_player_number or op_player_number
-    elseif currently_spectating then
+    elseif GAME.battleRoom.spectating then
       op_player_number = 2
     elseif op_player_number and op_player_number ~= 0 then
       print("We assumed op player number is still " .. op_player_number)
@@ -748,10 +747,10 @@ function select_screen.main()
       end
     elseif str == "P1" then
       draw_player_state(cursor_data[1], 1)
-      pstr = my_name
+      pstr = GAME.battleRoom.playerNames[1]
     elseif str == "P2" then
       draw_player_state(cursor_data[2], 2)
-      pstr = op_name
+      pstr = GAME.battleRoom.playerNames[2]
     elseif character and character ~= random_character_special_value then
       pstr = character.display_name
     elseif string.sub(str, 1, 2) ~= "__" then -- catch random_character_special_value case
@@ -841,7 +840,7 @@ function select_screen.main()
           GAME.battleRoom:updateWinCounts(msg.win_counts)
         end
         if msg.menu_state then
-          if currently_spectating then
+          if GAME.battleRoom.spectating then
             if msg.player_number == 1 or msg.player_number == 2 then
               cursor_data[msg.player_number].state = msg.menu_state
               refresh_based_on_own_mods(cursor_data[msg.player_number].state)
@@ -873,7 +872,7 @@ function select_screen.main()
           return main_dumb_transition, {main_net_vs_lobby, "", 0, 0} -- opponent left the select screen
         end
         if (msg.match_start or replay_of_match_so_far) and msg.player_settings and msg.opponent_settings then
-          print("currently_spectating: " .. tostring(currently_spectating))
+          print("spectating: " .. tostring(GAME.battleRoom.spectating))
           local fake_P1 = {panel_buffer = "", gpanel_buffer = ""}
           local fake_P2 = {panel_buffer = "", gpanel_buffer = ""}
           refresh_based_on_own_mods(msg.opponent_settings)
@@ -888,7 +887,7 @@ function select_screen.main()
           stage_loader_wait()
           GAME.match = Match("vs", GAME.battleRoom)
           local is_local = true
-          if currently_spectating then
+          if GAME.battleRoom.spectating then
             is_local = false
           end
           P1 = Stack(1, GAME.match, is_local, msg.player_settings.panels_dir, msg.player_settings.level, msg.player_settings.character, msg.player_settings.player_number)
@@ -897,7 +896,7 @@ function select_screen.main()
           P2 = Stack(2, GAME.match, false, msg.opponent_settings.panels_dir, msg.opponent_settings.level, msg.opponent_settings.character, msg.opponent_settings.player_number)
           GAME.match.P2 = P2
           P2.cur_wait_time = default_input_repeat_delay -- this enforces default cur_wait_time for online games.  It is yet to be decided if we want to allow this to be custom online.
-          if currently_spectating then
+          if GAME.battleRoom.spectating then
             P1.panel_buffer = fake_P1.panel_buffer
             P1.gpanel_buffer = fake_P1.gpanel_buffer
           end
@@ -916,8 +915,8 @@ function select_screen.main()
             in_buf = "",
             P1_level = P1.level,
             P2_level = P2.level,
-            P1_name = my_name,
-            P2_name = op_name,
+            P1_name = GAME.battleRoom.playerNames[1],
+            P2_name = GAME.battleRoom.playerNames[2],
             P1_char = P1.character,
             P2_char = P2.character,
             P1_cur_wait_time = P1.cur_wait_time,
@@ -925,7 +924,7 @@ function select_screen.main()
             ranked = msg.ranked,
             do_countdown = true
           }
-          if currently_spectating and replay_of_match_so_far then --we joined a match in progress
+          if GAME.battleRoom.spectating and replay_of_match_so_far then --we joined a match in progress
             replay.vs = replay_of_match_so_far.vs
             P1.input_buffer = replay_of_match_so_far.vs.in_buf
             P1.panel_buffer = replay_of_match_so_far.vs.P
@@ -943,7 +942,7 @@ function select_screen.main()
             P1.play_to_end = true --this makes non local stacks run until caught up
             P2.play_to_end = true
           end
-          if not currently_spectating then
+          if not GAME.battleRoom.spectating then
             ask_for_gpanels("000000")
             ask_for_panels("000000")
           end
@@ -1055,7 +1054,7 @@ function select_screen.main()
     assert(GAME.battleRoom, "need battle room")
     assert(my_player_number and (my_player_number == 1 or my_player_number == 2), "need number")
     draw_button(0, 2, 2, 1, get_player_state_str(my_player_number, my_rating_difference, GAME.battleRoom.playerWinCounts[my_player_number], GAME.battleRoom.playerWinCounts[op_player_number], my_expected_win_ratio), "left", "top", true)
-    if cursor_data[1].state and op_name then
+    if cursor_data[1].state and GAME.battleRoom.playerNames[2] then
       draw_button(0, 7, 1, 1, "P2")
       draw_button(0, 8, 2, 1, get_player_state_str(op_player_number, op_rating_difference, GAME.battleRoom.playerWinCounts[op_player_number], GAME.battleRoom.playerWinCounts[my_player_number], op_expected_win_ratio), "left", "top", true)
     --state = state.." "..json.encode(op_state)
@@ -1240,7 +1239,7 @@ function select_screen.main()
 
         -- Handle input
         local up, down, left, right = {-1, 0}, {1, 0}, {0, -1}, {0, 1}
-        if not currently_spectating then
+        if not GAME.battleRoom.spectating then
           local KMax = 1
           if select_screen.character_select_mode == "2p_local_vs" then
             KMax = 2
@@ -1330,7 +1329,7 @@ function select_screen.main()
             global_op_state.wants_ready = false
           end
 
-          if select_screen.character_select_mode == "2p_net_vs" and not content_equal(cursor_data[1].state, prev_state) and not currently_spectating then
+          if select_screen.character_select_mode == "2p_net_vs" and not content_equal(cursor_data[1].state, prev_state) and not GAME.battleRoom.spectating then
             json_send({menu_state = cursor_data[1].state})
           end
           prev_state = shallowcpy(cursor_data[1].state)


### PR DESCRIPTION
If you did multiple actions in the lobby you could end up having the wrong player names, and potentially spectate / play when you are doing the opposite.

Instead of setting these values when you pick them, set them when the server confirms we are doing that action.

Also deleted duplicate render code