### PR TITLE
Fix telegraph chaining off by 1 error

### DIFF
--- a/AttackEngine.lua
+++ b/AttackEngine.lua
@@ -55,7 +55,7 @@ function AttackEngine.run(self)
           for i = 1,  attackPattern.garbage[2], 1 do
             self.target.telegraph:push("chain", attackPattern.garbage[2], 0, origin_column, origin_row, self.clock)
           end
-          self.target.telegraph:chainingEnded(self.clock+1)
+          self.target.telegraph:chainingEnded(self.clock)
         else
           self.target.telegraph:push("combo", attackPattern.garbage[1]+1, 0, origin_column, origin_row, self.clock)
         end

--- a/engine.lua
+++ b/engine.lua
@@ -807,11 +807,6 @@ function Stack.shouldRun(self, runsSoFar)
     return true
   end
 
-  if config.debug_mode and self.which == 2 then
-    local framesBehind = 50
-    return self.CLOCK < self.garbage_target.CLOCK - framesBehind
-  end
-
   -- If we are not local, we want to run faster to catch up.
   if buffer_len >= 15 - runsSoFar then
     -- way behind, run at max speed.

--- a/engine.lua
+++ b/engine.lua
@@ -807,6 +807,11 @@ function Stack.shouldRun(self, runsSoFar)
     return true
   end
 
+  if config.debug_mode and self.which == 2 then
+    local framesBehind = 50
+    return self.CLOCK < self.garbage_target.CLOCK - framesBehind
+  end
+
   -- If we are not local, we want to run faster to catch up.
   if buffer_len >= 15 - runsSoFar then
     -- way behind, run at max speed.
@@ -1522,7 +1527,7 @@ function Stack.simulate(self)
       self.chain_counter = 0
 
       if self.garbage_target and self.garbage_target.telegraph then
-        self.garbage_target.telegraph:chainingEnded(self.CLOCK+1)
+        self.garbage_target.telegraph:chainingEnded(self.CLOCK)
       end
     end
 

--- a/engine/telegraph.lua
+++ b/engine/telegraph.lua
@@ -108,15 +108,17 @@ function Telegraph:update()
 end
 
 -- Adds a piece of garbage to the queue
-function Telegraph.push(self, attack_type, attack_size, metal_count, attack_origin_col, attack_origin_row, frame_earned)
+function Telegraph:push(attack_type, attack_size, metal_count, attack_origin_col, attack_origin_row, frame_earned)
 
-  -- If we got an attack earlier then last frame, (they attacked in the past and we missed it) we need to rollback
-  if frame_earned < self.owner.CLOCK - 1 then
-    self.owner:rollbackToFrame(frame_earned+1)
+  logger.debug("Player " .. self.sender.which .. " attacked with " .. attack_type .. " at " .. frame_earned)
+
+  -- If we are past the frame the attack would be processed we need to rollback
+  if self.owner.CLOCK > frame_earned + 1 then
+    self.owner:rollbackToFrame(frame_earned + 1)
   end
 
   -- If we got the attack in the future, wait to queue it
-  if frame_earned > self.owner.CLOCK then
+  if self.owner.CLOCK < frame_earned then
     if not self.pendingGarbage[frame_earned] then
       self.pendingGarbage[frame_earned] = {}
     end
@@ -175,13 +177,15 @@ end
 
 function Telegraph:chainingEnded(frameEnded)
 
-  -- If they ended chaining earlier then last frame, (they finished the chain in the past and we missed it) we need to rollback
-  if frameEnded < self.owner.CLOCK - 1 then
-    self.owner:rollbackToFrame(frameEnded+1)
+  logger.debug("Player " .. self.sender.which .. " chain ended at " .. frameEnded)
+
+  -- If we are past the frame the chain end would process we need to rollback
+  if self.owner.CLOCK > frameEnded + 1 then
+    self.owner:rollbackToFrame(frameEnded + 1)
   end
   
   -- If we got the attack in the future wait to queue it
-  if frameEnded > self.owner.CLOCK then
+  if self.owner.CLOCK < frameEnded then
     self.pendingChainingEnded[frameEnded] = true
     return
   end


### PR DESCRIPTION
It's okay for chaining to be sent to the opponent on the frame it happened just like attacks, because it doesn't interact with the opponents stack on that frame.

However we still want to rollback to the frame "after" the attack or chain end because:
A) We don't need to rollback any earlier
B) We don't want to rollback to the same frame as the player thats "behind" because we may have already sent an attack that frame that the behind player processed. We only clear attacks in the "future" so we need to make sure we don't rollback to a frame thats already processed attacks. Luckily we don't need to rollback that far since the attack only interacts with the next frame at a minimum.

Also added some debugging and reordered the ifs to make more sense