### PR TITLE
Remove Health Replenishment from Downstacking when Topped Out

### DIFF
--- a/differences.txt
+++ b/differences.txt
@@ -23,8 +23,6 @@ Tetris Attack.  Many fewer initial configurations are posible in Tetris Attack,
 and Tetris Attack's procedure for [!] blocks is based on how many
 panels the player clears, while panel-attack's is not.
 
-
-
 In Tetris Attack, a stack of garbage that should all begin falling at the same
 time will occasionally separate.  panel-attack will not implement this bug.
 
@@ -34,3 +32,10 @@ will not implement this bug.
 
 In Panel de Pon (but not in Tetris Attack), a 32 combo gives too many points.
 panel-attack will not implement this bug.
+
+In Tetris Attack, when you are topped out and have run out of stop and shake time,
+you can be granted a "grace period". This grace period comes in the form of
+literal stop time, and it will not be granted again until you are no longer topped out.
+panel-attack instead implements this in the form of "health". Health only drains when
+the player is topped out and has run out of stop/shake time. Health is seperate from stop/shake time.
+Health is restored when you are no longer topped out.

--- a/engine.lua
+++ b/engine.lua
@@ -471,30 +471,6 @@ function Stack.saveForRollback(self)
   end
 end
 
-function Stack.is_clearing_garbage(self)
-  for i = 1, self.height do 
-    local prow = self.panels[i]
-    for j = 1, self.width do
-      if prow and prow[j].garbage and prow[j].state == "matched" then
-        return true
-      end
-    end
-  end
-  return false
-end
-
-function Stack.has_hovering_chaining_panels(self)
-  for i = 1, self.height do 
-    local prow = self.panels[i]
-    for j = 1, self.width do
-      if prow and prow[j].state == "hovering" and prow[j].chaining then
-        return true
-      end
-    end
-  end
-  return false
-end
-
 function Stack.set_garbage_target(self, new_target)
   self.garbage_target = new_target
   if new_target.telegraph then
@@ -1100,21 +1076,15 @@ function Stack.simulate(self)
       self.FRAMECOUNT_RISE = speed_to_rise_time[self.speed]
     end
 
-    local has_life_time = self.pre_stop_time > 0 or self.stop_time > 0 or self.shake_time > 0
-    if self.panels_in_top_row and self.speed ~= 0 and self.match.mode ~= "puzzle" then
-      local used_health_bonus = (self.health ~= self.max_health or not has_life_time) -- Has the player been granted their bonus stop time
-      if used_health_bonus and not self:is_clearing_garbage() and not ((self.health == self.max_health) and (self:has_hovering_chaining_panels() or self:has_falling_garbage() or self.n_active_panels ~= 0 or self.prev_active_panels ~= 0)) then
-        self.health = bound(0, self.health - 1, self.max_health)
-      end
-      if self.health < 1 and not has_life_time and not (self.n_active_panels ~= 0 or self.prev_active_panels ~= 0 or self.do_swap) then
-        self:set_game_over()
-      end
-    end
-
     -- Phase 0 //////////////////////////////////////////////////////////////
     -- Stack automatic rising
     if self.speed ~= 0 and not self.manual_raise and self.stop_time == 0 and not self.rise_lock and self.match.mode ~= "puzzle" then
-      if not self.panels_in_top_row then
+      if self.panels_in_top_row then
+        self.health = self.health - 1
+        if self.health < 1 and self.shake_time < 1 then
+          self:set_game_over()
+        end
+      else
         self.rise_timer = self.rise_timer - 1
         if self.rise_timer <= 0 then -- try to rise
           self.displacement = self.displacement - 1

--- a/engine.lua
+++ b/engine.lua
@@ -1103,7 +1103,7 @@ function Stack.simulate(self)
     local has_life_time = self.pre_stop_time > 0 or self.stop_time > 0 or self.shake_time > 0
     if self.panels_in_top_row and self.speed ~= 0 and self.match.mode ~= "puzzle" then
       local used_health_bonus = (self.health ~= self.max_health or not has_life_time) -- Has the player been granted their bonus stop time
-      if used_health_bonus and not self:is_clearing_garbage() and not ((self.health == self.max_health) and self:has_hovering_chaining_panels()) then
+      if used_health_bonus and not self:is_clearing_garbage() and not ((self.health == self.max_health) and (self:has_hovering_chaining_panels() or self:has_falling_garbage() or self.n_active_panels ~= 0 or self.prev_active_panels ~= 0)) then
         self.health = bound(0, self.health - 1, self.max_health)
       end
       if self.health < 1 and not has_life_time and not (self.n_active_panels ~= 0 or self.prev_active_panels ~= 0 or self.do_swap) then


### PR DESCRIPTION
Or, more accurately, described as stop time. This changes it to be true to Tetris Attack.