### PR TITLE
Record when default panels have been copied and do it first time even…

### DIFF
--- a/panels.lua
+++ b/panels.lua
@@ -65,7 +65,8 @@ function panels_init()
 
   add_panels_from_dir_rec("panels")
   
-  if #panels_ids == 0 then
+  if #panels_ids == 0 or (config and not config.defaultPanelsCopied) then
+    config.defaultPanelsCopied = true
     recursive_copy("default_data/panels", "panels")
     add_panels_from_dir_rec("panels")
   end

--- a/save.lua
+++ b/save.lua
@@ -184,6 +184,9 @@ function read_conf_file()
       if type(read_data.fullscreen) == "boolean" then
         config.fullscreen = read_data.fullscreen
       end
+      if type(read_data.defaultPanelsCopied) == "boolean" then
+        config.defaultPanelsCopied = read_data.defaultPanelsCopied
+      end
 
       file:close()
     end


### PR DESCRIPTION
… if custom panels exist

This gives users that have already got mods the chance to still get the default panels and customize / remove them.