### PR TITLE
Reduce log output on client

### DIFF
--- a/character.lua
+++ b/character.lua
@@ -1,4 +1,5 @@
 require("character_loader")
+local logger = require("logger")
 
 -- Stuff defined in this file: the data structure that store a character's data
 
@@ -234,27 +235,27 @@ function Character.play_combo_chain_sfx(self, chain_combo)
 end
 
 function Character.preload(self)
-  print("preloading character " .. self.id)
+  logger.trace("preloading character " .. self.id)
   self:graphics_init(false, false)
   self:sound_init(false, false)
 end
 
 -- Loads all the sounds and graphics
 function Character.load(self, instant)
-  print("loading character " .. self.id)
+  logger.trace("loading character " .. self.id)
   self:graphics_init(true, (not instant))
   self:sound_init(true, (not instant))
   self.fully_loaded = true
-  print("loaded character " .. self.id)
+  logger.trace("loaded character " .. self.id)
 end
 
 -- Unloads the sounds and graphics
 function Character.unload(self)
-  print("unloading character " .. self.id)
+  logger.trace("unloading character " .. self.id)
   self:graphics_uninit()
   self:sound_uninit()
   self.fully_loaded = false
-  print("unloaded character " .. self.id)
+  logger.trace("unloaded character " .. self.id)
 end
 
 -- Adds all the characters recursively in a folder to the global characters variable
@@ -275,9 +276,9 @@ local function add_characters_from_dir_rec(path)
 
         if success then
           if characters[character.id] ~= nil then
-            print(current_path .. " has been ignored since a character with this id has already been found")
+            logger.trace(current_path .. " has been ignored since a character with this id has already been found")
           else
