### PR TITLE
click menu button calc

### DIFF
--- a/click_menu.lua
+++ b/click_menu.lua
@@ -10,8 +10,8 @@ Click_menu =
   function(self, x, y, width, height, active_idx)
     self.x = x or 0
     self.y = y or 0
-    self.width = width or (love.graphics.getWidth() - self.x - 30) --width not used yet for scrolling
-    self.height = height or (love.graphics.getHeight() - self.y - 30) --scrolling does care about height
+    self.width = width or (canvas_width - self.x - 30) --width not used yet for scrolling
+    self.height = height or (canvas_height - self.y - 30) --scrolling does care about height
     self.new_item_y = 0
     self.menu_controls = {
       up = {

--- a/config_inputs.lua
+++ b/config_inputs.lua
@@ -44,7 +44,7 @@ local function main_config_input()
   end
 
   function createInputMenu(player)
-    local clickMenu = Click_menu(menu_x, menu_y, nil, love.graphics.getHeight() - menu_y - 10, 1)
+    local clickMenu = Click_menu(menu_x, menu_y, nil, canvas_height - menu_y - 10, 1)
     clickMenu:add_button(loc("player") .. " ", incrementPlayer, goEscape)
     clickMenu:set_button_setting(#clickMenu.buttons, active_player)
     for i = 1, #key_names do

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -180,7 +180,7 @@ do
       {loc("mm_options"), options.main}
     }
 
-    main_menu = Click_menu(menu_x, menu_y, nil, love.graphics.getHeight() - menu_y - 10, main_menu_last_index)
+    main_menu = Click_menu(menu_x, menu_y, nil, canvas_height - menu_y - 10, main_menu_last_index)
     for i = 1, #items do
       main_menu:add_button(items[i][1], selectFunction(items[i][2], items[i][3]), goEscape)
     end
@@ -298,7 +298,7 @@ function main_select_speed_99(next_func)
 
   local menu_x, menu_y = unpack(main_menu_screen_pos)
   menu_y = menu_y + 70
-  gameSettingsMenu = Click_menu(menu_x, menu_y, nil, love.graphics.getHeight() - menu_y - 10, 1)
+  gameSettingsMenu = Click_menu(menu_x, menu_y, nil, canvas_height - menu_y - 10, 1)
   gameSettingsMenu:add_button(loc("speed"), nextMenu, goEscape, decreaseSpeed, increaseSpeed)
   gameSettingsMenu:add_button(loc("difficulty"), nextMenu, goEscape, decreaseDifficulty, increaseDifficulty)
   gameSettingsMenu:add_button(loc("go_"), startGame, goEscape)
@@ -714,7 +714,7 @@ function main_net_vs_lobby()
         return rating
       end
 
-      lobby_menu = Click_menu(lobby_menu_x[showing_leaderboard], lobby_menu_y, nil, love.graphics.getHeight() - lobby_menu_y - 10, 1)
+      lobby_menu = Click_menu(lobby_menu_x[showing_leaderboard], lobby_menu_y, nil, canvas_height - lobby_menu_y - 10, 1)
       for _, v in ipairs(unpaired_players) do
         if v ~= config.name then
           local unmatchedPlayer = v .. playerRatingString(v) .. (sent_requests[v] and " " .. loc("lb_request") or "") .. (willing_players[v] and " " .. loc("lb_received") or "")


### PR DESCRIPTION
Changed all click menus to initialize, and thus calculate available space based on canvas, not the client resolution. This affected how button_limit was calculated, reducing the number of buttons visible on the screen despite there still being available screenspace.

For Issue #345