### PR TITLE
Testing alternate rollback

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -402,8 +402,8 @@ end
 function Stack.restoreFromRollbackCopy(self, other)
   self:rollbackCopy(other, self)
   if self.telegraph then
-    self.telegraph.owner = self
-    self.telegraph.sender = self.garbage_target
+    self.telegraph.owner = self.garbage_target
+    self.telegraph.sender = self
   end
   -- The remaining inputs is the confirmed inputs not processed yet for this clock time
   -- We have processed CLOCK time number of inputs when we are at CLOCK, so we only want to process the CLOCK+1 input on
@@ -427,18 +427,12 @@ function Stack.rollbackToFrame(self, frame)
     assert(prev_states[frame])
     self:restoreFromRollbackCopy(prev_states[frame])
 
-    if self.garbage_target and self.garbage_target.telegraph then
+    if self.garbage_target and self.garbage_target.later_garbage then
       -- The garbage that we send this time might (rarely) not be the same
       -- as the garbage we sent before.  Wipe out the garbage we sent before...
-      for k, v in pairs(self.garbage_target.telegraph.pendingGarbage) do
+      for k, v in pairs(self.garbage_target.later_garbage) do
         if k > frame then
-          self.garbage_target.telegraph.pendingGarbage[k] = nil
-        end
-      end
-
-      for k, v in pairs(self.garbage_target.telegraph.pendingChainingEnded) do
-        if k > frame then
-          self.garbage_target.telegraph.pendingChainingEnded[k] = nil
+          self.garbage_target.later_garbage[k] = nil
         end
       end
     end
@@ -473,9 +467,9 @@ end
 
 function Stack.set_garbage_target(self, new_target)
   self.garbage_target = new_target
-  if new_target.telegraph then
-    new_target.telegraph.sender = self
-    new_target.telegraph.garbage_queue.sender = self
+  if self.telegraph then
+    self.telegraph.owner = new_target
+    self.telegraph:updatePosition()
   end
 end
 
@@ -1123,10 +1117,6 @@ function Stack.simulate(self)
       end
     end
 
-    if self.telegraph then
-      self.telegraph:update()
-    end
-
     -- Phase 2. /////////////////////////////////////////////////////////////
     -- Timer-expiring actions + falling
     local propogate_fall = {false, false, false, false, false, false}
@@ -1502,7 +1492,7 @@ function Stack.simulate(self)
       self.chain_counter = 0
 
       if self.garbage_target and self.garbage_target.telegraph then
-        self.garbage_target.telegraph:chainingEnded(self.CLOCK)
+        self.telegraph:chainingEnded(self.CLOCK)
       end
     end
 
@@ -1525,11 +1515,7 @@ function Stack.simulate(self)
     if self.telegraph then
       local to_send = self.telegraph:pop_all_ready_garbage(self.CLOCK)
       if to_send and to_send[1] then
