### PR TITLE
Fix Broken Stage Images

### DIFF
--- a/UpdatingImage.lua
+++ b/UpdatingImage.lua
@@ -34,8 +34,6 @@ function UpdatingImage:draw()
   if not self.tiled then   
     x_scale = self.width / self.image:getWidth()
     y_scale = self.height / self.image:getHeight()
-    gfx_q:push({love.graphics.draw, {self.image, 0, 0, 0, x_scale, y_scale}})
-  else
-    gfx_q:push({love.graphics.draw, {self.image, bg_quad, 0, 0, 0, x_scale, y_scale}})
   end
+  gfx_q:push({love.graphics.draw, {self.image, bg_quad, 0, 0, 0, x_scale, y_scale}})
 end

--- a/UpdatingImage.lua
+++ b/UpdatingImage.lua
@@ -29,9 +29,13 @@ function UpdatingImage:draw()
   -- note how the Quad's width and height are larger than the image width and height.
   local bg_quad = love.graphics.newQuad(x, y, self.width, self.height, self.image:getDimensions())
 
-  local scale = 1
+  local x_scale = 1
+  local y_scale = 1
   if not self.tiled then   
-    scale = self.width / math.max(self.image:getWidth(), self.image:getHeight()) -- keep image ratio
+    x_scale = self.width / self.image:getWidth()
+    y_scale = self.height / self.image:getHeight() -- keep image ratio
+    gfx_q:push({love.graphics.draw, {self.image, 0, 0, 0, x_scale, y_scale}})
+  else
+    gfx_q:push({love.graphics.draw, {self.image, bg_quad, 0, 0, 0, x_scale, y_scale}})
   end
-  gfx_q:push({love.graphics.draw, {self.image, bg_quad, 0, 0, 0, scale, scale}})
 end

--- a/UpdatingImage.lua
+++ b/UpdatingImage.lua
@@ -34,6 +34,8 @@ function UpdatingImage:draw()
   if not self.tiled then   
     x_scale = self.width / self.image:getWidth()
     y_scale = self.height / self.image:getHeight()
+    gfx_q:push({love.graphics.draw, {self.image, 0, 0, 0, x_scale, y_scale}})
+  else
+    gfx_q:push({love.graphics.draw, {self.image, bg_quad, 0, 0, 0, x_scale, y_scale}})
   end
-  gfx_q:push({love.graphics.draw, {self.image, bg_quad, 0, 0, 0, x_scale, y_scale}})
 end

--- a/UpdatingImage.lua
+++ b/UpdatingImage.lua
@@ -23,6 +23,12 @@ function UpdatingImage:update(dt)
 end
 
 function UpdatingImage:draw()
+  local x = math.floor(self.totalTime * self.speedX)
+  local y = math.floor(self.totalTime * -self.speedY)
+
+  -- note how the Quad's width and height are larger than the image width and height.
+  local bg_quad = love.graphics.newQuad(x, y, self.width, self.height, self.image:getDimensions())
+
   local x_scale = 1
   local y_scale = 1
   if not self.tiled then   
@@ -30,10 +36,6 @@ function UpdatingImage:draw()
     y_scale = self.height / self.image:getHeight()
     gfx_q:push({love.graphics.draw, {self.image, 0, 0, 0, x_scale, y_scale}})
   else
-    local x = math.floor(self.totalTime * self.speedX)
-    local y = math.floor(self.totalTime * -self.speedY)
-    -- note how the Quad's width and height are larger than the image width and height.
-    local bg_quad = love.graphics.newQuad(x, y, self.width, self.height, self.image:getDimensions())
     gfx_q:push({love.graphics.draw, {self.image, bg_quad, 0, 0, 0, x_scale, y_scale}})
   end
 end

--- a/UpdatingImage.lua
+++ b/UpdatingImage.lua
@@ -15,19 +15,24 @@ UpdatingImage =
     self.width = width or self.image:getWidth()
     self.height = height or self.image:getHeight()
     self.totalTime = 0
+    self.quad = nil
+    if self.tiled then
+      -- note how the Quad's width and height are larger than the image width and height.
+      self.quad = love.graphics.newQuad(0, 0, self.width, self.height, self.image:getDimensions())
+    end
   end
 )
 
 function UpdatingImage:update(dt)
   self.totalTime = self.totalTime + dt
