### PR TITLE
Ensure APM/GPM value updates when replays are using fastforward

### DIFF
--- a/graphics.lua
+++ b/graphics.lua
@@ -813,7 +813,7 @@ function Stack.drawAnalyticData(self, analytic, x, y)
   y = y + nextIconIncrement
 
   -- GPM
-  if math.fmod(self.CLOCK, 60) < math.fmod(self.CLOCK - (self.max_runs_per_frame), 60) then
+  if math.fmod(self.CLOCK, 60) < self.max_runs_per_frame then
     if self.CLOCK > 0 and (analytic.data.sent_garbage_lines > 0) then
       local garbagePerMinute = analytic.data.sent_garbage_lines / (self.CLOCK / 60 / 60)
       analytic.lastGPM = string.format("%0.1f", round(garbagePerMinute, 1))
@@ -842,7 +842,7 @@ function Stack.drawAnalyticData(self, analytic, x, y)
   y = y + nextIconIncrement
 
   -- APM
-  if math.fmod(self.CLOCK, 60) < math.fmod(self.CLOCK - (self.max_runs_per_frame), 60) then
+  if math.fmod(self.CLOCK, 60) < self.max_runs_per_frame then
     if self.CLOCK > 0 and (analytic.data.swap_count + analytic.data.move_count > 0) then
       local actionsPerMinute = (analytic.data.swap_count + analytic.data.move_count) / (self.CLOCK / 60 / 60)
       analytic.lastAPM = string.format("%0.0f", round(actionsPerMinute, 0))

--- a/graphics.lua
+++ b/graphics.lua
@@ -813,7 +813,7 @@ function Stack.drawAnalyticData(self, analytic, x, y)
   y = y + nextIconIncrement
 
   -- GPM
-  if math.fmod(self.CLOCK, 60) == 0 then
+  if math.fmod(self.CLOCK, 60) < math.fmod(self.CLOCK - (self.max_runs_per_frame), 60) then
     if self.CLOCK > 0 and (analytic.data.sent_garbage_lines > 0) then
       local garbagePerMinute = analytic.data.sent_garbage_lines / (self.CLOCK / 60 / 60)
       analytic.lastGPM = string.format("%0.1f", round(garbagePerMinute, 1))

--- a/graphics.lua
+++ b/graphics.lua
@@ -842,7 +842,7 @@ function Stack.drawAnalyticData(self, analytic, x, y)
   y = y + nextIconIncrement
 
   -- APM
-  if math.fmod(self.CLOCK, 60) == 0 then
+  if math.fmod(self.CLOCK, 60) < math.fmod(self.CLOCK - (self.max_runs_per_frame), 60) then
     if self.CLOCK > 0 and (analytic.data.swap_count + analytic.data.move_count > 0) then
       local actionsPerMinute = (analytic.data.swap_count + analytic.data.move_count) / (self.CLOCK / 60 / 60)
       analytic.lastAPM = string.format("%0.0f", round(actionsPerMinute, 0))


### PR DESCRIPTION
Prior to this fix, if a replay file was sped up, the APM counter would cease updating the value.