### PR TITLE
Fix rollback breaks

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -417,13 +417,13 @@ function Stack.rollbackToFrame(self, frame)
       -- The garbage that we send this time might (rarely) not be the same
       -- as the garbage we sent before.  Wipe out the garbage we sent before...
       for k, v in pairs(self.garbage_target.telegraph.pendingGarbage) do
-        if k >= frame then
+        if k > frame then
           self.garbage_target.telegraph.pendingGarbage[k] = nil
         end
       end
 
       for k, v in pairs(self.garbage_target.telegraph.pendingChainingEnded) do
-        if k >= frame then
+        if k > frame then
           self.garbage_target.telegraph.pendingChainingEnded[k] = nil
         end
       end

--- a/engine.lua
+++ b/engine.lua
@@ -1488,6 +1488,17 @@ function Stack.simulate(self)
       end
     end
 
+    if self.telegraph then
+      local to_send = self.telegraph:pop_all_ready_garbage(self.CLOCK)
+      if to_send and to_send[1] then
+        local garbage = self.later_garbage[self.CLOCK+1] or {}
+        for i = 1, #to_send do
+          garbage[#garbage + 1] = to_send[i]
+        end
+        self.later_garbage[self.CLOCK+1] = garbage
+      end
+    end
+    
     if self.later_garbage[self.CLOCK] then
       self.garbage_q:push(self.later_garbage[self.CLOCK])
       self.later_garbage[self.CLOCK] = nil
@@ -1746,23 +1757,6 @@ function Stack.simulate(self)
         if self:shouldChangeSoundEffects() then
           SFX_GameOver_Play = 1
         end
-      end
-    end
-
-  end
-end
-
-function Stack:runEndPhase()
-  if self:game_ended() == false then
-
-    if self.telegraph then
-      local to_send = self.telegraph:pop_all_ready_garbage(self.CLOCK)
-      if to_send and to_send[1] then
-        local garbage = self.later_garbage[self.CLOCK+1] or {}
-        for i = 1, #to_send do
-          garbage[#garbage + 1] = to_send[i]
-        end
-        self.later_garbage[self.CLOCK+1] = garbage
       end
     end
 

--- a/engine/GarbageQueue.lua
+++ b/engine/GarbageQueue.lua
@@ -116,16 +116,16 @@ GarbageQueue = class(function(s, sender)
   
   -- This is used by the telegraph to increase the size of the chain garbage being built
   -- or add a 6-wide if there is not chain garbage yet in the queue
-  function GarbageQueue.grow_chain(self,frame_earned, newChain)
+  function GarbageQueue:grow_chain(timeAttackInteracts, newChain)
     local result = nil
   
     if newChain then
-      result = {{6,1,false,true, frame_earned=frame_earned, finalized=nil}}
+      result = {{6,1,false,true, timeAttackInteracts=timeAttackInteracts, finalized=nil}}
       self:push(result) --a garbage block 6-wide, 1-tall, not metal, from_chain
     else 
       result = self.chain_garbage[self.chain_garbage.first]
       result[2]--[[height]] = result[2]--[[height]] + 1
-      result.frame_earned = frame_earned
+      result.timeAttackInteracts = timeAttackInteracts
       -- Note we are changing the value inside the queue so no need to pop and insert it.
       self.ghost_chain = result[2] - 1
       result = {result}

--- a/match.lua
+++ b/match.lua
@@ -204,14 +204,6 @@ function Match:run()
       self.attackEngine:run()
     end
 
-    if ranP1 then
-      P1:runEndPhase()
-    end
-
-    if ranP2 then
-      P2:runEndPhase()
-    end
-
     -- Since the stacks can affect each other, don't save rollback until after both have run
     if ranP1 then
       P1:saveForRollback()


### PR DESCRIPTION
I lost my way and forgot the golden rule:
Interactions with the other player need to always happen on future frames, never the current frame.

Thus I tried to have multiple phases of running and confuse things. One player might cause the other player to rollback in the midst of the phases, thus causing the CLOCK to increment at the wrong time.

Reverted the multiple phase stuff.

Instead just make sure attacks, extending attacks, and ending chains all happen on the frame after they happen. Then when we rollback to the frame after they happen, we are guaranteed they happened regardless of which side ran first.

Most of these changes are just the rename from frame_earned to timeAttackInteracts to clarify the +1.
The important changes are in telegraph:push and telegraph:chainEnded as well as the revert of the engine changes.