### PR TITLE
Send player ratings and seed from the server

### DIFF
--- a/mainloop.lua
+++ b/mainloop.lua
@@ -765,7 +765,6 @@ function main_net_vs_lobby()
   local requestedSpectateRoom = nil
 
   local playerData = nil
-  json_send({leaderboard_request = true}) -- Request the leaderboard so we can show ratings
 
   while true do
     if connection_up_time <= login_status_message_duration then

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -829,6 +829,9 @@ function main_net_vs_lobby()
         lobby_menu:remove_self()
         return select_screen.main
       end
+      if msg.ratings then
+        playerRatingMap = msg.ratings
+      end
       if msg.unpaired then
         unpaired_players = msg.unpaired
         -- players who leave the unpaired list no longer have standing invitations to us.\
@@ -851,14 +854,12 @@ function main_net_vs_lobby()
         play_optional_sfx(themes[config.theme].sounds.notification)
       end
       if msg.leaderboard_report then
-        playerRatingMap = {}
         if lobby_menu then
           lobby_menu:show_controls(true)
         end
         leaderboard_report = msg.leaderboard_report
         for i = #leaderboard_report, 1, -1 do
           local v = leaderboard_report[i]
-          playerRatingMap[v.user_name] = v.rating
           if v.is_you then
             my_rank = k
           end

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -764,7 +764,7 @@ function main_net_vs_lobby()
   local ret = nil
   local requestedSpectateRoom = nil
 
-  local playerRatingMap = nil
+  local playerData = nil
   json_send({leaderboard_request = true}) -- Request the leaderboard so we can show ratings
 
   while true do
@@ -829,8 +829,8 @@ function main_net_vs_lobby()
         lobby_menu:remove_self()
         return select_screen.main
       end
-      if msg.ratings then
-        playerRatingMap = msg.ratings
+      if msg.players then
+        playerData = msg.players
       end
       if msg.unpaired then
         unpaired_players = msg.unpaired
@@ -930,8 +930,8 @@ function main_net_vs_lobby()
 
       local function playerRatingString(playerName)
         local rating = ""
-        if playerRatingMap and playerRatingMap[playerName] then
-          rating = " (" .. playerRatingMap[playerName] .. ")"
+        if playerData and playerData[playerName] and playerData[playerName].rating then
+          rating = " (" .. playerData[playerName].rating .. ")"
         end
         return rating
       end

--- a/server.lua
+++ b/server.lua
@@ -43,7 +43,7 @@ function addPublicPlayerData(players, playerName, player)
     return
   end
 
-  if not players[player.name] then
+  if not players[playerName] then
     players[playerName] = {}
   end
 

--- a/server.lua
+++ b/server.lua
@@ -38,28 +38,40 @@ local loaded_placement_matches = {
   complete = {}
 }
 
+function addPublicPlayerData(players, playerName, player) 
+  if not players or not player then
+    return
+  end
+
+  if not players[player.name] then
+    players[playerName] = {}
+  end
+
+  if player.rating then
+    players[playerName].rating = round(player.rating)
+  end
+
+  if player.ranked_games_played then
+    players[playerName].ranked_games_played = player.ranked_games_played
+  end
+end
+
 function lobby_state()
   local names = {}
-  local ratings = {}
+  local players = {}
   for _, v in pairs(connections) do
     if v.state == "lobby" then
       names[#names + 1] = v.name
-      if leaderboard.players[v.user_id] and leaderboard.players[v.user_id].rating then
-        ratings[v.name] = round(leaderboard.players[v.user_id].rating)
-      end
+      addPublicPlayerData(players, v.name, leaderboard.players[v.user_id])
     end
   end
   local spectatableRooms = {}
   for _, v in pairs(rooms) do
     spectatableRooms[#spectatableRooms + 1] = {roomNumber = v.roomNumber, name = v.name, a = v.a.name, b = v.b.name, state = v:state()}
-    if leaderboard.players[v.a.user_id] and leaderboard.players[v.a.user_id].rating then
-      ratings[v.a.name] = round(leaderboard.players[v.a.user_id].rating)
-    end
-    if leaderboard.players[v.b.user_id] and leaderboard.players[v.b.user_id].rating then
-      ratings[v.b.name] = round(leaderboard.players[v.b.user_id].rating)
-    end
+    addPublicPlayerData(players, v.a.name, leaderboard.players[v.a.user_id])
+    addPublicPlayerData(players, v.b.name, leaderboard.players[v.b.user_id])
   end
-  return {unpaired = names, spectatable = spectatableRooms, ratings = ratings}
+  return {unpaired = names, spectatable = spectatableRooms, players = players}
 end
 
 function propose_game(sender, receiver, message)

--- a/server.lua
+++ b/server.lua
@@ -40,16 +40,26 @@ local loaded_placement_matches = {
 
 function lobby_state()
   local names = {}
+  local ratings = {}
   for _, v in pairs(connections) do
     if v.state == "lobby" then
       names[#names + 1] = v.name
+      if leaderboard.players[v.user_id] and leaderboard.players[v.user_id].rating then
+        ratings[v.name] = round(leaderboard.players[v.user_id].rating)
+      end
     end
   end
   local spectatableRooms = {}
   for _, v in pairs(rooms) do
     spectatableRooms[#spectatableRooms + 1] = {roomNumber = v.roomNumber, name = v.name, a = v.a.name, b = v.b.name, state = v:state()}
+    if leaderboard.players[v.a.user_id] and leaderboard.players[v.a.user_id].rating then
+      ratings[v.a.name] = round(leaderboard.players[v.a.user_id].rating)
+    end
+    if leaderboard.players[v.b.user_id] and leaderboard.players[v.b.user_id].rating then
+      ratings[v.b.name] = round(leaderboard.players[v.b.user_id].rating)
+    end
   end
-  return {unpaired = names, spectatable = spectatableRooms}
+  return {unpaired = names, spectatable = spectatableRooms, ratings = ratings}
 end
 
 function propose_game(sender, receiver, message)
@@ -153,6 +163,8 @@ function start_match(a, b)
       msg.opponent_settings.rating = DEFAULT_RATING
     end
   end
+  a.room.replay.vs.seed = math.random(1,9999999)
+  msg.seed = a.room.replay.vs.seed
   a.room.replay.vs.P1_name = a.name
   a.room.replay.vs.P2_name = b.name
   a.room.replay.vs.P1_char = a.character


### PR DESCRIPTION
Building on Shosoul's work this does two things
1. Move the ratings to be mapped by player name so its easier to use and matches what the client used before
2. Include the number of ranked matches so we can maybe show it some day.
3. Send a seed from the server. This will be ignored for now in normal games, but used in telegraph and beyond.