### PR TITLE
Use the correct character for dynamic music to fix stutter

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -1541,7 +1541,7 @@ function Stack.PdP(self)
             end
             musics_to_use = stages[current_stage].musics
           elseif characterHasMusic then
-            if characters[self.character].music_style == "dynamic" then
+            if characters[winningPlayer.character].music_style == "dynamic" then  
               dynamicMusic = true
             end
             musics_to_use = characters[winningPlayer.character].musics


### PR DESCRIPTION
because we weren't using the winning character P1 and P2 would fight back and forth about if we wanted dynamic music or not, causing the stutter