### PR TITLE
Improve menu layout

### DIFF
--- a/click_menu.lua
+++ b/click_menu.lua
@@ -13,6 +13,7 @@ Click_menu =
     self.x = xCenter
     self.y = yMin
     self.yMin = yMin
+    self.centerVertically = themes[config.theme].centerMenusVertically
     self.current_setting_x = nil -- the x offset for the second column of options
     local defaultPadding = 30
     self.width = width or 0
@@ -167,6 +168,13 @@ function Click_menu.set_active_idx(self, idx)
   self:layout_buttons()
 end
 
+-- Sets a new height and resizes the menu
+function Click_menu.setHeight(self, maxHeight)
+  self.maxHeight = maxHeight
+  self:resize_to_fit()
+  self:layout_buttons()
+end
+
 -- Repositions in the x direction so the menu doesn't go off the screen
 function Click_menu.resize_to_fit(self)
   for k, v in pairs(self.buttons) do
@@ -209,7 +217,11 @@ function Click_menu.layout_buttons(self)
     end
   end
 
-  self.y = self.yMin + (self.maxHeight / 2) - (height / 2)
+  if self.centerVertically then
+    self.y = self.yMin + (self.maxHeight / 2) - (height / 2)
+  else
+    self.y = self.yMin
+  end
 
   self:show_controls(false)
 end

--- a/theme.lua
+++ b/theme.lua
@@ -751,6 +751,7 @@ function Theme:final_init()
   self.images.bg_readme = UpdatingImage(load_theme_img("background/readme"), self.bg_readme_is_tiled, self.bg_readme_speed_x, self.bg_readme_speed_y, canvas_width, canvas_height)
 
   local menuYPadding = 10
+  self.centerMenusVertically = true
   if themes[config.theme].images.bg_title then
     menuYPadding = 100
     self.main_menu_screen_pos = {532, menuYPadding}
@@ -758,6 +759,7 @@ function Theme:final_init()
   else
     self.main_menu_screen_pos = {532, 249}
     self.main_menu_y_max = canvas_height - menuYPadding
+    self.centerMenusVertically = false
   end
   self.main_menu_max_height = (self.main_menu_y_max - self.main_menu_screen_pos[2])
   self.main_menu_y_center = self.main_menu_screen_pos[2] + (self.main_menu_max_height / 2)


### PR DESCRIPTION
Include notice in menu height in the lobby to avoid wasting space and looking weird
make the notice easier to read on light backgrounds
dont center vertically for old themes with the image on the main menu