### PR TITLE
Cleanup rollback memory

### DIFF
--- a/developer.lua
+++ b/developer.lua
@@ -1,1 +1,10 @@
 -- Put any local development changes you need in here that you don't want commited.
+
+local launch_type = arg[2]
+if launch_type == "test" or launch_type == "debug" then
+    require "lldebugger"
+    TESTS_ENABLED = 1
+    if launch_type == "debug" then
+        lldebugger.start()
+    end
+end

--- a/engine.lua
+++ b/engine.lua
@@ -763,6 +763,22 @@ function Stack.shouldRun(self, runsSoFar)
     return true
   end
 
+  -- In debug mode allow forcing a certain number of frames behind
+  if config.debug_mode and config.debug_vsFramesBehind and config.debug_vsFramesBehind ~= 0 then
+    if (config.debug_vsFramesBehind > 0) == (self.which == 2) then
+      -- Don't fall behind if the game is over for the other player
+      if self.garbage_target and self.garbage_target:game_ended() == false then
+        -- If we are at the end of the replay we want to catch up
+        if network_connected() or string.len(self.garbage_target.input_buffer) > 0 then
+          local framesBehind = math.abs(config.debug_vsFramesBehind)
+          if self.CLOCK >= self.garbage_target.CLOCK - framesBehind then
+            return false
+          end
+        end
+      end
+    end
+  end
+    
   -- If we are not local, we want to run faster to catch up.
   if buffer_len >= 15 - runsSoFar then
     -- way behind, run at max speed.

--- a/engine.lua
+++ b/engine.lua
@@ -401,6 +401,10 @@ end
 
 function Stack.restoreFromRollbackCopy(self, other)
   self:rollbackCopy(other, self)
+  if self.telegraph then
+    self.telegraph.owner = self
+    self.telegraph.sender = self.garbage_target
+  end
   -- The remaining inputs is the confirmed inputs not processed yet for this clock time
   -- We have processed CLOCK time number of inputs when we are at CLOCK, so we only want to process the CLOCK+1 input on
   self.input_buffer = string.sub(self.confirmedInput, self.CLOCK+1)
@@ -455,9 +459,13 @@ function Stack.saveForRollback(self)
   prev_states[self.CLOCK] = self:rollbackCopy(self)
   self.prev_states = prev_states
   self.garbage_target = garbage_target
-
   local deleteFrame = self.CLOCK - MAX_LAG - 1
   if prev_states[deleteFrame] then
