### PR TITLE
Fix shock garbage generation

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -2446,8 +2446,13 @@ function Stack.check_matches(self)
 
   if (combo_size ~= 0) then
     self.combos[self.CLOCK] = combo_size
-    if self.garbage_target and self.telegraph and metal_count == 3 and combo_size >= 3 then
-      self.telegraph:push({6, 1, true, false}, first_panel_col, first_panel_row, self.CLOCK)
+    if self.garbage_target and self.telegraph then
+      if metal_count >= 3 then
+        -- Give a shock garbage for every shock block after 2
+        for i = 3, metal_count do
+          self.telegraph:push({6, 1, true, false}, first_panel_col, first_panel_row, self.CLOCK)
+        end
+      end
     end
     self.analytic:register_destroyed_panels(combo_size)
     if (combo_size > 3) then
@@ -2466,16 +2471,11 @@ function Stack.check_matches(self)
 
       self:enqueue_card(false, first_panel_col, first_panel_row, combo_size)
       if self.garbage_target and self.telegraph then
-        if metal_count > 3 then
-          for i = 3, metal_count do
-            self.telegraph:push({6, 1, true, false}, first_panel_col, first_panel_row, self.CLOCK)
-          end
-        end
-        if metal_count ~= combo_size then
-          local combo_pieces = combo_garbage[combo_size]
-          for i=1,#combo_pieces do
-            self.telegraph:push({combo_pieces[i], 1, false, false}, first_panel_col, first_panel_row, self.CLOCK)
-          end
+        local combo_pieces = combo_garbage[combo_size]
+        for i=1,#combo_pieces do
+          -- Give out combo garbage based on the lookup table, even if we already made shock garbage,
+          -- OP! Too bad its hard to get shock panels in vs. :)
+          self.telegraph:push({combo_pieces[i], 1, false, false}, first_panel_col, first_panel_row, self.CLOCK)
         end
       end
       --EnqueueConfetti(first_panel_col<<4+P1StackPosX+4,


### PR DESCRIPTION
As a part of refactoring for training mode, we accidentally made it so doing shock only combos doesn't make the corresponding normal combo garbage as well.

Combos should always generate garbage, and shock should make one shock garbage per panel after 2.