-            -- print(current_path.." has been added to the character list!")
+            -- logger.trace(current_path.." has been added to the character list!")
             characters[character.id] = character
             characters_ids[#characters_ids + 1] = character.id
           end
@@ -301,20 +302,20 @@ local function fill_characters_ids()
       for _, sub_character in ipairs(copy_of_sub_characters) do
         if characters[sub_character] and #characters[sub_character].sub_characters == 0 then -- inner bundles are prohibited
           character.sub_characters[#character.sub_characters + 1] = sub_character
-          print(character.id .. " has " .. sub_character .. " as part of its subcharacters.")
+          logger.trace(character.id .. " has " .. sub_character .. " as part of its subcharacters.")
         end
       end
 
       if #character.sub_characters < 2 then
         invalid[#invalid + 1] = character_id -- character is invalid
-        print(character.id .. " (bundle) is being ignored since it's invalid!")
+        logger.warn(character.id .. " (bundle) is being ignored since it's invalid!")
       else
         characters_ids[#characters_ids + 1] = character_id
-        print(character.id .. " (bundle) has been added to the character list!")
+        logger.debug(character.id .. " (bundle) has been added to the character list!")
       end
     else -- normal character
       characters_ids[#characters_ids + 1] = character_id
-      print(character.id .. " has been added to the character list!")
+      logger.debug(character.id .. " has been added to the character list!")
     end
   end
 
@@ -394,7 +395,6 @@ end
 function Character.graphics_init(self, full, yields)
   local character_images = full and other_images or basic_images
   for _, image_name in ipairs(character_images) do
-    --print(image_name)
     self.images[image_name] = load_img_from_supported_extensions(self.path .. "/" .. image_name)
     if not self.images[image_name] and defaulted_images[image_name] and not self:is_bundle() then
       if image_name == "burst" or image_name == "fade" then
@@ -402,7 +402,6 @@ function Character.graphics_init(self, full, yields)
       else
         self.images[image_name] = default_character.images[image_name]
       end
-    --print("MISSING!")
     end
     if yields then
       coroutine.yield()
@@ -497,7 +496,7 @@ function Character.sound_init(self, full, yields)
         self.sounds.chains[i] = {}
         self:init_sfx_variants(self.sounds.chains[i], "chain" .. i, "_")
         if #self.sounds.chains[i] ~= 0 then
-          print("chain" .. i .. " has " .. #self.sounds.chains[i] .. " variant(s)")
+          logger.trace("chain" .. i .. " has " .. #self.sounds.chains[i] .. " variant(s)")
         end
       end
       self.sounds.chains[0] = {}

--- a/engine.lua
+++ b/engine.lua
@@ -1,4 +1,5 @@
 require("analytics")
+local logger = require("logger")
 
 -- Stuff defined in this file:
 --  . the data structures that store the configuration of
@@ -396,8 +397,8 @@ function GarbageQueue.push(self, garbage)
     self.metal = self.metal + 1
   elseif from_chain or height > 1 then
     if not from_chain then
-      print("ERROR: garbage with height > 1 was not marked as 'from_chain'")
-      print("adding it to the chain garbage queue anyway")
+      logger.warn("garbage with height > 1 was not marked as 'from_chain'")
+      logger.warn("adding it to the chain garbage queue anyway")
     end
     self.chain_garbage:push(garbage)
   else
@@ -1918,7 +1919,7 @@ function Stack.drop_garbage(self, width, height, metal)
       for j = 1, self.width do
         if self.panels[i][j] then
           if self.panels[i][j].color ~= 0 then
-            print("Aborting garbage drop: panel found at row " .. tostring(i) .. " column " .. tostring(j))
+            logger.trace("Aborting garbage drop: panel found at row " .. tostring(i) .. " column " .. tostring(j))
             return false
           end
         end
@@ -1927,7 +1928,7 @@ function Stack.drop_garbage(self, width, height, metal)
   end
 
   if self.canvas ~= nil then
-    print(string.format("Dropping garbage on player %d - height %d  width %d  %s", self.player_number, height, width, metal and "Metal" or ""))
+    logger.trace(string.format("Dropping garbage on player %d - height %d  width %d  %s", self.player_number, height, width, metal and "Metal" or ""))
   end
 
   for i = self.height + 1, spawn_row + height - 1 do
@@ -2028,7 +2029,7 @@ function Stack.recv_garbage(self, time, to_recv)
       local old_self = prev_states[time]
       --MAGICAL ROLLBACK!?!?
       self.in_rollback = true
-      print("attempting magical rollback with difference = " .. self.CLOCK - time .. " at time " .. self.CLOCK)
+      logger.trace("attempting magical rollback with difference = " .. self.CLOCK - time .. " at time " .. self.CLOCK)
 
       -- The garbage that we send this time might (rarely) not be the same
       -- as the garbage we sent before.  Wipe out the garbage we sent before...

--- a/logger.lua
+++ b/logger.lua
@@ -1,0 +1,53 @@
+local os = require("os")
+local socket = require("socket")
+
+local logger = {}
+
+local TRACE = 0
+local DEBUG = 1
+local INFO = 2
+local WARN = 3
+local ERROR = 4
+
+local LOG_LEVEL = WARN
+
+function logger.trace(msg)
+    if LOG_LEVEL <= TRACE then
+        direct_log("TRACE", msg);
+    end
+end
+
+function logger.debug(msg)
+    if LOG_LEVEL <= DEBUG then
+        direct_log("DEBUG", msg);
+    end
+end
+
+function logger.info(msg)
+    if LOG_LEVEL <= INFO then
+        direct_log(" INFO", msg);
+    end
+end
+
+function logger.warn(msg)
+    if LOG_LEVEL <= WARN then
+        direct_log(" WARN", msg);
+    end
+end
+
+function logger.error(msg)
+    if LOG_LEVEL <= ERROR then
+        direct_log("ERROR", msg);
+    end
+end
+
+function direct_log(prefix, msg)
+    local socket_millis = math.floor(socket.gettime()%1 * 1000)
+
+    -- Lua date format strings reference: https://www.lua.org/pil/22.1.html
+    -- %x - Date
+    -- %X - Time
+    print(os.date("%x %X") .. "." .. socket_millis .. " " .. prefix .. ": " .. msg)
+end
+
+return logger;

--- a/main.lua
+++ b/main.lua
@@ -26,6 +26,7 @@ require("gen_panels")
 require("panels")
 require("theme")
 require("click_menu")
+local logger = require("logger")
 
 GAME.scores = require("scores")
 
@@ -79,7 +80,7 @@ function love.update(dt)
     error(err .. "\n" .. debug.traceback(mainloop))
   end
   if server_queue and server_queue:size() > 0 then
-    print("Queue Size: " .. server_queue:size() .. " Data:" .. server_queue:to_short_string())
+    logger.trace("Queue Size: " .. server_queue:size() .. " Data:" .. server_queue:to_short_string())
   end
   this_frame_messages = {}
 

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -1,4 +1,4 @@
-
+local logger = require("logger")
 local select_screen = require("select_screen")
 local replay_browser = require("replay_browser")
 local options = require("options")
@@ -558,7 +558,7 @@ function main_net_vs_lobby()
           logged_in = true
           if msg.new_user_id then
             my_user_id = msg.new_user_id
-            print("about to write user id file")
+            logger.trace("about to write user id file")
             write_user_id_file()
             login_status_message = loc("lb_user_new", config.name)
           elseif msg.name_changed then
@@ -912,7 +912,7 @@ function main_net_vs()
     end
 
     if GAME.battleRoom.spectating and menu_escape(K[1]) then
-      print("spectator pressed escape during a game")
+      logger.trace("spectator pressed escape during a game")
       json_send({leave_room = true})
       return main_dumb_transition, {main_net_vs_lobby, "", 0, 0} -- spectator leaving the match
     end
@@ -921,7 +921,6 @@ function main_net_vs()
     end
     process_all_data_messages() -- main game play processing
 
-    --print(P1.CLOCK, P2.CLOCK)
     if (P1 and P1.play_to_end) or (P2 and P2.play_to_end) then
       P1:run()
       P2:run()
@@ -968,7 +967,7 @@ function main_net_vs()
       end
       filename = filename .. ".txt"
       write_replay_file()
-      print("saving replay as " .. path .. sep .. filename)
+      logger.info("saving replay as " .. path .. sep .. filename)
       write_replay_file(path, filename)
 
       select_screen.character_select_mode = "2p_net_vs"
@@ -1609,7 +1608,7 @@ function main_dumb_transition(next_func, text, timemin, timemax, winnerSFX)
     if winnerSFX ~= nil and winnerSFX ~= 0 then
       winnerSFX:play()
     elseif SFX_GameOver_Play == 1 then
-      print(debug.traceback(""))
+      logger.trace(debug.traceback(""))
       themes[config.theme].sounds.game_over:play()
     end
   end
@@ -1691,7 +1690,6 @@ function game_over_transition(next_func, text, winnerSFX, timemax)
         if not SFX_mute then
           if t >= winnerTime then
             if winnerSFX ~= nil then -- play winnerSFX then nil it so it doesn't loop
-              print(winnerSFX)
               winnerSFX:play()
               winnerSFX = nil
             end

--- a/network.lua
+++ b/network.lua
@@ -1,3 +1,5 @@
+local logger = require("logger")
+
 local TCP_sock = nil
 
 -- Expected length for each message type
@@ -45,7 +47,7 @@ function get_message()
   if type == "J" then
     if string.len(leftovers) >= 4 then
       len = byte(string.sub(leftovers, 2, 2)) * 65536 + byte(string.sub(leftovers, 3, 3)) * 256 + byte(string.sub(leftovers, 4, 4))
-      --print("json message has length "..len)
+      --logger.trace("json message has length "..len)
       gap = 3
     else
       return nil
@@ -126,7 +128,7 @@ function queue_message(type, data)
     local dataMessage = {}
     dataMessage[type] = data
     if printNetworkMessageForType(type) then
-      --print("Queuing: " .. type .. " with data:" .. data)
+      --logger.debug("Queuing: " .. type .. " with data:" .. data)
     end
     server_queue:push(dataMessage)
   elseif type == "L" then
@@ -150,7 +152,7 @@ function queue_message(type, data)
       return
     end
     if printNetworkMessageForType(type) then
-      --print("Queuing: " .. type .. " with data:" .. dump(current_message))
+      --logger.debug("Queuing: " .. type .. " with data:" .. dump(current_message))
     end
     server_queue:push(current_message)
   end
@@ -179,7 +181,7 @@ function process_all_data_messages()
     for type, data in pairs(msg) do
       if type ~= "_expiration" then
         if printNetworkMessageForType(type) then
-          print("Processing: " .. type .. " with data:" .. data)
+          logger.debug("Processing: " .. type .. " with data:" .. data)
         end
         process_data_message(type, data)
       end

--- a/panels.lua
+++ b/panels.lua
@@ -1,4 +1,5 @@
 require("graphics_util")
+local logger = require("logger")
 
 -- The class representing the panel image data
 -- Not to be confused with "Panel" which is one individual panel in the game stack model
@@ -47,9 +48,8 @@ local function add_panels_from_dir_rec(path)
 
         if success then
           if panels[panel_set.id] ~= nil then
-            print(current_path .. " has been ignored since a panel set with this id has already been found")
+            logger.trace(current_path .. " has been ignored since a panel set with this id has already been found")
           else
-            -- print(current_path.." has been added to the character list!")
             panels[panel_set.id] = panel_set
             panels_ids[#panels_ids + 1] = panel_set.id
           end
@@ -76,7 +76,7 @@ function panels_init()
 end
 
 function Panels.load(self)
-  print("loading panels " .. self.id)
+  logger.debug("loading panels " .. self.id)
 
   local function load_panel_img(name)
     local img = load_img_from_supported_extensions(self.path .. "/" .. name)

--- a/select_screen.lua
+++ b/select_screen.lua
@@ -1,3 +1,5 @@
+local logger = require("logger")
+
 local select_screen = {}
 
 select_screen.fallback_when_missing = {nil, nil}
@@ -24,7 +26,7 @@ local function fill_map(template_map, map)
           character_id_index = character_id_index + 1
           -- end case: no more characters_ids_for_current_theme to add
           if character_id_index == #characters_ids_for_current_theme + 1 then
-            print("filled " .. #characters_ids_for_current_theme .. " characters across " .. pages_amount .. " page(s)")
+            logger.trace("filled " .. #characters_ids_for_current_theme .. " characters across " .. pages_amount .. " page(s)")
             return pages_amount
           end
         end
@@ -173,7 +175,7 @@ function select_screen.main()
     P1 = nil
     P2 = nil
     drop_old_data_messages() -- Starting a new game, clear all old data messages from the previous game
-    print("Reseting player stacks")
+    logger.debug("Reseting player stacks")
 
     -- Wait till we have the room setup messages from the server
     local opponent_connected = false
@@ -206,10 +208,10 @@ function select_screen.main()
     elseif GAME.battleRoom.spectating then
       my_player_number = 1
     elseif my_player_number and my_player_number ~= 0 then
-      print("We assumed our player number is still " .. my_player_number)
+      logger.debug("We assumed our player number is still " .. my_player_number)
     else
       error(loc("nt_player_err"))
-      print("Error: The server never told us our player number.  Assuming it is 1")
+      logger.error("The server never told us our player number.  Assuming it is 1")
       my_player_number = 1
     end
 
@@ -218,15 +220,15 @@ function select_screen.main()
     elseif GAME.battleRoom.spectating then
       op_player_number = 2
     elseif op_player_number and op_player_number ~= 0 then
-      print("We assumed op player number is still " .. op_player_number)
+      logger.tracdebuge("We assumed op player number is still " .. op_player_number)
     else
       error("We never heard from the server as to what player number we are")
-      print("Error: The server never told us our player number.  Assuming it is 2")
+      logger.error("The server never told us our player number.  Assuming it is 2")
       op_player_number = 2
     end
 
     if my_player_number == 2 and msg.a_menu_state ~= nil and msg.b_menu_state ~= nil then
-      print("inverting the states to match player number!")
+      logger.warn("inverting the states to match player number!")
       msg.a_menu_state, msg.b_menu_state = msg.b_menu_state, msg.a_menu_state
     end
 
@@ -250,7 +252,7 @@ function select_screen.main()
       match_type = "Casual"
     end
 
-    print("current_server_supports_ranking: " .. tostring(current_server_supports_ranking))
+    logger.trace("current_server_supports_ranking: " .. tostring(current_server_supports_ranking))
 
     if current_server_supports_ranking then
       template_map = {
@@ -275,8 +277,8 @@ function select_screen.main()
     global_current_room_ratings = global_current_room_ratings or {{new = 0, old = 0, difference = 0}, {new = 0, old = 0, difference = 0}}
     my_expected_win_ratio = nil
     op_expected_win_ratio = nil
-    print("my_player_number = " .. my_player_number)
-    print("op_player_number = " .. op_player_number)
+    logger.trace("my_player_number = " .. my_player_number)
+    logger.trace("op_player_number = " .. op_player_number)
     if global_current_room_ratings[my_player_number].new and global_current_room_ratings[my_player_number].new ~= 0 and global_current_room_ratings[op_player_number] and global_current_room_ratings[op_player_number].new ~= 0 then
       my_expected_win_ratio = (100 * round(1 / (1 + 10 ^ ((global_current_room_ratings[op_player_number].new - global_current_room_ratings[my_player_number].new) / RATING_SPREAD_MODIFIER)), 2))
       op_expected_win_ratio = (100 * round(1 / (1 + 10 ^ ((global_current_room_ratings[my_player_number].new - global_current_room_ratings[op_player_number].new) / RATING_SPREAD_MODIFIER)), 2))
@@ -777,7 +779,7 @@ function select_screen.main()
     end
   end
 
-  print("got to LOC before net_vs_room character select loop")
+  logger.trace("got to LOC before net_vs_room character select loop")
   menu_clock = 0
 
   local v_align_center = {__Ready = true, __Random = true, __Leave = true}
@@ -872,7 +874,7 @@ function select_screen.main()
           return main_dumb_transition, {main_net_vs_lobby, "", 0, 0} -- opponent left the select screen
         end
         if (msg.match_start or replay_of_match_so_far) and msg.player_settings and msg.opponent_settings then
-          print("spectating: " .. tostring(GAME.battleRoom.spectating))
+          logger.debug("spectating: " .. tostring(GAME.battleRoom.spectating))
           local fake_P1 = {panel_buffer = "", gpanel_buffer = ""}
           local fake_P2 = {panel_buffer = "", gpanel_buffer = ""}
           refresh_based_on_own_mods(msg.opponent_settings)
@@ -965,11 +967,11 @@ function select_screen.main()
           local game_start_timeout = 0
           while P1.panel_buffer == "" or P2.panel_buffer == "" or P1.gpanel_buffer == "" or P2.gpanel_buffer == "" do
             game_start_timeout = game_start_timeout + 1
-            print("game_start_timeout = " .. game_start_timeout)
-            print("P1.panel_buffer = " .. P1.panel_buffer)
-            print("P2.panel_buffer = " .. P2.panel_buffer)
-            print("P1.gpanel_buffer = " .. P1.gpanel_buffer)
-            print("P2.gpanel_buffer = " .. P2.gpanel_buffer)
+            logger.trace("game_start_timeout = " .. game_start_timeout)
+            logger.trace("P1.panel_buffer = " .. P1.panel_buffer)
+            logger.trace("P2.panel_buffer = " .. P2.panel_buffer)
+            logger.trace("P1.gpanel_buffer = " .. P1.gpanel_buffer)
+            logger.trace("P2.gpanel_buffer = " .. P2.gpanel_buffer)
             gprint(to_print, unpack(main_menu_screen_pos))
             if not do_messages() then
               return main_dumb_transition, {main_select_mode, loc("ss_disconnect") .. "\n\n" .. loc("ss_return"), 60, 300}
@@ -1152,7 +1154,7 @@ function select_screen.main()
           state.stage = uniformly(stages[state.stage].sub_stages)
         end
       end
-      print("stage and stage_is_random: " .. state.stage .. " / " .. (state.stage_is_random or "nil"))
+      logger.trace("stage and stage_is_random: " .. state.stage .. " / " .. (state.stage_is_random or "nil"))
     end
 
     -- Function to tell the select screen to exit

--- a/select_screen.lua
+++ b/select_screen.lua
@@ -220,7 +220,7 @@ function select_screen.main()
     elseif GAME.battleRoom.spectating then
       op_player_number = 2
     elseif op_player_number and op_player_number ~= 0 then
-      logger.tracdebuge("We assumed op player number is still " .. op_player_number)
+      logger.debug("We assumed op player number is still " .. op_player_number)
     else
       error("We never heard from the server as to what player number we are")
       logger.error("The server never told us our player number.  Assuming it is 2")

--- a/sound.lua
+++ b/sound.lua
@@ -1,4 +1,5 @@
 require("sound_util")
+local logger = require("logger")
 
 -- Sets the volumes based on the current player configuration settings
 function apply_config_volume()
@@ -46,7 +47,7 @@ end
 
 -- Stop just music files
 function stop_the_music()
-  --print("musics have been stopped")
+  --logger.trace("musics have been stopped")
   for k, v in pairs(currently_playing_tracks) do
     v:stop()
     currently_playing_tracks[k] = nil
@@ -74,7 +75,7 @@ end
 
 -- Finds the given music file with the given type and adds it to the queue
 function find_and_add_music(musics, music_type)
-  print("music " .. music_type .. " is now playing")
+  logger.trace("music " .. music_type .. " is now playing")
   local start_music = musics[music_type .. "_start"] or zero_sound
   local loop_music = musics[music_type]
   if not loop_music or not start_music or loop_music:isPlaying() or start_music:isPlaying() then

--- a/stage.lua
+++ b/stage.lua
@@ -1,4 +1,5 @@
 require("stage_loader")
+local logger = require("logger")
 
 -- Stuff defined in this file:
 --  . the data structure that store a stage's data
@@ -79,27 +80,27 @@ end
 
 -- preemptively loads a stage
 function Stage.preload(self)
-  print("preloading stage " .. self.id)
+  logger.trace("preloading stage " .. self.id)
   self:graphics_init(false, false)
   self:sound_init(false, false)
 end
 
 -- loads a stage
 function Stage.load(self, instant)
-  print("loading stage " .. self.id)
+  logger.trace("loading stage " .. self.id)
   self:graphics_init(true, (not instant))
   self:sound_init(true, (not instant))
   self.fully_loaded = true
-  print("loaded stage " .. self.id)
+  logger.trace("loaded stage " .. self.id)
 end
 
 -- unloads a stage
 function Stage.unload(self)
-  print("unloading stage " .. self.id)
+  logger.trace("unloading stage " .. self.id)
   self:graphics_uninit()
   self:sound_uninit()
   self.fully_loaded = false
-  print("unloaded stage " .. self.id)
+  logger.trace("unloaded stage " .. self.id)
 end
 
 -- adds stages from the path given
@@ -120,7 +121,7 @@ local function add_stages_from_dir_rec(path)
 
         if success then
           if stages[stage.id] ~= nil then
-            print(current_path .. " has been ignored since a stage with this id has already been found")
+            logger.trace(current_path .. " has been ignored since a stage with this id has already been found")
           else
             stages[stage.id] = stage
             stages_ids[#stages_ids + 1] = stage.id
@@ -145,20 +146,20 @@ local function fill_stages_ids()
       for _, sub_stage in ipairs(copy_of_sub_stages) do
         if stages[sub_stage] and #stages[sub_stage].sub_stages == 0 then -- inner bundles are prohibited
           stage.sub_stages[#stage.sub_stages + 1] = sub_stage
-          print(stage.id .. " has " .. sub_stage .. " as part of its substages.")
+          logger.trace(stage.id .. " has " .. sub_stage .. " as part of its substages.")
         end
       end
 
       if #stage.sub_stages < 2 then
         invalid_stages[#invalid_stages + 1] = stage_id -- stage is invalid
-        print(stage.id .. " (bundle) is being ignored since it's invalid!")
+        logger.warn(stage.id .. " (bundle) is being ignored since it's invalid!")
       else
         stages_ids[#stages_ids + 1] = stage_id
-        print(stage.id .. " (bundle) has been added to the stage list!")
+        logger.debug(stage.id .. " (bundle) has been added to the stage list!")
       end
     else -- normal stage
       stages_ids[#stages_ids + 1] = stage_id
-      print(stage.id .. " has been added to the stage list!")
+      logger.debug(stage.id .. " has been added to the stage list!")
     end
   end
 


### PR DESCRIPTION
Introduces a logger with customizable verbosity and timestamps and cleans up several files with noisy logs on the client.

There are still several active print statements in the codebase (my editor shows 175), so more cleanup work can be done, but I addressed the noisiest log statements that showed up in my own casual playing and spectating. The majority of the remaining print statements (120 of them, oof) are in server.lua, so that should be addressed eventually.

Each file is updated in its own commit to make dealing with potential merge conflicts easier, though this probably wasn't necessary...

This partially addresses #341.