### PR TITLE
Music test revamp

### DIFF
--- a/character.lua
+++ b/character.lua
@@ -46,7 +46,7 @@ local defaulted_images = {
   fade = true
 } -- those images will be defaulted if missing
 local basic_sfx = {"selection"}
-local other_sfx = {"chain", "combo", "combo_echo", "chain_echo", "chain2", "chain2_echo", "garbage_match", "garbage_land", "win", "taunt_up", "taunt_down"}
+local other_sfx = {"chain", "combo", "combo_echo", "chain2", "chain_echo", "chain2_echo", "garbage_match", "garbage_land", "win", "taunt_up", "taunt_down"}
 local defaulted_sfxs = {} -- those sfxs will be defaulted if missing
 local basic_musics = {}
 local other_musics = {"normal_music", "danger_music", "normal_music_start", "danger_music_start"}
@@ -505,19 +505,16 @@ function Character.sound_init(self, full, yields)
 
     -- fallback case: chain/combo can be used for the other one if missing and for the longer names versions ("combo" used for "combo_echo" for instance)
     if not self.sounds.others[sfx] then
-      if sfx == "combo" then
-        self.sounds.others[sfx] = load_sound_from_supported_extensions(self.path .. "/chain", false)
-      elseif sfx == "chain" then
+      if sfx == "chain" then
         self.sounds.others[sfx] = load_sound_from_supported_extensions(self.path .. "/combo", false)
+      elseif sfx == "combo" then
+        self.sounds.others[sfx] = self.sounds.others["chain"]
       elseif sfx == "combo_echo" then
-        self.sounds.others[sfx] = load_sound_from_supported_extensions(self.path .. "/combo", false)
-        if not self.sounds.others[sfx] then
-          self.sounds.others[sfx] = load_sound_from_supported_extensions(self.path .. "/chain", false)
-        end
+        self.sounds.others[sfx] = self.sounds.others["combo"]
       elseif string.find(sfx, "chain") then
-        self.sounds.others[sfx] = load_sound_from_supported_extensions(self.path .. "/chain", false)
+        self.sounds.others[sfx] = self.sounds.others["chain"]
       elseif string.find(sfx, "combo") then
-        self.sounds.others[sfx] = load_sound_from_supported_extensions(self.path .. "/combo", false)
+        self.sounds.others[sfx] = self.sounds.others["combo"]
       end
     end
     if not self.sounds.others[sfx] and defaulted_sfxs[sfx] and not self:is_bundle() then

--- a/localization.csv
+++ b/localization.csv
@@ -22,6 +22,7 @@ player,,Player,Joueur,Jogador,プレイヤー,Jugador,Spieler,Giocatore
 player_n,,Player %1,Joueur %1,Jogador %1,プレイヤー%1,Jugador %1,Spieler %1,Giocatore %1
 page,,Page,Page,Página,ページ,Página,Seite,Pagina
 panels,,Panels,Panels,Painéis,パネル,Paneles,Panels,Tessere
+character,,Character,Personnage,Personagem,??????,Personaje,Charakter,Carattere
 stage,,Stage,Terrain,Cenário,ステージ,Escenario,Arena,Scenario
 mode,,Mode,Mode,Modo,モード,Modo,Modus,Modalità
 ready,,Ready,Prêt,Pronto,READY,Listo,Bereit,Pronto
@@ -287,6 +288,10 @@ op_music_nav,,"%1 and %2 to navigate songs
 %3で戻る","%1 y %2 para navegar entre melodías
 %3 para salir","Nutze %1 und %2 um zwischen Liedern zu navigieren und %3, um das Menü zu verlassen","%1 e %2 per navigare tra le canzoni
 %3 per uscire"
+op_music_play,Play music button in Sound Test,Play,Play,Play,Play,Play,Play,Play
+op_music_stop,Stop music button in Sound Test,Stop,Arr�ter,Pare,???,Detener,Stoppen,Fermare
+op_music_type,Select music type in Sound Test,Music type,La musique,M�sica,??,M�sica,Musik,Musica
+op_music_sfx,Sound Effect in Sound Test,SFX,Sonner,Som,?,Sonar,Klang,Suono
 op_panels,,Panels set,Choisir les blocs,Definir painéis,パネルセット,Set de paneles,Panelset,Scelta delle tessere
 op_reload_analytics,,reloading analytics...,rechargement des statistiques...,recarregando estatísticas...,解析を再読み込みしています...,Recargando estadísticas...,Statistiken neu laden...,Ricaricamento delle statistiche...
 op_reload_characters,,reloading characters...,rechargement des personnages...,recarregando personagens...,キャラクターを再読み込みしています...,Recargando personajes...,Charaktere neu laden...,Ricaricamento dei personaggi...

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -115,8 +115,11 @@ end
 do
   function main_select_mode()
     CLICK_MENUS = {}
