### PR TITLE
Add garbage to puzzles

### DIFF
--- a/Puzzle.lua
+++ b/Puzzle.lua
@@ -1,4 +1,3 @@
-
 -- A puzzle is a particular instance of the game, where there is a specific goal for clearing the panels
 Puzzle =
   class(
@@ -6,6 +5,75 @@ Puzzle =
     self.puzzleType = puzzleType
     self.doCountdown = doCountdown
     self.moves = moves
-    self.stack = stack
+    self.stack = string.gsub(stack, "%s+", "") -- Remove whitespace so files can be easier to read
   end
 )
+
+function Puzzle.getPuzzleTypes()
+  return { "moves", "chain" }
+end
+
+function Puzzle.getLegalCharacters()
+  return { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "[", "]", "{", "}", "=" }
+end
+
+function Puzzle.validate(self)
+  local errMessage = ""
+
+  if type(self.doCountdown) ~= "boolean" then
+    errMessage = "\nInvalid value for property 'doCountdown'"
+  end
+
+  if string.len(self.stack) > 6*12 then
+    errMessage = errMessage ..
+     "\nPuzzlestring contains more panels than the playfield can contain." ..
+     "\nNumber of panels: " .. string.len(self.stack) ..
+     "\nMaximum allowed: " .. 6*12
+  end
+
+  local illegalCharacters = {}
+  local pendingGarbageStart = nil
+  for i = 1, #self.stack do
+    local char = string.sub(self.stack, i, i)
+    if not table.contains(Puzzle.getLegalCharacters(), char)
+      and not table.contains(illegalCharacters, char) then
+      table.insert(illegalCharacters, char)
+    end
+    if char == "[" or char == "{" then
+      if not pendingGarbageStart then
+        pendingGarbageStart = char
+      else
+        errMessage = errMessage ..
+        "\nPuzzlestring contains invalid garbage notation, make sure you close garbage before you open another."
+      end
+    elseif char == "]" and pendingGarbageStart ~= "[" and pendingGarbageStart
+      or char == "}" and pendingGarbageStart ~= "{" and pendingGarbageStart then
+        errMessage = errMessage ..
+        "\nPuzzlestring contains invalid garbage notation, make sure to not mix the symbols for opening/closing regular and shock garbage in your puzzle."
+    elseif char == "]" and pendingGarbageStart == "["
+      or char == "}" and pendingGarbageStart == "{" then
+        -- garbage has been properly closed - most likely
+        pendingGarbageStart = nil
+    end
+  end
+
+  if #illegalCharacters > 0 then
+    errMessage = errMessage .. "\nPuzzlestring contains invalid characters: " .. table.concat(illegalCharacters, ", ")
+  end
+
+  if not table.contains(Puzzle.getPuzzleTypes(), self.puzzleType) then
+    errMessage = errMessage ..
+    "\nInvalid puzzle type detected, available puzzle types are: " .. table.concat(Puzzle.getPuzzleTypes(), ", ")
+  end
+
+  if string.lower(self.puzzleType) == "moves" and (not tonumber(self.moves) or tonumber(self.moves) < 1 ) then
+    errMessage = errMessage ..
+    "\nInvalid number of moves detected, expecting a number greater than zero but instead got " .. self.moves
+  end
+
+  if errMessage ~= "" then
+    errMessage = "The following puzzle contains invalid values:\n" .. json.encode(self) .. errMessage
+  end
+
+  return errMessage == "", errMessage
+end

--- a/Puzzle.lua
+++ b/Puzzle.lua
@@ -33,6 +33,7 @@ function Puzzle.validate(self)
 
   local illegalCharacters = {}
   local pendingGarbageStart = nil
+  local pendingGarbageStartIndex = 0
   for i = 1, #self.stack do
     local char = string.sub(self.stack, i, i)
     if not table.contains(Puzzle.getLegalCharacters(), char)
@@ -42,6 +43,7 @@ function Puzzle.validate(self)
     if char == "[" or char == "{" then
       if not pendingGarbageStart then
         pendingGarbageStart = char
