### PR TITLE
Add a delay after chaining ends to avoid rollback teleporting

### DIFF
--- a/engine/GarbageQueue.lua
+++ b/engine/GarbageQueue.lua
@@ -120,7 +120,7 @@ GarbageQueue = class(function(s, sender)
     local result = nil
   
     if newChain then
-      result = {{6,1,false,true, frame_earned=frame_earned, finalized=false}}
+      result = {{6,1,false,true, frame_earned=frame_earned, finalized=nil}}
       self:push(result) --a garbage block 6-wide, 1-tall, not metal, from_chain
     else 
       result = self.chain_garbage[self.chain_garbage.first]

--- a/globals.lua
+++ b/globals.lua
@@ -15,6 +15,10 @@ server_queue = ServerQueue()
 score_mode = SCOREMODE_TA
  
 GARBAGE_DELAY = 60
+CHAIN_ENDED_DELAY = 30 -- this is the amount of time to delay committing a chain after the chain ends
+											 -- Technically this was 0 in classic games, but we are using 60 to make rollback less noticable and match PA history.
+											 -- In a standard chain this doesn't introduce much delay, but when garbage chaining it typically introduces the full 
+											 -- delay which is only noticable if the opponent is able to recieve a chain in that moment.
 GARBAGE_TRANSIT_TIME = 90
 MAX_LAG = 200 -- maximum amount of lag before net games abort
 


### PR DESCRIPTION
If chains immediately fall after you stop chaining, they can "teleport" onto the other players side. Before telegraph, we had a delay of 60 frames to avoid this for all garbage.

For now lets try 30 for chains.