### PR TITLE
Bug Fix: defaultname pattern check

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -1202,7 +1202,7 @@ function Connection.J(self, message)
       response = {choose_another_name = {reason = 'Username cannot be "anonymous"'}}
       self:send(response)
       return
-    elseif string.lower(message.name:match("d+e+f+a+u+l+t+n+a+m+e?")) then
+    elseif message.name:lower():match("d+e+f+a+u+l+t+n+a+m+e?") then
       print('connection tried to use name "defaultname", or a variation of it')
       response = {choose_another_name = {reason = 'Username cannot be "defaultname" or a variation of it'}}
       self:send(response)


### PR DESCRIPTION
Current method throws error because the methods were in the wrong order, this patch fixes it.

This hasn't been applied to the actual server yet, so no changes need to be made there.