### PR TITLE
Fix end phase desync

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -1801,6 +1801,23 @@ function Stack.simulate(self)
       end
     end
 
+  end
+end
+
+function Stack:runEndPhase()
+  if self:game_ended() == false then
+
+    if self.telegraph then
+      local to_send = self.telegraph:pop_all_ready_garbage(self.CLOCK)
+      if to_send and to_send[1] then
+        local garbage = self.later_garbage[self.CLOCK+1] or {}
+        for i = 1, #to_send do
+          garbage[#garbage + 1] = to_send[i]
+        end
+        self.later_garbage[self.CLOCK+1] = garbage
+      end
+    end
+
     self.CLOCK = self.CLOCK + 1
     local gameEndedClockTime = self.match:gameEndedClockTime()
     if self.game_stopwatch_running and (gameEndedClockTime == 0 or self.CLOCK <= gameEndedClockTime) then
@@ -1810,19 +1827,6 @@ function Stack.simulate(self)
 
   self:update_popfxs()
   self:update_cards()
-end
-
-function Stack:processIncomingTelegraph()
-  if self.telegraph then
-    local to_send = self.telegraph:pop_all_ready_garbage(self.CLOCK)
-    if to_send and to_send[1] then
-      local garbage = self.later_garbage[self.CLOCK+1] or {}
-      for i = 1, #to_send do
-        garbage[#garbage + 1] = to_send[i]
-      end
-      self.later_garbage[self.CLOCK+1] = garbage
-    end
-  end
 end
 
 function Stack.behindRollback(self)

--- a/match.lua
+++ b/match.lua
@@ -126,11 +126,11 @@ function Match.run(self)
     end
 
     if ranP1 then
-      P1:processIncomingTelegraph()
+      P1:runEndPhase()
     end
 
     if ranP2 then
-      P2:processIncomingTelegraph()
+      P2:runEndPhase()
     end
 
     -- Since the stacks can affect each other, don't save rollback until after both have run


### PR DESCRIPTION
We were incrementing the CLOCK before processing telegraph, causing it to be one frame off.
Instead move all the end phase processing into a separate method that happens after both players stacks have run