-        local garbage = self.later_garbage[self.CLOCK+1] or {}
-        for i = 1, #to_send do
-          garbage[#garbage + 1] = to_send[i]
-        end
-        self.later_garbage[self.CLOCK+1] = garbage
+        self.garbage_target:receiveGarbage(self.CLOCK + GARBAGE_ATTACK_DELAY, to_send)
       end
     end
     
@@ -1808,6 +1794,20 @@ function Stack.simulate(self)
 
   self:update_popfxs()
   self:update_cards()
+end
+
+function Stack:receiveGarbage(frameToReceive, garbageList)
+
+  -- If we are past the frame the attack would be processed we need to rollback
+  if self.CLOCK > frameToReceive then
+    self:rollbackToFrame(frameToReceive)
+  end
+
+  local garbage = self.later_garbage[frameToReceive] or {}
+  for i = 1, #garbageList do
+    garbage[#garbage + 1] = garbageList[i]
+  end
+  self.later_garbage[frameToReceive] = garbage
 end
 
 function Stack:updateFramesBehind()
@@ -2330,8 +2330,8 @@ function Stack.check_matches(self)
 
   if (combo_size ~= 0) then
     self.combos[self.CLOCK] = combo_size
-    if self.garbage_target and self.garbage_target.telegraph and metal_count == 3 and combo_size >= 3 then
-      self.garbage_target.telegraph:push({6, 1, true, false}, first_panel_col, first_panel_row, self.CLOCK)
+    if self.garbage_target and self.telegraph and metal_count == 3 and combo_size >= 3 then
+      self.telegraph:push({6, 1, true, false}, first_panel_col, first_panel_row, self.CLOCK)
     end
     self.analytic:register_destroyed_panels(combo_size)
     if (combo_size > 3) then
@@ -2349,16 +2349,16 @@ function Stack.check_matches(self)
       end
 
       self:enqueue_card(false, first_panel_col, first_panel_row, combo_size)
-      if self.garbage_target and self.garbage_target.telegraph then
+      if self.garbage_target and self.telegraph then
         if metal_count > 3 then
           for i = 3, metal_count do
-            self.garbage_target.telegraph:push({6, 1, true, false}, first_panel_col, first_panel_row, self.CLOCK)
+            self.telegraph:push({6, 1, true, false}, first_panel_col, first_panel_row, self.CLOCK)
           end
         end
         if metal_count ~= combo_size then
           local combo_pieces = combo_garbage[combo_size]
           for i=1,#combo_pieces do
-            self.garbage_target.telegraph:push({combo_pieces[i], 1, false, false}, first_panel_col, first_panel_row, self.CLOCK)
+            self.telegraph:push({combo_pieces[i], 1, false, false}, first_panel_col, first_panel_row, self.CLOCK)
           end
         end
       end
@@ -2376,8 +2376,8 @@ function Stack.check_matches(self)
       self:enqueue_card(true, first_panel_col, first_panel_row, self.chain_counter)
     --EnqueueConfetti(first_panel_col<<4+P1StackPosX+4,
     --          first_panel_row<<4+P1StackPosY+self.displacement-9);
-      if self.garbage_target and self.garbage_target.telegraph then
-        self.garbage_target.telegraph:push({6, self.chain_counter - 1, false, true}, first_panel_col, first_panel_row, self.CLOCK)
+      if self.garbage_target and self.telegraph then
+        self.telegraph:push({6, self.chain_counter - 1, false, true}, first_panel_col, first_panel_row, self.CLOCK)
       end
     end
     local chain_bonus = self.chain_counter

--- a/engine/telegraph.lua
+++ b/engine/telegraph.lua
@@ -20,11 +20,8 @@ Telegraph = class(function(self, sender, owner)
   
   self.sender = sender -- The stack that sent this garbage
   self.owner = owner -- The stack that is receiving the garbage
-  self.pos_x = owner.pos_x - 4
-  self.pos_y = owner.pos_y - 4 - TELEGRAPH_HEIGHT - TELEGRAPH_PADDING
+  self:updatePosition()
   self.attacks = {} -- A copy of the chains and combos earned used to render the animation of going to the telegraph
-  self.pendingGarbage = {} -- Table of garbage that needs to be pushed into the telegraph at specific CLOCK times
-  self.pendingChainingEnded = {} -- A list of CLOCK times where chaining ended in the future
   self.senderCurrentlyChaining = false -- Set when we start a new chain, cleared when the sender is done chaining, used to know if we should grow a chain or start a new one, and to know if we are allowed to send the attack since the sender is done.
   -- (typically sending is prevented by garbage chaining)
 end)
@@ -76,6 +73,11 @@ for k, animation in ipairs(leftward_or_rightward) do
   end
 end
 
+function Telegraph:updatePosition()
+  self.pos_x = self.owner.pos_x - 4
+  self.pos_y = self.owner.pos_y - 4 - TELEGRAPH_HEIGHT - TELEGRAPH_PADDING
+end
+
 function Telegraph.saveClone(toSave)
   clone_pool[#clone_pool + 1] = toSave
 end
@@ -97,28 +99,11 @@ function Telegraph.rollbackCopy(self, source, other)
   other.pos_x = source.pos_x
   other.pos_y = source.pos_y
   other.senderCurrentlyChaining = source.senderCurrentlyChaining
-  other.pendingGarbage = deepcpy(source.pendingGarbage)
-  other.pendingChainingEnded = deepcpy(source.pendingChainingEnded)
 
   -- We don't want saved copies to hold on to stacks, up to the rollback restore to set these back up.
   other.sender = nil
   other.owner = nil
   return other
-end
-
-function Telegraph:update() 
-
-  if self.pendingChainingEnded[self.owner.CLOCK] then
-    self:privateChainingEnded(self.owner.CLOCK)
-    self.pendingChainingEnded[self.owner.CLOCK] = nil
-  end
-
-  if self.pendingGarbage[self.owner.CLOCK] then
-    for _, pendingGarbage in ipairs(self.pendingGarbage[self.owner.CLOCK]) do
-      self:privatePush(unpack(pendingGarbage))
-    end
-    self.pendingGarbage[self.owner.CLOCK] = nil
-  end
 end
 
 -- Adds a piece of garbage to the queue
@@ -129,36 +114,13 @@ function Telegraph:push(garbage, attack_origin_col, attack_origin_row, frame_ear
   local timeAttackInteracts = frame_earned + 1
   --logger.debug("Player " .. self.sender.which .. " attacked with " .. attack_type .. " at " .. frame_earned)
 
-  -- If we are past the frame the attack would be processed we need to rollback
-  if self.owner.CLOCK > timeAttackInteracts then
-    self.owner:rollbackToFrame(timeAttackInteracts)
-  end
+  assert(frame_earned == self.sender.CLOCK, "expected sender clock to equal attack")
 
-  -- If we got the attack in the future, wait to queue it
-  if self.owner.CLOCK < timeAttackInteracts then
-    if not self.pendingGarbage[timeAttackInteracts] then
-      self.pendingGarbage[timeAttackInteracts] = {}
-    end
-
-    self.pendingGarbage[timeAttackInteracts][#self.pendingGarbage[timeAttackInteracts]+1] = {garbage, attack_origin_col, attack_origin_row, timeAttackInteracts}
-
-    return -- EARLY RETURN
-  end
-
-  -- Now push this attack
   self:privatePush(garbage, attack_origin_col, attack_origin_row, timeAttackInteracts)
-
-  -- We may have more attacks this frame. To make sure we save our rollback state with all attacks, don't save and resimulate till we are done with this frame.
-  -- Then only resimulate as needed, because we might simulate more than we need to since another rollback might happen.
 end
 
 -- Adds a piece of garbage to the queue
 function Telegraph.privatePush(self, garbage, attack_origin_col, attack_origin_row, timeAttackInteracts)
-
-  local x_displacement 
-  if not metal_count then
-    metal_count = 0
-  end
   local stuff_to_send
   if garbage[4] then
     stuff_to_send = self:grow_chain(timeAttackInteracts)
@@ -172,7 +134,6 @@ function Telegraph.privatePush(self, garbage, attack_origin_col, attack_origin_r
   end
   self.attacks[timeAttackInteracts][#self.attacks[timeAttackInteracts]+1] =
     {timeAttackInteracts=timeAttackInteracts, origin_col=attack_origin_col, origin_row= attack_origin_row, stuff_to_send=stuff_to_send}
-
 end
 
 function Telegraph.add_combo_garbage(self, garbage, timeAttackInteracts)
@@ -196,18 +157,9 @@ function Telegraph:chainingEnded(frameEnded)
 
   logger.debug("Player " .. self.sender.which .. " chain ended at " .. frameEnded)
 
-  -- If we are past the frame the chain end would process we need to rollback
-  if self.owner.CLOCK > timeAttackInteracts then
-    self.owner:rollbackToFrame(timeAttackInteracts)
-  end
-  
-  -- If we got the attack in the future wait to queue it
-  if self.owner.CLOCK < timeAttackInteracts then
-    self.pendingChainingEnded[timeAttackInteracts] = true
-    return -- EARLY RETURN
-  end
+  assert(frameEnded == self.sender.CLOCK, "expected sender clock to equal attack")
 
-  self:privateChainingEnded(timeAttackInteracts)
+  self:privateChainingEnded(frameEnded)
 end
 
 function Telegraph:privateChainingEnded(timeAttackInteracts)
@@ -292,8 +244,7 @@ function Telegraph.pop_all_ready_garbage(self, time_to_check, just_peeking)
   while subject.garbage_queue.chain_garbage:peek() do
 
     if not subject.stoppers.chain[subject.garbage_queue.chain_garbage.first] and 
-       subject.garbage_queue.chain_garbage:peek().finalized and 
-       time_to_check >= CHAIN_ENDED_DELAY + subject.garbage_queue.chain_garbage:peek().finalized then
+       subject.garbage_queue.chain_garbage:peek().finalized then
       logger.debug("committing chain at " .. time_to_check)
       ready_garbage[#ready_garbage+1] = subject.garbage_queue:pop()
     else 
@@ -377,7 +328,6 @@ function Telegraph:render()
   local telegraph_to_render = self
   local senderCharacter = telegraph_to_render.sender.character
 
-  local render_x = telegraph_to_render.pos_x
   local orig_atk_w, orig_atk_h = characters[senderCharacter].telegraph_garbage_images["attack"]:getDimensions()
   local atk_scale = 16 / math.max(orig_atk_w, orig_atk_h) -- keep image ratio
 
@@ -387,7 +337,7 @@ function Telegraph:render()
   end
 
   for timeAttackInteracts, attacks_this_frame in pairs(telegraph_to_render.attacks) do
-    local frames_since_earned = telegraph_to_render.owner.CLOCK - timeAttackInteracts
+    local frames_since_earned = telegraph_to_render.sender.CLOCK - timeAttackInteracts
     if frames_since_earned <= #card_animation then
       --don't draw anything yet, card animation is still in progress.
     elseif frames_since_earned >= GARBAGE_TRANSIT_TIME then
@@ -441,7 +391,7 @@ function Telegraph:render()
 
   local currentIndex = 0
   while current_block do
-    if telegraph_to_render.owner.CLOCK - current_block.timeAttackInteracts >= GARBAGE_TRANSIT_TIME then
+    if telegraph_to_render.sender.CLOCK - current_block.timeAttackInteracts >= GARBAGE_TRANSIT_TIME then
       local draw_x = self:telegraphRenderXPosition(currentIndex)
       if not current_block[3]--[[is_metal]] then
         local height = math.min(current_block[2], 14)

--- a/globals.lua
+++ b/globals.lua
@@ -15,10 +15,10 @@ server_queue = ServerQueue()
 score_mode = SCOREMODE_TA
  
 GARBAGE_DELAY = 60
-CHAIN_ENDED_DELAY = 30 -- this is the amount of time to delay committing a chain after the chain ends
-											 -- Technically this was 0 in classic games, but we are using 60 to make rollback less noticable and match PA history.
-											 -- In a standard chain this doesn't introduce much delay, but when garbage chaining it typically introduces the full 
-											 -- delay which is only noticable if the opponent is able to recieve a chain in that moment.
+GARBAGE_ATTACK_DELAY = 60 -- this is the amount of time to delay landing a chain on the opponent.
+													-- A higher value allows less rollback to happen and makes lag have less of an impact on the game
+										      -- Technically this was 0 in classic games, but we are using 60 to make rollback less noticable and match PA history.
+
 GARBAGE_TRANSIT_TIME = 90
 MAX_LAG = 200 + GARBAGE_DELAY -- maximum amount of lag before net games abort
 


### PR DESCRIPTION
It appears there are a couple problems with the current rollback in alpha:
1. It seems like during rollbacks the game can feel sluggish, at high level play this can become a problem because lots of attacks are happening, and every frame matters.
2. If the opponent is laggy, the telegraph attacks can hover over your stack temporarily
3. If you interrupt one of your own combos and have a laggy connection, the opponent might drop that combo and rollback to it not falling yet.

Instead of rolling back during the attack animation, what if we delay dropping garbage just like we do in stable by 60 frames? This means the telegraph and attacks can now go back to being in sync with the sender, and as long as there is not more than 60 frames of lag, rollback will never happen just like stable.

I want to land this on alpha and experiment with how it feels. Initial tests look promising.