+        pendingGarbageStartIndex = i
       else
         errMessage = errMessage ..
         "\nPuzzlestring contains invalid garbage notation, make sure you close garbage before you open another."
@@ -52,6 +54,18 @@ function Puzzle.validate(self)
         "\nPuzzlestring contains invalid garbage notation, make sure to not mix the symbols for opening/closing regular and shock garbage in your puzzle."
     elseif char == "]" and pendingGarbageStart == "["
       or char == "}" and pendingGarbageStart == "{" then
+        if (i + 1 - pendingGarbageStartIndex) - 6 > 0 then-- more than 6 panels in the garbage -> chain garbage
+          if ((i + 1 - pendingGarbageStartIndex) % 6 > 0 -- length of the garbage is not valid (needs to be divisable by 6)
+            or (i % 6 > 0)) then -- end position of the garbage is not valid (needs to be at the end of a row)
+            errMessage = errMessage ..
+            "\nPuzzlestring contains invalid garbage notation, make sure to enter a valid length for chain type garbage, creating garbage that is  possible to encounter in the game."
+          end
+        else -- combo garbage
+          if math.floor((i - 1) / 6) ~= math.floor(pendingGarbageStartIndex / 6) then
+            errMessage = errMessage ..
+            "\nPuzzlestring contains invalid garbage notation, make sure that your combo garbage does not extend over the scope of a single row."
+          end
+        end
         -- garbage has been properly closed - most likely
         pendingGarbageStart = nil
     end

--- a/Puzzle.lua
+++ b/Puzzle.lua
@@ -2,13 +2,10 @@
 -- A puzzle is a particular instance of the game, where there is a specific goal for clearing the panels
 Puzzle =
   class(
-  function(self, puzzleType, doCountdown, moves, stack, name, hint)
+  function(self, puzzleType, doCountdown, moves, stack)
     self.puzzleType = puzzleType
     self.doCountdown = doCountdown
     self.moves = moves
     self.stack = stack
-    self.name = name
-    self.hint = hint
-    self.replay = replay
   end
 )

--- a/Puzzle.lua
+++ b/Puzzle.lua
@@ -2,10 +2,13 @@
 -- A puzzle is a particular instance of the game, where there is a specific goal for clearing the panels
 Puzzle =
   class(
-  function(self, puzzleType, doCountdown, moves, stack)
+  function(self, puzzleType, doCountdown, moves, stack, name, hint)
     self.puzzleType = puzzleType
     self.doCountdown = doCountdown
     self.moves = moves
     self.stack = stack
+    self.name = name
+    self.hint = hint
+    self.replay = replay
   end
 )

--- a/PuzzleTests.lua
+++ b/PuzzleTests.lua
@@ -58,6 +58,22 @@ function PuzzleTests.validationGarbageCoherence2()
   assert(string.match(validationMessage, "invalid garbage notation"))
 end
 
+function PuzzleTests.validationGarbageCoherence3()
+  local puzzle = Puzzle("moves", false, 2, "{====}929999[======]040000224999949999")
+  local isValid, validationMessage = puzzle:validate()
+
+  assert(not isValid)
+  assert(string.match(validationMessage, "length"))
+end
+
+function PuzzleTests.validationGarbageCoherence4()
+  local puzzle = Puzzle("moves", false, 2, "9299[===]99040000224999949999")
+  local isValid, validationMessage = puzzle:validate()
+
+  assert(not isValid)
+  assert(string.match(validationMessage, "extend"))
+end
+
 function PuzzleTests.validationValid()
   local puzzle = Puzzle("moves", false, 2, "{====}929999[====]040000224999949999")
   local isValid, validationMessage = puzzle:validate()
@@ -73,4 +89,6 @@ PuzzleTests.validationStackLength()
 PuzzleTests.validationStackCharacters()
 PuzzleTests.validationGarbageCoherence1()
 PuzzleTests.validationGarbageCoherence2()
+PuzzleTests.validationGarbageCoherence3()
+PuzzleTests.validationGarbageCoherence4()
 PuzzleTests.validationValid()

