### PR TITLE
Fully play sound effects when transitioning

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -602,9 +602,6 @@ function Stack.set_puzzle_state(self, pstr, n_turns, do_countdown, puzzleType)
   if n_turns ~= 0 then
     self.puzzle_moves = n_turns
   end
-  if self.character and characters[self.character] then
-    characters[self.character]:stop_sounds()
-  end
 end
 
 function Stack.puzzle_done(self)
@@ -690,7 +687,6 @@ function Stack.starting_state(self, n)
       self.cur_row = self.cur_row - 1
     end
   end
-  characters[self.character]:stop_sounds()
 end
 
 function Stack.prep_first_row(self)

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -1601,14 +1601,8 @@ end
 
 -- dumb transition that shows a black screen
 function main_dumb_transition(next_func, text, timemin, timemax, winnerSFX)
-  if P1 and P1.character then
-    characters[P1.character]:stop_sounds()
-  end
-  if P2 and P2.character then
-    characters[P2.character]:stop_sounds()
-  end
   game_is_paused = false
-  stop_all_audio()
+  stop_the_music()
   winnerSFX = winnerSFX or nil
   if not SFX_mute then
     -- TODO: somehow winnerSFX can be 0 instead of nil
@@ -1728,7 +1722,7 @@ function game_over_transition(next_func, text, winnerSFX, timemax)
         -- if conditions are met, leave the game over screen
         if t >= timemin and ((t >= timemax and timemax >= 0) or (menu_enter(k) or menu_escape(k))) or left_select_menu then
           setMusicFadePercentage(1) -- reset the music back to normal config volume
-          stop_all_audio()
+          stop_the_music()
           SFX_GameOver_Play = 0
           analytics.game_ends(P1.analytic)
           ret = {next_func}


### PR DESCRIPTION
Win lose and select character sound effects would be interrupted when starting / ending a game making for a bad experience.

Don't stop sound effects but do continue to stop music.