+    Telegraph.saveClone(prev_states[deleteFrame].telegraph)
+
+     -- Has a reference to stacks we don't want kept around
+    prev_states[deleteFrame].telegraph = nil
+
     clone_pool[#clone_pool + 1] = prev_states[deleteFrame]
     prev_states[deleteFrame] = nil
   end

--- a/engine/GarbageQueue.lua
+++ b/engine/GarbageQueue.lua
@@ -1,7 +1,6 @@
 local logger = require("logger")
 
-GarbageQueue = class(function(s, sender)
-    s.sender = sender
+GarbageQueue = class(function(s)
     s.chain_garbage = Queue()
     s.combo_garbage = {Queue(),Queue(),Queue(),Queue(),Queue(),Queue()} --index here represents width, and length represents how many of that width queued
     s.metal = Queue()
@@ -9,7 +8,6 @@ GarbageQueue = class(function(s, sender)
   
   function GarbageQueue.makeCopy(self)
     local other = GarbageQueue()
-    other.sender = self.sender
     other.chain_garbage = deepcpy(self.chain_garbage)
     for i=1, 6 do
       other.combo_garbage[i] = deepcpy(self.combo_garbage[i])

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -107,9 +107,6 @@ function variable_step(f)
       leftover_time = leftover_time - 1 / 60
       if leftover_time >= 1 / 60 then
         GAME.droppedFrames = GAME.droppedFrames + 1
-      --if GAME.match then
-      --print("Dropped Frame, total is: " .. GAME.droppedFrames)
-      --end
       end
     end
   end

--- a/match.lua
+++ b/match.lua
@@ -12,6 +12,7 @@ Match =
     self.battleRoom = battleRoom
     GAME.droppedFrames = 0
     self.timeSpentRunning = 0
+    self.maxTimeSpentRunning = 0
     self.createTime = love.timer.getTime()
     self.supportsPause = true
     self.attackEngine = nil
@@ -91,10 +92,12 @@ function Match:debugRollbackAndCaptureState()
     return
   end
 
+  local rollbackAmount = 50
+
   local P1 = self.P1
   local P2 = self.P2
 
-  if P1.CLOCK == 0 then
+  if P1.CLOCK <= rollbackAmount then
     return
   end
 
@@ -107,9 +110,9 @@ function Match:debugRollbackAndCaptureState()
     self.savedStackP2 = P2.prev_states[P2.CLOCK]
   end
   
-  P1:rollbackToFrame(P1.CLOCK - 1)
+  P1:rollbackToFrame(P1.CLOCK - rollbackAmount)
   if P2 then
-    P2:rollbackToFrame(P2.CLOCK - 1)
+    P2:rollbackToFrame(P2.CLOCK - rollbackAmount)
   end
 end
 
@@ -234,6 +237,7 @@ function Match:run()
   local endTime = love.timer.getTime()
   local timeDifference = endTime - startTime
   self.timeSpentRunning = self.timeSpentRunning + timeDifference
+  self.maxTimeSpentRunning = math.max(self.maxTimeSpentRunning, timeDifference)
 end
 
 local P1_win_quads = {}
@@ -386,8 +390,12 @@ function Match.render(self)
 
     drawY = drawY + padding
     local totalTime = love.timer.getTime() - self.createTime
-    local timePercent = round(self.timeSpentRunning / totalTime, 4)
+    local timePercent = round(self.timeSpentRunning / totalTime, 5)
     gprintf("Time Percent Running Match: " .. timePercent, drawX, drawY)
+
+    drawY = drawY + padding
+    local maxTime = round(self.maxTimeSpentRunning, 5)
+    gprintf("Max Stack Update: " .. maxTime, drawX, drawY)
 
     drawY = drawY + padding
     gprintf("Seed " .. GAME.match.seed, drawX, drawY)

--- a/options.lua
+++ b/options.lua
@@ -18,50 +18,36 @@ local function general_menu()
   end
   local generalMenu
 
-  local function update_vsync(noToggle)
-    if not noToggle then
-      config.vsync = not config.vsync
-    end
-    generalMenu:set_button_setting(1, config.vsync and loc("op_on") or loc("op_off"))
-  end
-
-  local function update_debug(noToggle)
-    if not noToggle then
-      config.debug_mode = not config.debug_mode
-    end
-    generalMenu:set_button_setting(2, config.debug_mode and loc("op_on") or loc("op_off"))
-  end
-
   local function update_countdown(noToggle)
     if not noToggle then
       config.ready_countdown_1P = not config.ready_countdown_1P
     end
-    generalMenu:set_button_setting(3, config.ready_countdown_1P and loc("op_on") or loc("op_off"))
+    generalMenu:set_button_setting(1, config.ready_countdown_1P and loc("op_on") or loc("op_off"))
   end
 
   local function update_fps(noToggle)
     if not noToggle then
       config.show_fps = not config.show_fps
     end
-    generalMenu:set_button_setting(4, config.show_fps and loc("op_on") or loc("op_off"))
+    generalMenu:set_button_setting(2, config.show_fps and loc("op_on") or loc("op_off"))
   end
 
   local function update_infos(noToggle)
     if not noToggle then
       config.show_ingame_infos = not config.show_ingame_infos
     end
-    generalMenu:set_button_setting(5, config.show_ingame_infos and loc("op_on") or loc("op_off"))
+    generalMenu:set_button_setting(3, config.show_ingame_infos and loc("op_on") or loc("op_off"))
   end
 
   local function update_analytics(noToggle)
     if not noToggle then
       config.enable_analytics = not config.enable_analytics
     end
-    generalMenu:set_button_setting(6, config.enable_analytics and loc("op_on") or loc("op_off"))
+    generalMenu:set_button_setting(4, config.enable_analytics and loc("op_on") or loc("op_off"))
   end
 
   local function update_input_repeat_delay()
-    generalMenu:set_button_setting(7, config.input_repeat_delay)
+    generalMenu:set_button_setting(5, config.input_repeat_delay)
   end
 
   local function increase_input_repeat_delay()
@@ -76,7 +62,7 @@ local function general_menu()
 
   local function update_replay_preference()
     config.save_replays_publicly = save_replays_publicly_choices[save_replays_preference_index][1]
-    generalMenu:set_button_setting(8, loc(save_replays_publicly_choices[save_replays_preference_index][2]))
+    generalMenu:set_button_setting(6, loc(save_replays_publicly_choices[save_replays_preference_index][2]))
   end
 
   local function increase_publicness() -- privatize or publicize?
@@ -102,8 +88,6 @@ local function general_menu()
   end
 
   generalMenu = Click_menu(menu_x, menu_y, nil, canvas_height - menu_y - 10, 1)
-  generalMenu:add_button(loc("op_vsync"), update_vsync, goEscape, update_vsync, update_vsync)
-  generalMenu:add_button(loc("op_debug"), update_debug, goEscape, update_debug, update_debug)
   generalMenu:add_button(loc("op_countdown"), update_countdown, goEscape, update_countdown, update_countdown)
   generalMenu:add_button(loc("op_fps"), update_fps, goEscape, update_fps, update_fps)
   generalMenu:add_button(loc("op_ingame_infos"), update_infos, goEscape, update_infos, update_infos)
@@ -111,8 +95,6 @@ local function general_menu()
   generalMenu:add_button(loc("op_input_delay"), nextMenu, goEscape, decrease_input_repeat_delay, increase_input_repeat_delay)
   generalMenu:add_button(loc("op_replay_public"), nextMenu, goEscape, increase_publicness, increase_privateness)
   generalMenu:add_button(loc("back"), exitSettings, exitSettings)
-  update_vsync(true)
-  update_debug(true)
   update_countdown(true)
   update_fps(true)
   update_infos(true)
@@ -472,6 +454,76 @@ local function audio_menu(button_idx)
   end
 end
 
+local function debug_menu(button_idx)
+  local ret = nil
+  local menu_x, menu_y = unpack(main_menu_screen_pos)
+  menu_y = menu_y + 70
+  local vsFramesBehind = config.debug_vsFramesBehind or 0
+  local debugMenu
+
+  local function update_debug(noToggle)
+    if not noToggle then
+      config.debug_mode = not config.debug_mode
+    end
+    debugMenu:set_button_setting(1, config.debug_mode and loc("op_on") or loc("op_off"))
+  end
+
+  local function updateVsFramesBehind()
+    config.debug_vsFramesBehind = vsFramesBehind
+    debugMenu:set_button_setting(2, vsFramesBehind)
+  end
+
+  local framesBehindLimit = 200
+
+  local function increaseVsFramesBehind()
+    vsFramesBehind = bound(-framesBehindLimit, vsFramesBehind + 1, framesBehindLimit)
+    updateVsFramesBehind()
+  end
+
+  local function decreaseVsFramesBehind()
+    vsFramesBehind = bound(-framesBehindLimit, vsFramesBehind - 1, framesBehindLimit)
+    updateVsFramesBehind()
+  end
+
+  local function nextMenu()
+    debugMenu:selectNextIndex()
+  end
+
+  local function goEscape()
+    debugMenu:set_active_idx(#debugMenu.buttons)
+  end
+
+  local function exitSettings()
+    ret = {options.main, {5}}
+  end
+
+  debugMenu = Click_menu(menu_x, menu_y, nil, canvas_height - menu_y - 10, 1)
+  debugMenu:add_button(loc("op_debug"), update_debug, goEscape, update_debug, update_debug)
+  debugMenu:add_button("VS Frames Behind", nextMenu, goEscape, decreaseVsFramesBehind, increaseVsFramesBehind)
+  debugMenu:add_button(loc("back"), exitSettings, exitSettings)
+  update_debug(true)
+  updateVsFramesBehind()
+
+  if button_idx then
+    debugMenu:set_active_idx(button_idx)
+  end
+
+  while true do
+    debugMenu:draw()
+    wait()
+    variable_step(
+      function()
+        debugMenu:update()
+      end
+    )
+
+    if ret then
+      debugMenu:remove_self()
+      return unpack(ret)
+    end
+  end
+end
+
 local function about_menu(button_idx)
   local ret = nil
   local menu_x, menu_y = unpack(main_menu_screen_pos)
@@ -676,6 +728,10 @@ function options.main(button_idx)
     ret = {audio_menu}
   end
 
+  local function enter_debug_menu()
+    ret = {debug_menu}
+  end
+
   local function enter_about_menu()
     ret = {about_menu}
   end
@@ -737,6 +793,7 @@ function options.main(button_idx)
   optionsMenu:add_button("General", enter_general_menu, goEscape)
   optionsMenu:add_button("Graphics", enter_graphics_menu, goEscape)
   optionsMenu:add_button("Audio", enter_audio_menu, goEscape)
+  optionsMenu:add_button("Debug", enter_debug_menu, goEscape)
   optionsMenu:add_button("About", enter_about_menu, goEscape)
   optionsMenu:add_button(loc("back"), exitSettings, exitSettings)
   update_language()

--- a/options.lua
+++ b/options.lua
@@ -18,36 +18,43 @@ local function general_menu()
   end
   local generalMenu
 
+  local function update_vsync(noToggle)
+    if not noToggle then
+      config.vsync = not config.vsync
+    end
+    generalMenu:set_button_setting(1, config.vsync and loc("op_on") or loc("op_off"))
+  end
+
   local function update_countdown(noToggle)
     if not noToggle then
       config.ready_countdown_1P = not config.ready_countdown_1P
     end
-    generalMenu:set_button_setting(1, config.ready_countdown_1P and loc("op_on") or loc("op_off"))
+    generalMenu:set_button_setting(2, config.ready_countdown_1P and loc("op_on") or loc("op_off"))
   end
 
   local function update_fps(noToggle)
     if not noToggle then
       config.show_fps = not config.show_fps
     end
-    generalMenu:set_button_setting(2, config.show_fps and loc("op_on") or loc("op_off"))
+    generalMenu:set_button_setting(3, config.show_fps and loc("op_on") or loc("op_off"))
   end
 
   local function update_infos(noToggle)
     if not noToggle then
       config.show_ingame_infos = not config.show_ingame_infos
     end
-    generalMenu:set_button_setting(3, config.show_ingame_infos and loc("op_on") or loc("op_off"))
+    generalMenu:set_button_setting(4, config.show_ingame_infos and loc("op_on") or loc("op_off"))
   end
 
   local function update_analytics(noToggle)
     if not noToggle then
       config.enable_analytics = not config.enable_analytics
     end
-    generalMenu:set_button_setting(4, config.enable_analytics and loc("op_on") or loc("op_off"))
+    generalMenu:set_button_setting(5, config.enable_analytics and loc("op_on") or loc("op_off"))
   end
 
   local function update_input_repeat_delay()
-    generalMenu:set_button_setting(5, config.input_repeat_delay)
+    generalMenu:set_button_setting(6, config.input_repeat_delay)
   end
 
   local function increase_input_repeat_delay()
@@ -62,7 +69,7 @@ local function general_menu()
 
   local function update_replay_preference()
     config.save_replays_publicly = save_replays_publicly_choices[save_replays_preference_index][1]
-    generalMenu:set_button_setting(6, loc(save_replays_publicly_choices[save_replays_preference_index][2]))
+    generalMenu:set_button_setting(7, loc(save_replays_publicly_choices[save_replays_preference_index][2]))
   end
 
   local function increase_publicness() -- privatize or publicize?
@@ -88,6 +95,7 @@ local function general_menu()
   end
 
   generalMenu = Click_menu(menu_x, menu_y, nil, canvas_height - menu_y - 10, 1)
+  generalMenu:add_button(loc("op_vsync"), update_vsync, goEscape, update_vsync, update_vsync)
   generalMenu:add_button(loc("op_countdown"), update_countdown, goEscape, update_countdown, update_countdown)
   generalMenu:add_button(loc("op_fps"), update_fps, goEscape, update_fps, update_fps)
   generalMenu:add_button(loc("op_ingame_infos"), update_infos, goEscape, update_infos, update_infos)
@@ -95,6 +103,7 @@ local function general_menu()
   generalMenu:add_button(loc("op_input_delay"), nextMenu, goEscape, decrease_input_repeat_delay, increase_input_repeat_delay)
   generalMenu:add_button(loc("op_replay_public"), nextMenu, goEscape, increase_publicness, increase_privateness)
   generalMenu:add_button(loc("back"), exitSettings, exitSettings)
+  update_vsync(true)
   update_countdown(true)
   update_fps(true)
   update_infos(true)


### PR DESCRIPTION
The telegraph and garbage queue were holding onto the stack class in their rollback copies causing a whole swatch of memory to stay around till the next game.

To prevent this, we don't store references to the stack in the rollback save states, and hook it back up on rollback.

Debug Improvements
- Debug options menu for inducing lag in replays and vs online
- Fix debug frames behind to work online
- record slowest max frame