--- a/PuzzleTests.lua
+++ b/PuzzleTests.lua
@@ -1,0 +1,76 @@
+require("puzzles")
+
+local PuzzleTests = class(function() end)
+
+function PuzzleTests.validationCountdown()
+  local puzzle = Puzzle("moves", "idc", "5", "1254216999999952")
+  local isValid, validationMessage = puzzle:validate()
+
+  assert(not isValid)
+  assert(string.match(validationMessage, "doCountdown"))
+end
+
+function PuzzleTests.validationPuzzleType()
+  local puzzle = Puzzle("garbageGoal", false, "5", "1254216999999952")
+  local isValid, validationMessage = puzzle:validate()
+
+  assert(not isValid)
+  assert(string.match(validationMessage, "puzzle type"))
+end
+
+function PuzzleTests.validationMoves()
+  local puzzle = Puzzle("moves", false, 0, "1254216999999952")
+  local isValid, validationMessage = puzzle:validate()
+
+  assert(not isValid)
+  assert(string.match(validationMessage, "expecting a number greater than zero"))
+end
+
+function PuzzleTests.validationStackCharacters()
+  local puzzle = Puzzle("moves", false, 3, "12542169999f9952")
+  local isValid, validationMessage = puzzle:validate()
+
+  assert(not isValid)
+  assert(string.match(validationMessage, "invalid characters: f"))
+end
+
+function PuzzleTests.validationStackLength()
+  local puzzle = Puzzle("moves", false, 2, "1254216999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999952")
+  local isValid, validationMessage = puzzle:validate()
+
+  assert(not isValid)
+  assert(string.match(validationMessage, "Maximum allowed"))
+end
+
+function PuzzleTests.validationGarbageCoherence1()
+  local puzzle = Puzzle("moves", false, 2, "929999[==========}040000224999949999")
+  local isValid, validationMessage = puzzle:validate()
+
+  assert(not isValid)
+  assert(string.match(validationMessage, "invalid garbage notation"))
+end
+
+function PuzzleTests.validationGarbageCoherence2()
+  local puzzle = Puzzle("moves", false, 2, "929999[====[====]]040000224999949999")
+  local isValid, validationMessage = puzzle:validate()
+
+  assert(not isValid)
+  assert(string.match(validationMessage, "invalid garbage notation"))
+end
+
+function PuzzleTests.validationValid()
+  local puzzle = Puzzle("moves", false, 2, "{====}929999[====]040000224999949999")
+  local isValid, validationMessage = puzzle:validate()
+
+  assert(isValid)
+  assert(validationMessage == "")
+end
+
+PuzzleTests.validationCountdown()
+PuzzleTests.validationPuzzleType()
+PuzzleTests.validationMoves()
+PuzzleTests.validationStackLength()
+PuzzleTests.validationStackCharacters()
+PuzzleTests.validationGarbageCoherence1()
+PuzzleTests.validationGarbageCoherence2()
+PuzzleTests.validationValid()

--- a/StackTests.lua
+++ b/StackTests.lua
@@ -8,7 +8,7 @@ stack:wait_for_random_character()
 pick_random_stage()
 
 assert(characters ~= nil, "no characters")
-stack:set_puzzle_state("011010", 1)
+stack:set_puzzle_state(Puzzle(nil, nil, 1, "011010"))
 
 assert(stack.panels[1][1].color == 0, "wrong color")
 assert(stack.panels[1][2].color == 1, "wrong color")

--- a/engine.lua
+++ b/engine.lua
@@ -583,22 +583,19 @@ function Panel.clear_flags(self)
   self.state = "normal"
 end
 
-function Stack.set_puzzle_state(self, puzzleString, n_turns, do_countdown, puzzleType)
+function Stack.set_puzzle_state(self, puzzle)
   -- Copy the puzzle into our state
   self:setLevel(5)
-  puzzleType = puzzleType or "moves"
-  do_countdown = do_countdown or false
-  puzzleString = string.gsub(puzzleString, "%s+", "") -- Remove whitespace so files can be easier to read
   local boardSizeInPanels = self.width * self.height
