### PR TITLE
Gracefully log out of server from game close

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -156,7 +156,9 @@ function love.mousepressed(x, y)
 end
 
 function love.quit()
-  json_send({logout = true})
+  if network_connected() then
+    json_send({logout = true})
+  end
 end
 
 -- Handle a touch press

--- a/main.lua
+++ b/main.lua
@@ -155,6 +155,10 @@ function love.mousepressed(x, y)
   end
 end
 
+function love.quit()
+  json_send({logout = true})
+end
+
 -- Handle a touch press
 -- Note we are specifically not implementing this because mousepressed above handles mouse and touch
 -- function love.touchpressed(id, x, y, dx, dy, pressure)


### PR DESCRIPTION
This allows the server to properly log out the user should they simply close the game instead of using the exit function to go back to the main menu. This prevents massive CPU spikes from the server (shown below) from trying to locate a client that has ceased communicating.

This is an image of the actual server CPU usage after a user closes their client without sending the `logout` message.
![image](https://user-images.githubusercontent.com/18148657/154548636-13d04a0d-07a5-4ab4-931d-ab2314225b97.png)