-    if themes[config.theme].musics["main"] then
-      find_and_add_music(themes[config.theme].musics, "main")
+    if next(currently_playing_tracks) == nil then
+      stop_the_music()
+      if themes[config.theme].musics["main"] then
+        find_and_add_music(themes[config.theme].musics, "main")
+      end
     end
     character_loader_clear()
     stage_loader_clear()
@@ -610,8 +613,11 @@ local function main_select_speed_99(mode)
 
   GAME.backgroundImage = themes[config.theme].images.bg_main
   reset_filters()
-  if themes[config.theme].musics["main"] then
-    find_and_add_music(themes[config.theme].musics, "main")
+  if next(currently_playing_tracks) == nil then
+    stop_the_music()
+    if themes[config.theme].musics["main"] then
+      find_and_add_music(themes[config.theme].musics, "main")
+    end
   end
 
   local gameSettingsMenu
@@ -729,8 +735,11 @@ end
 
 -- The menu where you spectate / join net vs games
 function main_net_vs_lobby()
-  if themes[config.theme].musics.main then
-    find_and_add_music(themes[config.theme].musics, "main")
+  if next(currently_playing_tracks) == nil then
+    stop_the_music()
+    if themes[config.theme].musics["main"] then
+      find_and_add_music(themes[config.theme].musics, "main")
+    end
   end
   GAME.backgroundImage = themes[config.theme].images.bg_main
   GAME.battleRoom = nil