-  while string.len(puzzleString) < boardSizeInPanels do
-    puzzleString = "0" .. puzzleString
+  while string.len(puzzle.stack) < boardSizeInPanels do
+    puzzle.stack = "0" .. puzzle.stack
   end
 
-  self.panels = self:puzzleStringToPanels(puzzleString)
-  self.do_countdown = do_countdown
-  self.puzzleType = puzzleType
-  if n_turns ~= 0 then
-    self.puzzle_moves = n_turns
+  self.panels = self:puzzleStringToPanels(puzzle.stack)
+  self.do_countdown = puzzle.do_countdown or false
+  self.puzzleType = puzzle.puzzleType or "moves"
+  if puzzle.moves ~= 0 then
+    self.puzzle_moves = puzzle.moves
   end
 
   -- transform any cleared garbage into colorless garbage panels

--- a/engine.lua
+++ b/engine.lua
@@ -602,6 +602,10 @@ function Stack.set_puzzle_state(self, pstr, n_turns, do_countdown, puzzleType)
   if n_turns ~= 0 then
     self.puzzle_moves = n_turns
   end
+
+  -- transform any cleared garbage into colorles garbage panels
+  self.gpanel_buffer = "9999999999999999999999999999999999999999999999999999999999999999999999999"
+
 end
 
 function Stack.puzzle_done(self)

--- a/main.lua
+++ b/main.lua
@@ -1,3 +1,12 @@
+local launch_type = arg[2]
+if launch_type == "test" or launch_type == "debug" then
+    require "lldebugger"
+    TESTS_ENABLED = 1
+    if launch_type == "debug" then
+        lldebugger.start()
+    end
+end
+
 require("class")
 socket = require("socket")
 json = require("dkjson")

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -76,6 +76,7 @@ function fmainloop()
   -- Run Unit Tests
   if TESTS_ENABLED then
     -- Run all unit tests now that we have everything loaded
+    require("PuzzleTests")
     require("ServerQueueTests")
     require("StackTests")
     require("table_util_tests")
@@ -1439,8 +1440,15 @@ function make_main_puzzle(puzzleSet, awesome_idx)
     if awesome_idx == nil then
       awesome_idx = math.random(#puzzleSet.puzzles)
     end
-    local puzzleDetails = puzzleSet.puzzles[awesome_idx]
-    P1:set_puzzle_state(puzzleDetails.stack, puzzleDetails.moves, puzzleDetails.doCountdown, puzzleDetails.puzzleType)
+    local puzzle = puzzleSet.puzzles[awesome_idx]
+    local isValid, validationError = puzzle:validate()
+    if isValid then
+      P1:set_puzzle_state(puzzle)
+    else
+      validationError = "Validation error in puzzle set " .. puzzleSet.setName .. "\n"
+                        .. validationError
+      return main_dumb_transition, {main_select_mode, validationError, 60, -1}
+    end
 
     local function update() 
     end

--- a/readme_puzzles.txt
+++ b/readme_puzzles.txt
@@ -70,9 +70,11 @@ About the numbers mapping out each puzzle now:
 
 Panel Attack reads the numbers that represent what each panel's color should be from right to left,
 filling the play field with panels starting at the bottom right corner, from right to left, bottom to top.
+Additionally there exists a special notation for representing connected garbage blocks.
 
 This allows us to lay out our text representation of the puzzle how it would look in the game, like this:
 
+[====]
 001200
 002100
 002100
@@ -90,3 +92,8 @@ panel colors:
 7 = orange (not really used in the game so far, but it exists)
 8 = exclamation block [!]
 9 = block with no color (dark grey, doesn't match with anything)
+[ = top left corner of a combo / chain garbage block
+] = bottom right corner of a combo / chain garbage block
+{ = left end of a shock garbage block
+} = right end of a shock garbage block
+= = filler space to determine the size of the garbage block indicated by the surrounding []{}


### PR DESCRIPTION
Enable use of garbage tiles in puzzles through use of the [====] {====} syntax as proposed in #193 
I'm a bit unsure why I needed to explicitly set the level again but the garbage panel hover time wasn't set if I didn't and I suppose it's a decent method extraction anyway.
