### PR TITLE
Telegraph rollback fixes

### DIFF
--- a/AttackEngine.lua
+++ b/AttackEngine.lua
@@ -55,7 +55,7 @@ function AttackEngine.run(self)
           for i = 1,  attackPattern.garbage[2], 1 do
             self.target.telegraph:push("chain", attackPattern.garbage[2], 0, origin_column, origin_row, self.clock)
           end
-          self.target.telegraph:chainingEnded(self.clock)
+          self.target.telegraph:chainingEnded(self.clock+1)
         else
           self.target.telegraph:push("combo", attackPattern.garbage[1]+1, 0, origin_column, origin_row, self.clock)
         end

--- a/developer.lua
+++ b/developer.lua
@@ -1,0 +1,1 @@
+-- Put any local development changes you need in here that you don't want commited. This file is git ignored by default.

--- a/developer.lua
+++ b/developer.lua
@@ -1,1 +1,1 @@
--- Put any local development changes you need in here that you don't want commited. This file is git ignored by default.
+-- Put any local development changes you need in here that you don't want commited.

--- a/engine.lua
+++ b/engine.lua
@@ -1522,7 +1522,7 @@ function Stack.simulate(self)
       self.chain_counter = 0
 
       if self.garbage_target and self.garbage_target.telegraph then
-        self.garbage_target.telegraph:chainingEnded(self.CLOCK)
+        self.garbage_target.telegraph:chainingEnded(self.CLOCK+1)
       end
     end
 

--- a/main.lua
+++ b/main.lua
@@ -1,3 +1,4 @@
+require("developer")
 require("class")
 socket = require("socket")
 json = require("dkjson")

--- a/match.lua
+++ b/match.lua
@@ -304,8 +304,8 @@ function Match.render(self)
       gprintf("Clock " .. P2.CLOCK, drawX, drawY)
 
       drawY = drawY + padding
-      local framesAhead = string.len(P1.confirmedInput) - string.len(P2.confirmedInput)
-      gprintf("Ahead: " .. framesAhead, drawX, drawY)
+      local framesAhead = P1.CLOCK - P2.CLOCK
+      gprintf("P1 Ahead: " .. framesAhead, drawX, drawY)
 
       drawY = drawY + padding
       gprintf("Confirmed " .. string.len(P2.confirmedInput) , drawX, drawY)


### PR DESCRIPTION
Each interaction of the stack with it's opponent needs to happen on the frame after or later so the order they run doesn't matter.
Thus chain ending and attacks should happen on the frame after they happened.
We also only need to rollback to the frame AFTER what happened, because thats the first frame things can be affected.
Also did some other cleanups to make debugging easier.