@@ -1518,8 +1527,11 @@ do
   end
   items[#items + 1] = {"back", main_select_mode}
   function main_select_puzz()
-    if themes[config.theme].musics.main then
-      find_and_add_music(themes[config.theme].musics, "main")
+    if next(currently_playing_tracks) == nil then
+      stop_the_music()
+      if themes[config.theme].musics["main"] then
+        find_and_add_music(themes[config.theme].musics, "main")
+      end
     end
     GAME.backgroundImage = themes[config.theme].images.bg_main
     reset_filters()

--- a/options.lua
+++ b/options.lua
@@ -492,6 +492,7 @@ local function audio_menu(button_idx)
               addSounds("taunt down", characters[tracks[index].id].sounds.taunt_downs, " ")
               
               current_sound_index = 1
+
             else
               if not stages[tracks[index].id].fully_loaded then
                 stages[tracks[index].id]:sound_init(true, false)
@@ -687,8 +688,6 @@ local function audio_menu(button_idx)
           themes[config.theme].sounds.menu_validate = menu_validate_sound
           audio_test_ret = {audio_menu, {6}}
         end
-  
-        -- TO-DO: localization options: "Play/Stop", "Type/Music(?)", "SFX/Sounds(?)"
         
         soundTestMenu = Click_menu(menu_x, menu_y, nil, canvas_height - menu_y - 10, 1)
         soundTestMenu:add_button(loc("character"), nextTrack, goBack, previousTrack, nextTrack)
@@ -697,7 +696,11 @@ local function audio_menu(button_idx)
         soundTestMenu:add_button(loc("op_music_sfx"), playSFX, goBack, previousSFX, nextSFX)
         soundTestMenu:add_button(loc("back"), exitAudioTest, exitAudioTest)
         soundTestMenu:set_button_setting(1, tracks[index].name)
-        soundTestMenu:set_button_setting(2, music_type)
+        if tracks[index].has_music then
+          soundTestMenu:set_button_setting(2, music_type)
+        else
+          soundTestMenu:set_button_setting(2, loc("op_none"))
+        end
         soundTestMenu:set_button_setting(4, "combo")
         unloadTrack()
         loadTrack()

--- a/options.lua
+++ b/options.lua
@@ -288,129 +288,432 @@ local function audio_menu(button_idx)
   local function enter_music_test()
     ret = {
       function()
-        gprint(loc("op_music_load"), unpack(main_menu_screen_pos))
-        wait()
-        -- load music for characters/stages that are not fully loaded
-        for _, character_id in ipairs(characters_ids_for_current_theme) do
-          if not characters[character_id].fully_loaded then
-            characters[character_id]:sound_init(true, false)
-          end
-        end
-        for _, stage_id in ipairs(stages_ids_for_current_theme) do
-          if not stages[stage_id].fully_loaded then -- we perform the same although currently no stage are being loaded at this point
-            stages[stage_id]:sound_init(true, false)
-          end
-        end
-
+        local audio_test_ret = nil
+        local menu_x, menu_y = unpack(main_menu_screen_pos)
+        local soundTestMenu
+        local loaded_track_index = 0
         local index = 1
+        local normalMusic = {}
+        local dangerMusic = {}
+        local playing = false
         local tracks = {}
+        local character_sounds = {}
+        local character_sounds_keys = {}
+        local current_sound_index = 0
 
-        for _, character_id in ipairs(characters_ids_for_current_theme) do
-          local character = characters[character_id]
-          if character.musics.normal_music then
-            tracks[#tracks + 1] = {
-              is_character = true,
-              name = character.display_name .. ": normal_music",
-              id = character_id,
-              type = "normal_music",
-              start = character.musics.normal_music_start or zero_sound,
-              loop = character.musics.normal_music
-            }
-          end
-          if character.musics.danger_music then
-            tracks[#tracks + 1] = {
-              is_character = true,
-              name = character.display_name .. ": danger_music",
-              id = character_id,
-              type = "danger_music",
-              start = character.musics.danger_music_start or zero_sound,
-              loop = character.musics.danger_music
-            }
-          end
-        end
-        for _, stage_id in ipairs(stages_ids_for_current_theme) do
-          local stage = stages[stage_id]
-          if stage.musics.normal_music then
-            tracks[#tracks + 1] = {
-              is_character = false,
-              name = stage.display_name .. ": normal_music",
-              id = stage_id,
-              type = "normal_music",
-              start = stage.musics.normal_music_start or zero_sound,
-              loop = stage.musics.normal_music
-            }
-          end
-          if stage.musics.danger_music then
-            tracks[#tracks + 1] = {
-              is_character = false,
-              name = stage.display_name .. ": danger_music",
-              id = stage_id,
-              type = "danger_music",
-              start = stage.musics.danger_music_start or zero_sound,
-              loop = stage.musics.danger_music
-            }
-          end
-        end
+        local ram_load = 0
+        local max_ram_load = 20 --arbitrary number of characters/stages allowed to load before forcing a garbagecollection
+  
+        local music_type = "normal_music"
+        local musics_to_use = nil
 
         -- stop main music
         stop_all_audio()
 
-        -- initial song starts here
-        find_and_add_music(tracks[index].is_character and characters[tracks[index].id].musics or stages[tracks[index].id].musics, tracks[index].type)
+        -- disable the menu_validate sound and keep a copy of it to restore later
+        local menu_validate_sound = themes[config.theme].sounds.menu_validate
+        themes[config.theme].sounds.menu_validate = zero_sound
 
-        while true do
-          tp = loc("op_music_current") .. tracks[index].name
-          tp = tp .. (table.getn(currently_playing_tracks) == 1 and "\n" .. loc("op_music_intro") .. "\n" or "\n" .. loc("op_music_loop") .. "\n")
-          min_time = math.huge
-          for k, _ in pairs(music_t) do
-            if k and k < min_time then
-              min_time = k
+        gprint(loc("op_music_load"), unpack(main_menu_screen_pos))
+        wait()
+
+        -- temporarily load music for characters that are not fully loaded to build tracklist, bundle characters add their subcharacters as tracks instead
+        for _, character_id in ipairs(characters_ids_for_current_theme) do
+          if not characters[character_id].fully_loaded then
+            characters[character_id]:sound_init(true, false)
+          end
+          local character = characters[character_id]
+          if next(character.sub_characters) == nil then
+            tracks[#tracks + 1] = {
+            is_character = true,
+            name = string.len(trim(character.display_name)) == 0 and character_id or character.display_name,
+            id = character_id,
+            parent_id = nil,
+            has_music = character.musics.normal_music and true,
+            has_danger = character.musics.danger_music and true,
+            style = character.music_style or "normal"
+            }
+            ram_load = ram_load + 1
+          else
+            for _, sub_character_id in ipairs(character.sub_characters) do
+              if not characters[sub_character_id].fully_loaded then
+                characters[sub_character_id]:sound_init(true, false)
+              end
+              local subcharacter = characters[sub_character_id]
+              tracks[#tracks + 1] = {
+              is_character = true,
+              name = (string.len(trim(character.display_name)) == 0 and character_id or character.display_name) .. " " .. (string.len(trim(subcharacter.display_name)) == 0 and sub_character_id or subcharacter.display_name),
+              id = sub_character_id,
+              parent_id = character_id,
+              has_music = subcharacter.musics.normal_music and true,
+              has_danger = subcharacter.musics.danger_music and true,
+              style = subcharacter.music_style or "normal"
+              }
+              ram_load = ram_load + 1
+              if not characters[sub_character_id].fully_loaded then
+                characters[sub_character_id]:sound_uninit(true, false)
+              end
             end
           end
-          tp = tp .. string.format("%d", min_time - love.timer.getTime())
-          tp = tp .. "\n\n\n" .. loc("op_music_nav", "<", ">", "ESC")
-          gprint(tp, unpack(main_menu_screen_pos))
-          wait()
-          local audio_test_ret = nil
-          variable_step(
-            function()
-              if menu_left() or menu_right() or menu_escape() then
-                stop_the_music()
-              end
-              if menu_left() then
-                index = index - 1
-              end
-              if menu_right() then
-                index = index + 1
-              end
-              if index > #tracks then
-                index = 1
-              end
-              if index < 1 then
-                index = #tracks
-              end
-              if menu_left() or menu_right() then
-                find_and_add_music(tracks[index].is_character and characters[tracks[index].id].musics or stages[tracks[index].id].musics, tracks[index].type)
-              end
+          if not characters[character_id].fully_loaded then
+            characters[character_id]:sound_uninit() -- give thanks to our memory bandwidth
+          end
+          if ram_load > max_ram_load then
+            collectgarbage("collect") -- forced collection to prevent our RAM from spiking too high and crashing
+            ram_load = 0
+          end
+        end
 
-              if menu_escape() then
-                -- unloads music for characters/stages that are not fully loaded (they have been loaded when entering this submenu)
-                for _, character_id in ipairs(characters_ids_for_current_theme) do
-                  if not characters[character_id].fully_loaded then
-                    characters[character_id]:sound_uninit()
-                  end
-                end
-                for _, stage_id in ipairs(stages_ids_for_current_theme) do
-                  if not stages[stage_id].fully_loaded then
-                    stages[stage_id]:sound_uninit()
-                  end
-                end
+        -- temporarily load music for stages that are not fully loaded to continue building tracklist, stages without music are skipped
+        for _, stage_id in ipairs(stages_ids_for_current_theme) do
+          if not stages[stage_id].fully_loaded then 
+            stages[stage_id]:sound_init(true, false)
+          end
+          local stage = stages[stage_id]
+          if stage.musics.normal_music then
+            tracks[#tracks + 1] = {
+              is_character = false,
+              name = stage.display_name,
+              id = stage_id,
+              parent_id = nil,
+              has_music = true,
+              has_danger = stage.musics.danger_music and true,
+              style = stage.music_style  or "normal"
+            }
+            ram_load = ram_load + 1
+          end
+          if not stages[stage_id].fully_loaded then
+            stages[stage_id]:sound_uninit()
+          end
+          if ram_load > max_ram_load then
+            collectgarbage("collect")
+            ram_load = 0
+          end
+        end
 
-                audio_test_ret = {audio_menu, {6}}
+        local function unloadTrack()
+          if loaded_track_index > 0 then
+            stop_the_music()
+            if tracks[loaded_track_index].is_character then
+              for _, v in pairs(character_sounds) do
+                v:stop()
+              end
+              character_sounds = {}
+              if not characters[tracks[loaded_track_index].id].fully_loaded then
+                characters[tracks[loaded_track_index].id]:sound_uninit()
+              end
+              if tracks[index].parent_id then
+                if not characters[tracks[loaded_track_index].parent_id].fully_loaded then
+                  characters[tracks[loaded_track_index].parent_id]:sound_uninit(true, false)
+                end
+              end
+            else
+              if not stages[tracks[loaded_track_index].id].fully_loaded then
+                stages[tracks[loaded_track_index].id]:sound_uninit()
               end
             end
+            normalMusic = {}
+            dangerMusic = {}
+            character_sounds = {}
+            character_sounds_keys = {}
+            loaded = false
+            playing = false
+            soundTestMenu:set_button_text(3, loc("op_music_play"))
+            loaded_track_index = 0
+          end
+        end
+
+        local function addSound(name, sound)
+          if sound then
+            character_sounds[#character_sounds + 1] = sound
+            character_sounds_keys[#character_sounds_keys + 1] = name
+          end
+        end
+
+        local function addSounds(sound_name, sound_table, spacer)
+          for num, sound in ipairs(sound_table) do
+            addSound(sound_name .. ((num==1 and "") or (spacer .. num)), sound)
+          end
+        end
+
+        local function loadTrack()
+          if loaded_track_index ~= index then
+            unloadTrack()
+          end
+          if not loaded then
+            if tracks[index].is_character then
+              if not characters[tracks[index].id].fully_loaded then
+                characters[tracks[index].id]:sound_init(true, false)
+                if tracks[index].parent_id then
+                  characters[tracks[index].parent_id]:sound_init(true, false)
+                end
+              end
+              musics_to_use = characters[tracks[index].id].musics
+
+              addSounds("combo", characters[tracks[index].id].sounds.combos, " ")
+
+              if next(characters[tracks[index].id].sounds.combos) and next(characters[tracks[index].id].sounds.combo_echos) and not (characters[tracks[index].id].sounds.combos[1] == characters[tracks[index].id].sounds.combo_echos[1]) then
+                addSounds("combo echo", characters[tracks[index].id].sounds.combo_echos, " ")
+              end
+
+              if next(characters[tracks[index].id].sounds.chains) == nil and next(characters[tracks[index].id].sounds.others) and not (characters[tracks[index].id].sounds.others["chain"] == characters[tracks[index].id].sounds.combos[1]) then
+                addSound("chain", characters[tracks[index].id].sounds.others["chain"])
+                if characters[tracks[index].id].sounds.others["chain"] ~= characters[tracks[index].id].sounds.others["chain2"] then
+                  addSound("chain 2", characters[tracks[index].id].sounds.others["chain2"])
+                end
+                if characters[tracks[index].id].sounds.others["chain2"] ~= characters[tracks[index].id].sounds.others["chain_echo"] then
+                  addSound("chain echo", characters[tracks[index].id].sounds.others["chain_echo"])
+                end
+                if characters[tracks[index].id].sounds.others["chain_echo"] ~= characters[tracks[index].id].sounds.others["chain2_echo"] then
+                  addSound("chain 2 echo", characters[tracks[index].id].sounds.others["chain2_echo"])
+                end
+              else
+                for i=2,13 do
+                  if characters[tracks[index].id].sounds.chains[i] ~=nil and i==2 or not content_equal(characters[tracks[index].id].sounds.chains[i-1], characters[tracks[index].id].sounds.chains[i]) then
+                    addSounds("chain "..i, characters[tracks[index].id].sounds.chains[i], "-")
+                  end
+                end
+                if characters[tracks[index].id].sounds.chains[0] ~=nil and not content_equal(characters[tracks[index].id].sounds.chains[13], characters[tracks[index].id].sounds.chains[0]) then
+                  addSounds("chain ?", characters[tracks[index].id].sounds.chains[0], "-")
+                end
+              end
+
+              addSounds("garbage match", characters[tracks[index].id].sounds.garbage_matches, " ")
+              addSounds("garbage land", characters[tracks[index].id].sounds.garbage_lands, " ")
+              
+              if next(characters[tracks[index].id].sounds.selections) == nil and tracks[index].parent_id then
+                addSounds("selection", characters[tracks[index].parent_id].sounds.selections, " ")
+              else
+                addSounds("selection", characters[tracks[index].id].sounds.selections, " ")
+              end
+
+              addSounds("win", characters[tracks[index].id].sounds.wins, " ")
+              addSounds("taunt up", characters[tracks[index].id].sounds.taunt_ups, " ")
+              addSounds("taunt down", characters[tracks[index].id].sounds.taunt_downs, " ")
+              
+              current_sound_index = 1
+            else
+              if not stages[tracks[index].id].fully_loaded then
+                stages[tracks[index].id]:sound_init(true, false)
+              end
+              musics_to_use = stages[tracks[index].id].musics
+
+              current_sound_index = 0
+              character_sounds = {}
+              character_sounds_keys = {}
+              soundTestMenu:set_button_setting(4, loc("op_none"))
+            end
+            if tracks[index].style == "dynamic" then
+              normalMusic = {musics_to_use["normal_music"], musics_to_use["normal_music_start"]}
+              dangerMusic = {musics_to_use["danger_music"], musics_to_use["danger_music_start"]}
+            else
+              normalMusic = {}
+              dangerMusic = {}
+            end
+            if not tracks[index].has_music then
+              soundTestMenu:set_button_setting(2, loc("op_none"))
+            elseif not tracks[index].has_danger then
+              music_type = "normal_music"
+              soundTestMenu:set_button_setting(2, music_type)
+            end
+          end
+          loaded = true
+          loaded_track_index = index
+        end
+  
+        local function switchDanger()
+          if not loaded then
+            loadTrack()
+          end
+          if tracks[index].has_music and tracks[index].has_danger then
+            if music_type == "danger_music" then
+              music_type = "normal_music"
+            else
+              music_type = "danger_music"
+            end
+            soundTestMenu:set_button_setting(2, music_type)
+            if playing then
+              if tracks[index].style == "dynamic" then
+                if music_type == "danger_music" then
+                  setFadePercentageForGivenTracks(0, normalMusic)
+                  setFadePercentageForGivenTracks(1, dangerMusic)
+                else
+                  setFadePercentageForGivenTracks(0, dangerMusic)
+                  setFadePercentageForGivenTracks(1, normalMusic)
+                end
+              else
+                stop_the_music()
+                find_and_add_music(musics_to_use, music_type)
+              end
+            end
+            soundTestMenu:set_button_setting(2, music_type)
+          end
+        end
+  
+        local function nextTrack()
+          unloadTrack()
+          if index == #tracks then
+            index = 1
+          else
+            index = index + 1
+          end
+          soundTestMenu:set_button_setting(1, tracks[index].name)
+          if tracks[index].is_character then
+            soundTestMenu:set_button_text(1, loc("character"))
+            soundTestMenu:set_button_setting(4, "combo")
+          else
+            soundTestMenu:set_button_text(1, loc("stage"))
+            soundTestMenu:set_button_setting(4, loc("op_none"))
+          end
+          if not tracks[index].has_music then
+            soundTestMenu:set_button_setting(2, loc("op_none"))
+          elseif not tracks[index].has_danger then
+            soundTestMenu:set_button_setting(2, "normal_music")
+          else
+            soundTestMenu:set_button_setting(2, music_type)
+          end
+        end
+  
+        local function previousTrack()
+          unloadTrack()
+          if index == 1 then
+            index = #tracks
+          else
+            index = index - 1
+          end
+          soundTestMenu:set_button_setting(1, tracks[index].name)
+          if tracks[index].is_character then
+            soundTestMenu:set_button_text(1, loc("character"))
+            soundTestMenu:set_button_setting(4, "combo")
+          else
+            soundTestMenu:set_button_text(1, loc("stage"))
+            soundTestMenu:set_button_setting(4, loc("op_none"))
+          end
+          if not tracks[index].has_music then
+            soundTestMenu:set_button_setting(2, loc("op_none"))
+          elseif not tracks[index].has_danger then
+            soundTestMenu:set_button_setting(2, "normal_music")
+          else
+            soundTestMenu:set_button_setting(2, music_type)
+          end
+        end
+
+        local function playOrStopMusic()
+          if not loaded then
+            loadTrack()
+          end
+          if tracks[index].has_music then
+            if playing then
+              stop_the_music()
+              playing = false
+              soundTestMenu:set_button_text(3, loc("op_music_play"))
+            else
+              if tracks[index].style == "dynamic" then
+                find_and_add_music(musics_to_use, "normal_music")
+                find_and_add_music(musics_to_use, "danger_music")
+                if music_type == "danger_music" then
+                  setFadePercentageForGivenTracks(0, normalMusic)
+                  setFadePercentageForGivenTracks(1, dangerMusic)
+                else
+                  setFadePercentageForGivenTracks(0, dangerMusic)
+                  setFadePercentageForGivenTracks(1, normalMusic)
+                end
+              else
+                stop_the_music()
+                find_and_add_music(musics_to_use, music_type)
+              end
+              playing = true
+              soundTestMenu:set_button_text(3, loc("op_music_stop"))
+            end
+          end
+        end
+
+        local function nextSFX()
+          if tracks[index].is_character then
+            if not loaded then
+              loadTrack()
+            end
+            if next(character_sounds_keys) then
+              if current_sound_index == #character_sounds then
+                current_sound_index = 1
+              else
+                current_sound_index = current_sound_index + 1
+              end
+              soundTestMenu:set_button_setting(4, character_sounds_keys[current_sound_index])
+            end
+          end
+        end
+
+        local function previousSFX()
+          if tracks[index].is_character then
+            if not loaded then
+              loadTrack()
+            end
+            if next(character_sounds_keys) then
+              if current_sound_index == 1 then
+                current_sound_index = #character_sounds
+              else
+                current_sound_index = current_sound_index - 1
+              end
+              soundTestMenu:set_button_setting(4, character_sounds_keys[current_sound_index])
+            end
+          end
+        end
+
+        local function playSFX()
+          if tracks[index].is_character then
+            if not loaded then
+              loadTrack()
+            end
+            for _, v in pairs(character_sounds) do
+              v:stop()
+            end
+            play_optional_sfx(character_sounds[current_sound_index])
+          end
+        end
+  
+        local function goBack()
+          soundTestMenu:set_active_idx(#soundTestMenu.buttons)
+        end
+
+        --fallback to main theme if nothing is playing or if dynamic music is playing, dynamic music cannot cleanly be "carried out" of the sound test due to the master volume reapplication in the audio options menu
+        local function exitAudioTest()
+          if (not playing) or (tracks[index].style == "dynamic") then 
+            if loaded then
+              unloadTrack()
+            end
+            find_and_add_music(themes[config.theme].musics, "main")
+          end
+          themes[config.theme].sounds.menu_validate = menu_validate_sound
+          audio_test_ret = {audio_menu, {6}}
+        end
+  
+        -- TO-DO: localization options: "Play/Stop", "Type/Music(?)", "SFX/Sounds(?)"
+        
+        soundTestMenu = Click_menu(menu_x, menu_y, nil, canvas_height - menu_y - 10, 1)
+        soundTestMenu:add_button(loc("character"), nextTrack, goBack, previousTrack, nextTrack)
+        soundTestMenu:add_button(loc("op_music_type"), switchDanger, goBack, switchDanger, switchDanger)
+        soundTestMenu:add_button(loc("op_music_play"), playOrStopMusic, goBack)
+        soundTestMenu:add_button(loc("op_music_sfx"), playSFX, goBack, previousSFX, nextSFX)
+        soundTestMenu:add_button(loc("back"), exitAudioTest, exitAudioTest)
+        soundTestMenu:set_button_setting(1, tracks[index].name)
+        soundTestMenu:set_button_setting(2, music_type)
+        soundTestMenu:set_button_setting(4, "combo")
+        unloadTrack()
+        loadTrack()
+        unloadTrack()
+
+        while true do
+          soundTestMenu:draw()
+          wait()
+          variable_step(
+            function()
+              soundTestMenu:update()
+            end
           )
+    
           if audio_test_ret then
+            soundTestMenu:remove_self()
             return unpack(audio_test_ret)
           end
         end


### PR DESCRIPTION
Changes to reduce memory use:
Track tables/objects are now based on characters & stages (anything with normal & danger songs are now one track instead of two). However, characters without songs are now added since they still have sounds.
-loading process now uninitializes sounds after each track is made, and has forced garbage collection intervals to cover love2d's auto collection not being enough in this file-initialization-intensive process
-In the actual music room after loading is complete, only one track's sounds can be loaded at a time. Changing tracks will immediately unload the previous track's sounds, and next track's sounds will only be loaded when needed.

The fun changes:
-Click menu, to now line up with the re-done options menu
-Added support for character bundles and dynamic music
-Music room's currently playing song can be carried out to the options and main menus (dynamic music not supported)
--mainloop.lua changes were to support this
-Sound Test, characters' unique sound effects are loaded and can be played on demand.
--character.lua changes were primarily to make comparing sounds easier (whereas loading the same file to multiple variables count as unequal variables), but should marginally improve efficiency loading characters that default most of their sound categories (all default characters)