### PR TITLE
Implement Local Replays

### DIFF
--- a/localization.csv
+++ b/localization.csv
@@ -334,6 +334,7 @@ Leggi il README e guarda i puzzle d'esempio che si trovano lì per avere istruzi
 pz_puzzles,Puzzles:,Puzzles :,Quebra-cabeças:,パズル：,Puzzles:, ,Puzzles:
 rp_endless,endless,infini,Infinito,エンドレス,Interminable, ,infinito
 rp_no_endless,I don't have an endless replay :(,Je n'ai pas de replay infini :(,Não possuo replay sem fim :(,エンドレスのリプレイはありません -_-,No encuentro ninguna repetición del modo Interminable :(, ,Non ho un replay della modalità infinito :(
+rp_no_time_trial,I don't have a time attack replay :(, , , , , , 
 rp_no_puzzle,I don't have a puzzle replay :(,Je n'ai pas de replay puzzle :(,Não possuo replay de quebra-cabeça :(,パズルのリプレイはありません -_-,No encuentro ninguna repetición del modo Puzzle :(, ,Non ho un replay della modalità puzzle :(
 rp_no_replay,I don't have a vs replay :(,Je n'ai pas de replay :(,Não possuo replay vs :(,VSリプレイはありません -_-,No encuentro ninguna repetición del modo VS :(, ,Non ho un replay della modalità vs :(
 rp_score,"You scored %1

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -991,7 +991,6 @@ function main_local_vs_setup()
 end
 
 function main_local_vs()
-  -- TODO: replay!
   use_current_stage()
   pick_use_music_from()
   local end_text = nil
@@ -1024,6 +1023,22 @@ function main_local_vs()
       end_text = loc("pl_1_win")
     end
     if end_text then
+      local now = os.date("*t",to_UTC(os.time()))
+      local sep = "/"
+      local path = "replays"..sep.."v"..VERSION..sep..string.format("%04d"..sep.."%02d"..sep.."%02d", now.year, now.month, now.day)
+      path = path.."/local-vs"
+      local filename = "v"..VERSION.."-"..string.format("%04d-%02d-%02d-%02d-%02d-%02d", now.year, now.month, now.day, now.hour, now.min, now.sec).."-".."local-vs"
+      if outcome_claim == 1 or outcome_claim == 2 then
+        filename = filename.."-P"..outcome_claim.."wins"
+      elseif outcome_claim == 0 then
+        filename = filename.."-draw"
+      end
+      filename = filename..".txt"
+      print("saving replay as "..path..sep..filename)
+      write_replay_file(path, filename)
+      print("also saving replay as replay.txt")
+      write_replay_file()
+
       analytics.game_ends()
       return main_dumb_transition, {select_screen.main, end_text, 45, -1, winSFX}
     end
@@ -1100,23 +1115,23 @@ function main_replay_vs()
   P1 = Stack(1, "vs", config.panels, replay.P1_level or 5)
   P1.do_countdown = replay.do_countdown or false
   P1.ice = true
-  P1.input_buffer = replay.in_buf
-  P1.panel_buffer = replay.P or replay.pan_buf
-  P1.gpanel_buffer = replay.Q or replay.gpan_buf
+  P1.input_buffer = replay.in_buf or replay.P1.in_buf
+  P1.panel_buffer = replay.P or replay.pan_buf or replay.P1.pan_buf
+  P1.gpanel_buffer = replay.Q or replay.gpan_buf or replay.P1.gpan_buf
   P1.max_runs_per_frame = 1
   P1.character = replay.P1_char
   P1.cur_wait_time = replay.P1_cur_wait_time or default_input_repeat_delay
   refresh_based_on_own_mods(P1)
   character_loader_load(P1.character)
 
-  if replay.I ~= nil and replay.O ~= nil and replay.R ~= nil then
+  if (replay.I ~= nil and replay.O ~= nil and replay.R ~= nil) or (replay.P1 ~= nil and replay.P2 ~= nil) then
     P2 = Stack(2, "vs", config.panels, replay.P2_level or 5)
     P2.do_countdown = replay.do_countdown or false
     P2.garbage_target = P1
     move_stack(P2,2)
-    P2.input_buffer = replay.I
-    P2.panel_buffer = replay.O
-    P2.gpanel_buffer = replay.R
+    P2.input_buffer = replay.I or replay.P2.in_buf
+    P2.panel_buffer = replay.O or replay.P2.pan_buf
+    P2.gpanel_buffer = replay.R or replay.P2.gpan_buf
     P2.max_runs_per_frame = 1
     P2.character = replay.P2_char
     P2.cur_wait_time = replay.P2_cur_wait_time or default_input_repeat_delay

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -353,11 +353,11 @@ end
 function main_endless(...)
   pick_random_stage()
   pick_use_music_from()
+  replay = {}
   replay.endless = {}
   local replay=replay.endless
   replay.pan_buf = ""
   replay.in_buf = ""
-  replay.gpan_buf = ""
   replay.mode = "endless"
   P1 = Stack(1, "endless", config.panels, ...)
   P1:wait_for_random_character()
@@ -379,7 +379,17 @@ function main_endless(...)
     wait()
     if P1.game_over then
     -- TODO: proper game over.
+      local now = os.date("*t",to_UTC(os.time()))
+      local sep = "/"
+      local path = "replays"..sep.."v"..VERSION..sep..string.format("%04d"..sep.."%02d"..sep.."%02d", now.year, now.month, now.day)
+      path = path..sep.."endless"
+      local filename = "v"..VERSION.."-"..string.format("%04d-%02d-%02d-%02d-%02d-%02d", now.year, now.month, now.day, now.hour, now.min, now.sec).."-".."endless"
+      filename = filename..".txt"
+      print("saving replay as "..path..sep..filename)
+      write_replay_file(path, filename)
+      print("also saving replay as replay.txt")
       write_replay_file()
+
       local end_text = loc("rp_score", P1.score, frames_to_time_string(P1.game_stopwatch, true))
       analytics.game_ends()
       return main_dumb_transition, {main_select_mode, end_text, 0, -1, P1:pick_win_sfx()}
@@ -1159,6 +1169,7 @@ function main_replay_endless()
   P1 = Stack(1, "endless", config.panels, replay.speed, replay.difficulty)
   P1:wait_for_random_character()
   P1.do_countdown = replay.do_countdown or false
+  P1.enable_analytics = true
   P1.max_runs_per_frame = 1
   P1.input_buffer = table.concat({replay.in_buf})
   P1.panel_buffer = replay.pan_buf

--- a/network.lua
+++ b/network.lua
@@ -197,6 +197,8 @@ function make_local_panels(stack, prev_panels)
   local replay = replay[P1.mode]
   if replay and replay.pan_buf then
     replay.pan_buf = replay.pan_buf .. ret
+  elseif replay and replay["P"..stack.player_number] and replay["P"..stack.player_number].pan_buf then
+    replay["P"..stack.player_number].pan_buf = replay["P"..stack.player_number].pan_buf .. ret
   end
 end
 
@@ -206,6 +208,8 @@ function make_local_gpanels(stack, prev_panels)
   local replay = replay[P1.mode]
   if replay and replay.gpan_buf then
     replay.gpan_buf = replay.gpan_buf .. ret
+  elseif replay and replay["P"..stack.player_number] and replay["P"..stack.player_number].gpan_buf then
+    replay["P"..stack.player_number].gpan_buf = replay["P"..stack.player_number].gpan_buf .. ret
   end
 end
 
@@ -250,6 +254,8 @@ function Stack.send_controls(self)
   local replay = replay[self.mode]
   if replay and replay.in_buf then
     replay.in_buf = replay.in_buf .. to_send
+  elseif replay and replay["P"..self.player_number] and replay["P"..self.player_number].in_buf then
+    replay["P"..self.player_number].in_buf = replay["P"..self.player_number].in_buf .. to_send
   end
   return to_send
 end

--- a/replay_browser.lua
+++ b/replay_browser.lua
@@ -177,6 +177,15 @@ function replay_browser.main()
 
         next_func = main_replay_endless
 
+
+      elseif replay.time then
+        gprint(loc("rp_browser_info_time_trial"), replay_browser.menu_x + 220, replay_browser.menu_y + 20)
+
+        gprint(loc("rp_browser_info_speed", replay.time.speed), replay_browser.menu_x + 150, replay_browser.menu_y + 50)
+        gprint(loc("rp_browser_info_difficulty", replay.time.difficulty), replay_browser.menu_x + 150, replay_browser.menu_y + 65)
+
+        next_func = main_replay_time_attack
+
       elseif replay.puzzle then
         gprint(loc("rp_browser_info_puzzle"), replay_browser.menu_x + 220, replay_browser.menu_y + 20)
 

--- a/replay_browser.lua
+++ b/replay_browser.lua
@@ -151,20 +151,28 @@ function replay_browser.main()
       gprint(replay_browser.filename, replay_browser.menu_x - 150, replay_browser.menu_y - 40 + replay_browser.menu_h)
 
       if replay.vs then
-        gprint(loc("rp_browser_info_2p_vs"), replay_browser.menu_x + 220, replay_browser.menu_y + 20)
+        if replay.I ~= nil and replay.O ~= nil and replay.R ~= nil then
+          gprint(loc("rp_browser_info_2p_vs"), replay_browser.menu_x + 220, replay_browser.menu_y + 20)
 
-        gprint(loc("rp_browser_info_1p"), replay_browser.menu_x, replay_browser.menu_y + 50)
-        gprint(loc("rp_browser_info_name", replay.vs.P1_name), replay_browser.menu_x, replay_browser.menu_y + 65)
-        gprint(loc("rp_browser_info_level", replay.vs.P1_level), replay_browser.menu_x, replay_browser.menu_y + 80)
-        gprint(loc("rp_browser_info_character", replay.vs.P1_char), replay_browser.menu_x, replay_browser.menu_y + 95)
+          gprint(loc("rp_browser_info_1p"), replay_browser.menu_x, replay_browser.menu_y + 50)
+          gprint(loc("rp_browser_info_name", replay.vs.P1_name), replay_browser.menu_x, replay_browser.menu_y + 65)
+          gprint(loc("rp_browser_info_level", replay.vs.P1_level), replay_browser.menu_x, replay_browser.menu_y + 80)
+          gprint(loc("rp_browser_info_character", replay.vs.P1_char), replay_browser.menu_x, replay_browser.menu_y + 95)
 
-        gprint(loc("rp_browser_info_2p"), replay_browser.menu_x + 300, replay_browser.menu_y + 50)
-        gprint(loc("rp_browser_info_name", replay.vs.P2_name), replay_browser.menu_x + 300, replay_browser.menu_y + 65)
-        gprint(loc("rp_browser_info_level", replay.vs.P2_level), replay_browser.menu_x + 300, replay_browser.menu_y + 80)
-        gprint(loc("rp_browser_info_character", replay.vs.P2_char), replay_browser.menu_x + 300, replay_browser.menu_y + 95)
+          gprint(loc("rp_browser_info_2p"), replay_browser.menu_x + 300, replay_browser.menu_y + 50)
+          gprint(loc("rp_browser_info_name", replay.vs.P2_name), replay_browser.menu_x + 300, replay_browser.menu_y + 65)
+          gprint(loc("rp_browser_info_level", replay.vs.P2_level), replay_browser.menu_x + 300, replay_browser.menu_y + 80)
+          gprint(loc("rp_browser_info_character", replay.vs.P2_char), replay_browser.menu_x + 300, replay_browser.menu_y + 95)
 
-        if replay.vs.ranked then
-          gprint(loc("rp_browser_info_ranked"), replay_browser.menu_x + 200, replay_browser.menu_y + 120)
+          if replay.vs.ranked then
+            gprint(loc("rp_browser_info_ranked"), replay_browser.menu_x + 200, replay_browser.menu_y + 120)
+          end
+        else
+          gprint(loc("rp_browser_info_1p_vs"), replay_browser.menu_x + 220, replay_browser.menu_y + 20)
+
+          gprint(loc("rp_browser_info_name", replay.vs.P1_name), replay_browser.menu_x, replay_browser.menu_y + 50)
+          gprint(loc("rp_browser_info_level", replay.vs.P1_level), replay_browser.menu_x, replay_browser.menu_y + 65)
+          gprint(loc("rp_browser_info_character", replay.vs.P1_char), replay_browser.menu_x, replay_browser.menu_y + 80)
         end
 
         next_func = main_replay_vs

--- a/replay_browser.lua
+++ b/replay_browser.lua
@@ -151,7 +151,7 @@ function replay_browser.main()
       gprint(replay_browser.filename, replay_browser.menu_x - 150, replay_browser.menu_y - 40 + replay_browser.menu_h)
 
       if replay.vs then
-        if replay.I ~= nil and replay.O ~= nil and replay.R ~= nil then
+        if replay.vs.I ~= nil and replay.vs.O ~= nil and replay.vs.R ~= nil then
           gprint(loc("rp_browser_info_2p_vs"), replay_browser.menu_x + 220, replay_browser.menu_y + 20)
 
           gprint(loc("rp_browser_info_1p"), replay_browser.menu_x, replay_browser.menu_y + 50)
@@ -167,6 +167,16 @@ function replay_browser.main()
           if replay.vs.ranked then
             gprint(loc("rp_browser_info_ranked"), replay_browser.menu_x + 200, replay_browser.menu_y + 120)
           end
+        elseif replay.vs.P1 ~= nil and replay.vs.P2 ~= nil then
+          gprint(loc("rp_browser_info_2p_vs"), replay_browser.menu_x + 220, replay_browser.menu_y + 20)
+
+          gprint(loc("rp_browser_info_1p"), replay_browser.menu_x, replay_browser.menu_y + 50)
+          gprint(loc("rp_browser_info_level", replay.vs.P1_level), replay_browser.menu_x, replay_browser.menu_y + 65)
+          gprint(loc("rp_browser_info_character", replay.vs.P1_char), replay_browser.menu_x, replay_browser.menu_y + 80)
+
+          gprint(loc("rp_browser_info_2p"), replay_browser.menu_x + 300, replay_browser.menu_y + 50)
+          gprint(loc("rp_browser_info_level", replay.vs.P2_level), replay_browser.menu_x + 300, replay_browser.menu_y + 65)
+          gprint(loc("rp_browser_info_character", replay.vs.P2_char), replay_browser.menu_x + 300, replay_browser.menu_y + 80)
         else
           gprint(loc("rp_browser_info_1p_vs"), replay_browser.menu_x + 220, replay_browser.menu_y + 20)
 

--- a/schemas
+++ b/schemas
@@ -1,0 +1,81 @@
+== Old ==
+
+Online VS
+{
+	"vs": {
+		"do_countdown": boolean,
+		"I": string,
+		"in_buf": string,
+		"O": string,
+		"P": string,
+		"P1_char": string,
+		"P1_cur_wait_time": number,
+		"P1_level": number,
+		"P1_name": string,
+		"P2_char": string,
+		"P2_cur_wait_time": number,
+		"P2_level": number,
+		"P2_name": string,
+		"Q": string,
+		"R": string,
+		"ranked": boolean
+	}
+}
+
+== New ==
+Do we need do_countdown?
+Do we need cur_wait_time?
+
+Online Vs
+{
+	"do_countdown": boolean,
+	"P1": {
+		"char": string,
+		"cur_wait_time": string,
+		"gpan_buf": string,
+		"in_buf": string,
+		"level": number,
+		"name": string,
+		"pan_buf": string,
+	},
+	"P2": {
+		"char": string,
+		"cur_wait_time": string,
+		"gpan_buf": string,
+		"in_buf": string,
+		"level": number,
+		"name": string,
+		"pan_buf": string,
+	},
+	"ranked": boolean,
+	"type": string,
+}
+
+Endless
+{
+	"do_countdown": boolean,
+	"P1": {
+		"char": string,
+		"cur_wait_time": string,
+		"gpan_buf": string,
+		"in_buf": string,
+		"level": number,
+		"name": string,
+		"pan_buf": string,
+	},
+}
+
+Time Attack
+{
+	
+}
+
+Vs Yourself
+{
+	
+}
+
+Local 2p Vs
+{
+	
+}

--- a/select_screen.lua
+++ b/select_screen.lua
@@ -1303,6 +1303,15 @@ function select_screen.main()
       --
       -- In general the block-generation logic should be the same as the server's, so
       -- maybe there should be only one implementation.
+
+      replay = {}
+      replay.vs = {P1={pan_buf="",gpan_buf="",in_buf=""},
+                  P2={pan_buf="",gpan_buf="",in_buf=""},
+                  P1_level=P1.level,P2_level=P2.level,
+                  P1_char=P1.character,P2_char=P2.character,
+                  P1_cur_wait_time=P1.cur_wait_time, P2_cur_wait_time=P2.cur_wait_time,
+                  do_countdown=true}
+
       make_local_panels(P1, "000000")
       make_local_gpanels(P1, "000000")
       make_local_panels(P2, "000000")

--- a/select_screen.lua
+++ b/select_screen.lua
@@ -873,6 +873,7 @@ function select_screen.main()
           P1.garbage_target = P2
           P2.garbage_target = P1
           move_stack(P2,2)
+          replay = {}
           replay.vs = {P="",O="",I="",Q="",R="",in_buf="",
                       P1_level=P1.level,P2_level=P2.level,
                       P1_name=my_name, P2_name=op_name,
@@ -1272,6 +1273,13 @@ function select_screen.main()
       P1 = Stack(1, "vs", cursor_data[1].state.panels_dir, cursor_data[1].state.level, cursor_data[1].state.character)
       P1.enable_analytics = true
       P1.garbage_target = P1
+
+      replay = {}
+      replay.vs = {pan_buf="",gpan_buf="",in_buf="",P1_level=P1.level,
+                  P1_name=my_name,P1_char=P1.character,
+                  P1_cur_wait_time=P1.cur_wait_time,
+                  do_countdown=true}
+
       make_local_panels(P1, "000000")
       make_local_gpanels(P1, "000000")
       current_stage = cursor_data[1].state.stage


### PR DESCRIPTION
The replay system works fine for online vs play, but it doesn't capture any local games. As someone who primarily plays "vs yourself" when I play Panel Attack, I find this moderately annoying! So, here is support for recording all forms of local play (except for puzzle games) for future replay enjoyment.

These changes update the format of the Panel Attack replay files in a non-backwards-compatible way. Older versions of the PA client will not be able to view replays created by this code. I consider this an acceptable sacrifice, especially since replays are already prefixed with their versions, implying that the community already expects to not be able to watch one version's replays on a different version (reasonable, if engine changes are involved). However, the format of old replays will still be readable with these code changes. This extra compatibility may be removed in the future. It occurs to me that I don't need to go through this extra effort with future replay changes as long as the changes go out with a version change, but I didn't know for sure and wanted to be careful while making these changes. Also, people playing on nightly builds probably would prefer their replays didn't break.

Details of how the schema has been changed will be included further down.

It should be noted that these code changes are over a year old. I pulled up my old changes today and verified that all replays are valid with my changes (local 2p vs, local vs self, local endless, local time attack, online 2p vs casual with my changes, online 2p vs casual from vanilla v045), though I have not tested online 2p ranked. There are inconsistencies in the way that replays are stored for different match types (see the schema explanation below). Since all of the features are there and working, I decided to open a pull request anyways. Better to have any replays at all and get consistency later on.

Future change opportunities:
- "in_buf" is full of redundant data. I propose using some strategy to consolidate repeated inputs (like a wall of AAAAAAAAAA) to take up fewer characters, thus reducing replay file size
- Add map info to replays. Currently, the music being played is unlikely to match the music that the players heard when actually playing the game. This is, admittedly, more relevant for local single-player replays than online 2p replays
- Make all schema types more consistent. I think I originally stopped working on this code for an entire year because I wanted to make forward progress in this regard but got slightly overwhelmed with the effort
- Either make key names shorter (like the one-letter values in the old schema) for conciseness or make all key names (including the network-only keys like O and R) more verbose for clarity
- I don't know if most (or all) of the countdown and wait-time-related fields in the replay data are actually relevant. They could be removed for conciseness

### Schema Descriptions

Old (v045) Schema:
```
{
	"vs": {
		"do_countdown": boolean,
		"I": string,
		"in_buf": string,
		"O": string,
		"P": string,
		"P1_char": string,
		"P1_cur_wait_time": number,
		"P1_level": number,
		"P1_name": string,
		"P2_char": string,
		"P2_cur_wait_time": number,
		"P2_level": number,
		"P2_name": string,
		"Q": string,
		"R": string,
		"ranked": boolean
	}
}
```

New Online 2p VS Schema:
```{
    "vs": {
        "do_countdown": boolean,
        "O": string,
        "P2_char": string,
        "P2_name": string,
        "R": string,
        "in_buf": string,
        "P2_cur_wait_time": number,
        "Q": string,
        "ranked": boolean,
        "P1_cur_wait_time": number,
        "P1_name": string,
        "P1_level": number,
        "P2_level": number
    }
}
```

Endless Schema:
```
{
    "endless": {
        "difficulty": number,
        "cur_wait_time": number,
        "speed": number,
        "pan_buf": string,
        "in_buf": string,
        "mode": "endless",
        "do_countdown": boolean
    }
}
```

Time Attack Schema:
```
{
    "time": {
        "difficulty": number,
        "cur_wait_time": number,
        "speed": number,
        "pan_buf": string,
        "in_buf": string,
        "mode": "time",
        "do_countdown": boolean
    }
}
```

VS Self Schema:
```
{
    "vs": {
        "P1_level": number,
        "gpan_buf": string,
        "P1_cur_wait_time": number,
        "P1_name": string,
        "pan_buf": string,
        "in_buf": string,
        "P1_char": string,
        "do_countdown": boolean
    }
}
```