+  if self.tiled then
+    local x = math.floor(self.totalTime * self.speedX)
+    local y = math.floor(self.totalTime * -self.speedY)
+    self.quad:setViewport(x, y, self.width, self.height, self.image:getDimensions())
+  end
 end
 
 function UpdatingImage:draw()
-  local x = math.floor(self.totalTime * self.speedX)
-  local y = math.floor(self.totalTime * -self.speedY)
-
-  -- note how the Quad's width and height are larger than the image width and height.
-  local bg_quad = love.graphics.newQuad(x, y, self.width, self.height, self.image:getDimensions())
 
   local x_scale = 1
   local y_scale = 1
@@ -36,6 +41,6 @@ function UpdatingImage:draw()
     y_scale = self.height / self.image:getHeight()
     gfx_q:push({love.graphics.draw, {self.image, 0, 0, 0, x_scale, y_scale}})
   else
-    gfx_q:push({love.graphics.draw, {self.image, bg_quad, 0, 0, 0, x_scale, y_scale}})
+    gfx_q:push({love.graphics.draw, {self.image, self.quad, 0, 0, 0, x_scale, y_scale}})
   end
 end

--- a/UpdatingImage.lua
+++ b/UpdatingImage.lua
@@ -33,7 +33,7 @@ function UpdatingImage:draw()
   local y_scale = 1
   if not self.tiled then   
     x_scale = self.width / self.image:getWidth()
-    y_scale = self.height / self.image:getHeight() -- keep image ratio
+    y_scale = self.height / self.image:getHeight()
     gfx_q:push({love.graphics.draw, {self.image, 0, 0, 0, x_scale, y_scale}})
   else
     gfx_q:push({love.graphics.draw, {self.image, bg_quad, 0, 0, 0, x_scale, y_scale}})

--- a/UpdatingImage.lua
+++ b/UpdatingImage.lua
@@ -23,12 +23,6 @@ function UpdatingImage:update(dt)
 end
 
 function UpdatingImage:draw()
-  local x = math.floor(self.totalTime * self.speedX)
-  local y = math.floor(self.totalTime * -self.speedY)
-
-  -- note how the Quad's width and height are larger than the image width and height.
-  local bg_quad = love.graphics.newQuad(x, y, self.width, self.height, self.image:getDimensions())
-
   local x_scale = 1
   local y_scale = 1
   if not self.tiled then   
@@ -36,6 +30,10 @@ function UpdatingImage:draw()
     y_scale = self.height / self.image:getHeight()
     gfx_q:push({love.graphics.draw, {self.image, 0, 0, 0, x_scale, y_scale}})
   else
+    local x = math.floor(self.totalTime * self.speedX)
+    local y = math.floor(self.totalTime * -self.speedY)
+    -- note how the Quad's width and height are larger than the image width and height.
+    local bg_quad = love.graphics.newQuad(x, y, self.width, self.height, self.image:getDimensions())
     gfx_q:push({love.graphics.draw, {self.image, bg_quad, 0, 0, 0, x_scale, y_scale}})
   end
 end

--- a/theme.lua
+++ b/theme.lua
@@ -747,7 +747,7 @@ function Theme:final_init()
   end
 
   self.images.bg_main = UpdatingImage(load_theme_img("background/main"), self.bg_main_is_tiled, self.bg_main_speed_x, self.bg_main_speed_y, canvas_width, canvas_height)
-  self.images.bg_select_screen = UpdatingImage(load_theme_img("background/select_screen"), self.bg_select_is_tiled, self.bg_select_speed_x, self.bg_select_speed_y, canvas_width, canvas_height)
+  self.images.bg_select_screen = UpdatingImage(load_theme_img("background/select_screen"), self.bg_select_screen_is_tiled, self.bg_select_speed_x, self.bg_select_speed_y, canvas_width, canvas_height)
   self.images.bg_readme = UpdatingImage(load_theme_img("background/readme"), self.bg_readme_is_tiled, self.bg_readme_speed_x, self.bg_readme_speed_y, canvas_width, canvas_height)
 
   local menuYPadding = 10


### PR DESCRIPTION
This bug fixes images that are larger than the canvas. Those images would not be fully drawn onto the canvas prior to the fix.
![screenshot_v046-2022-06-07-23-24-27](https://user-images.githubusercontent.com/18148657/172499910-d5d4cd37-2751-4ce4-9c0f-c013cc85d068.png)
