### PR TITLE
Fix Desyncs when stoppers are popped and extended on the same frame

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -1542,17 +1542,6 @@ function Stack.simulate(self)
       end
     end
 
-    if self.telegraph then
-      local to_send = self.telegraph:pop_all_ready_garbage(self.CLOCK)
-      if to_send and to_send[1] then
-        local garbage = self.later_garbage[self.CLOCK+1] or {}
-        for i = 1, #to_send do
-          garbage[#garbage + 1] = to_send[i]
-        end
-        self.later_garbage[self.CLOCK+1] = garbage
-      end
-    end
-
     if self.later_garbage[self.CLOCK] then
       self.garbage_q:push(self.later_garbage[self.CLOCK])
       self.later_garbage[self.CLOCK] = nil
@@ -1823,6 +1812,19 @@ function Stack.simulate(self)
 
   self:update_popfxs()
   self:update_cards()
+end
+
+function Stack:processIncomingTelegraph()
+  if self.telegraph then
+    local to_send = self.telegraph:pop_all_ready_garbage(self.CLOCK)
+    if to_send and to_send[1] then
+      local garbage = self.later_garbage[self.CLOCK+1] or {}
+      for i = 1, #to_send do
+        garbage[#garbage + 1] = to_send[i]
+      end
+      self.later_garbage[self.CLOCK+1] = garbage
+    end
+  end
 end
 
 function Stack.behindRollback(self)

--- a/match.lua
+++ b/match.lua
@@ -132,6 +132,14 @@ function Match.run(self)
       self.attackEngine:run()
     end
 
+    if ranP1 then
+      P1:processIncomingTelegraph()
+    end
+
+    if ranP2 then
+      P2:processIncomingTelegraph()
+    end
+
     -- Since the stacks can affect each other, don't save rollback until after both have run
     if ranP1 then
       P1:saveForRollback()


### PR DESCRIPTION
If a stopper is extended by one player and popped by the other player on the same frame, the order of which stack runs first matters.
To avoid this, don't pop garbage off the telegraph until both players have extended stoppers.
That data isn't processed till next frame anyways, so its pretty convenient to move this.