### PR TITLE
Save window state in config

### DIFF
--- a/input.lua
+++ b/input.lua
@@ -219,7 +219,14 @@ end
 function love.keypressed(key, scancode, rep)
   local function handleFullscreenToggle()
     if key == "return" and not rep and love.keyboard.isDown("lalt") then
-      love.window.setFullscreen(not love.window.getFullscreen(), "desktop")
+      local fullscreen, fullscreenmode = love.window.getFullscreen()
+      if not fullscreen then
+        love.window.setFullscreen(true, "desktop")
+      elseif fullscreenmode == "desktop" then
+        love.window.setFullscreen(true, "exclusive")
+      else
+        love.window.setFullscreen(false)
+      end
       return true
     end
   end

--- a/input.lua
+++ b/input.lua
@@ -219,14 +219,7 @@ end
 function love.keypressed(key, scancode, rep)
   local function handleFullscreenToggle()
     if key == "return" and not rep and love.keyboard.isDown("lalt") then
-      local fullscreen, fullscreenmode = love.window.getFullscreen()
-      if not fullscreen then
-        love.window.setFullscreen(true, "desktop")
-      elseif fullscreenmode == "desktop" then
-        love.window.setFullscreen(true, "exclusive")
-      else
-        love.window.setFullscreen(false)
-      end
+      love.window.setFullscreen(not love.window.getFullscreen(), "desktop")
       return true
     end
   end

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -38,13 +38,14 @@ end
 
 function fmainloop()
   read_conf_file()
-  local x, y, display = love.window.getPosition()
+  local width, height, current = love.window.getMode()
+
   -- config.window_x etc. for migration support
   if config.window then
-    love.window.updateMode(config.window.width or 0, config.window.height or 0,
-                          {x = config.window.x or config.window_x or x,
-                           y = config.window.y or config.window_y or y,
-                           display = config.window.display or config.display or display,
+    love.window.updateMode(config.window.width or width, config.window.height or height,
+                          {x = config.window.x or config.window_x or current.x,
+                           y = config.window.y or config.window_y or current.y,
+                           display = config.window.display or config.display or current.display,
                            fullscreen = config.window.fullscreen or config.fullscreen or false,
                            fullscreentype = config.window.fullscreentype or "desktop",
                            vsync = config.vsync and 1 or 0})
@@ -52,12 +53,16 @@ function fmainloop()
       love.window.maximize()
     end
   else
-    love.window.updateMode(0, 0, -- width/height zero causes the game to use the full desktop
-                          {x = config.window_x or x,
-                           y = config.window_y or y,
-                           display = config.display or display,
+    love.window.updateMode(width, height,
+                          {x = config.window_x or current.x,
+                           y = config.window_y or current.y,
+                           display = config.display or current.display,
                            fullscreen = config.fullscreen or false,
                            vsync = config.vsync and 1 or 0})
+    if config.firstStartup then
+      --have a reasonable resolution on first startup while ignoring OS specifics like title/task bar height
+      love.window.maximize()
+    end
   end
 
   Localization.init(localization)
@@ -2091,6 +2096,7 @@ function love.quit()
     json_send({logout = true})
   end
   love.audio.stop()
+
   local width, height, settings = love.window.getMode()
   settings.width = width
   settings.height = height
@@ -2098,5 +2104,6 @@ function love.quit()
   --don't let 'y' be zero, or the title bar will not be visible on next launch.
   config.window.y = math.max(config.window.y, 30)
   config.window.maximized = love.window.isMaximized()
+
   write_conf_file()
 end

--- a/save.lua
+++ b/save.lua
@@ -74,164 +74,168 @@ function read_conf_file()
       -- config current values are defined in globals.lua,
       -- we consider those values are currently in config
 
-      local file = love.filesystem.newFile("conf.json")
-      file:open("r")
-      local read_data = {}
-      local teh_json = file:read(file:getSize())
-      for k, v in pairs(json.decode(teh_json)) do
-        read_data[k] = v
-      end
-
-      -- do stuff using read_data.version for retrocompatibility here
-
-      if type(read_data.theme) == "string" and love.filesystem.getInfo("themes/" .. read_data.theme) then
-        config.theme = read_data.theme
-      end
-
-      -- language_code, panels, character and stage are patched later on by their own subsystems, we store their values in config for now!
-      if type(read_data.language_code) == "string" then
-        config.language_code = read_data.language_code
-      end
-      if type(read_data.panels) == "string" then
-        config.panels = read_data.panels
-      end
-      if type(read_data.character) == "string" then
-        config.character = read_data.character
-      end
-      if type(read_data.stage) == "string" then
-        config.stage = read_data.stage
-      end
-
-      if type(read_data.ranked) == "boolean" then
-        config.ranked = read_data.ranked
-      end
-
-      if type(read_data.vsync) == "boolean" then
-        config.vsync = read_data.vsync
-      end
-
-      if type(read_data.use_music_from) == "string" and use_music_from_values[read_data.use_music_from] then
-        config.use_music_from = read_data.use_music_from
-      end
-
-      if type(read_data.level) == "number" then
-        config.level = bound(1, read_data.level, 10)
-      end
-      if type(read_data.endless_speed) == "number" then
-        config.endless_speed = bound(1, read_data.endless_speed, 99)
-      end
-      if type(read_data.endless_difficulty) == "number" then
-        config.endless_difficulty = bound(1, read_data.endless_difficulty, 3)
-      end
-      if type(read_data.endless_level) == "number" then
-        config.endless_level = bound(1, read_data.endless_level, 11)
-      end
-      if type(read_data.puzzle_level) == "number" then
-        config.puzzle_level = bound(1, read_data.puzzle_level, 11)
-      end
-      if type(read_data.puzzle_randomColors) == "boolean" then
-        config.puzzle_randomColors = read_data.puzzle_randomColors
-      end
-
-      if type(read_data.name) == "string" then
-        config.name = read_data.name
-      end
-
-      if type(read_data.master_volume) == "number" then
-        config.master_volume = bound(0, read_data.master_volume, 100)
-      end
-      if type(read_data.SFX_volume) == "number" then
-        config.SFX_volume = bound(0, read_data.SFX_volume, 100)
-      end
-      if type(read_data.music_volume) == "number" then
-        config.music_volume = bound(0, read_data.music_volume, 100)
-      end
-      if type(read_data.input_repeat_delay) == "number" then
-        config.input_repeat_delay = bound(1, read_data.input_repeat_delay, 50)
-      end
-      if type(read_data.portrait_darkness) == "number" then
-        config.portrait_darkness = bound(0, read_data.portrait_darkness, 100)
-      end
-      if type(read_data.cardfx_scale) == "number" then
-        config.cardfx_scale = bound(1, read_data.cardfx_scale, 200)
-      end
-
-      if type(read_data.debug_mode) == "boolean" then
-        config.debug_mode = read_data.debug_mode
-      end
-      if type(read_data.show_fps) == "boolean" then
-        config.show_fps = read_data.show_fps
-      end
-      if type(read_data.show_ingame_infos) == "boolean" then
-        config.show_ingame_infos = read_data.show_ingame_infos
-      end
-      if type(read_data.ready_countdown_1P) == "boolean" then
-        config.ready_countdown_1P = read_data.ready_countdown_1P
-      end
-      if type(read_data.danger_music_changeback_delay) == "boolean" then
-        config.danger_music_changeback_delay = read_data.danger_music_changeback_delay
-      end
-      if type(read_data.enable_analytics) == "boolean" then
-        config.enable_analytics = read_data.enable_analytics
-      end
-      if type(read_data.popfx) == "boolean" then
-        config.popfx = read_data.popfx
-      end
-      if type(read_data.renderTelegraph) == "boolean" then
-        config.renderTelegraph = read_data.renderTelegraph
-      end
-      if type(read_data.renderAttacks) == "boolean" then
-        config.renderAttacks = read_data.renderAttacks
-      end
-
-      if type(read_data.save_replays_publicly) == "string" and save_replays_values[read_data.save_replays_publicly] then
-        config.save_replays_publicly = read_data.save_replays_publicly
-      end
-
-      if type(read_data.window_x) == "number" then
-        config.window_x = read_data.window_x
-      end
-      if type(read_data.window_y) == "number" then
-        config.window_y = read_data.window_y
-      end
-      if type(read_data.display) == "number" then
-        config.display = read_data.display
-      end
-      if type(read_data.fullscreen) == "boolean" then
-        config.fullscreen = read_data.fullscreen
-      end
-      if type(read_data.defaultPanelsCopied) == "boolean" then
-        config.defaultPanelsCopied = read_data.defaultPanelsCopied
-      end
-      if type(read_data.window) == "table" then
-        config.window = {}
-        if type(read_data.window.x) == "number" then
-          config.window.x = read_data.window.x
+      if love.filesystem.getInfo("conf.json") == nil then
+        config.firstStartup = true
+      else
+        local file = love.filesystem.newFile("conf.json")
+        file:open("r")
+        local read_data = {}
+        local teh_json = file:read(file:getSize())
+        for k, v in pairs(json.decode(teh_json)) do
+          read_data[k] = v
         end
-        if type(read_data.window.y) == "number" then
-          config.window.y = read_data.window.y
+  
+        -- do stuff using read_data.version for retrocompatibility here
+  
+        if type(read_data.theme) == "string" and love.filesystem.getInfo("themes/" .. read_data.theme) then
+          config.theme = read_data.theme
         end
-        if type(read_data.window.width) == "number" then
-          config.window.width = read_data.window.width
+  
+        -- language_code, panels, character and stage are patched later on by their own subsystems, we store their values in config for now!
+        if type(read_data.language_code) == "string" then
+          config.language_code = read_data.language_code
         end
-        if type(read_data.window.height) == "number" then
-          config.window.height = read_data.window.height
+        if type(read_data.panels) == "string" then
+          config.panels = read_data.panels
         end
-        if type(read_data.window.display) == "number" then
-          config.window.display = read_data.window.display
+        if type(read_data.character) == "string" then
+          config.character = read_data.character
         end
-        if type(read_data.window.fullscreen) == "boolean" then
-          config.window.fullscreen = read_data.window.fullscreen
+        if type(read_data.stage) == "string" then
+          config.stage = read_data.stage
         end
-        if type(read_data.window.fullscreentype) == "string" then
-          config.window.fullscreentype = read_data.window.fullscreentype
+  
+        if type(read_data.ranked) == "boolean" then
+          config.ranked = read_data.ranked
         end
-        if type(read_data.window.maximized) == "boolean" then
-          config.window.maximized = read_data.window.maximized
+  
+        if type(read_data.vsync) == "boolean" then
+          config.vsync = read_data.vsync
         end
+  
+        if type(read_data.use_music_from) == "string" and use_music_from_values[read_data.use_music_from] then
+          config.use_music_from = read_data.use_music_from
+        end
+  
+        if type(read_data.level) == "number" then
+          config.level = bound(1, read_data.level, 10)
+        end
+        if type(read_data.endless_speed) == "number" then
+          config.endless_speed = bound(1, read_data.endless_speed, 99)
+        end
+        if type(read_data.endless_difficulty) == "number" then
+          config.endless_difficulty = bound(1, read_data.endless_difficulty, 3)
+        end
+        if type(read_data.endless_level) == "number" then
+          config.endless_level = bound(1, read_data.endless_level, 11)
+        end
+        if type(read_data.puzzle_level) == "number" then
+          config.puzzle_level = bound(1, read_data.puzzle_level, 11)
+        end
+        if type(read_data.puzzle_randomColors) == "boolean" then
+          config.puzzle_randomColors = read_data.puzzle_randomColors
+        end
+  
+        if type(read_data.name) == "string" then
+          config.name = read_data.name
+        end
+  
+        if type(read_data.master_volume) == "number" then
+          config.master_volume = bound(0, read_data.master_volume, 100)
+        end
+        if type(read_data.SFX_volume) == "number" then
+          config.SFX_volume = bound(0, read_data.SFX_volume, 100)
+        end
+        if type(read_data.music_volume) == "number" then
+          config.music_volume = bound(0, read_data.music_volume, 100)
+        end
+        if type(read_data.input_repeat_delay) == "number" then
+          config.input_repeat_delay = bound(1, read_data.input_repeat_delay, 50)
+        end
+        if type(read_data.portrait_darkness) == "number" then
+          config.portrait_darkness = bound(0, read_data.portrait_darkness, 100)
+        end
+        if type(read_data.cardfx_scale) == "number" then
+          config.cardfx_scale = bound(1, read_data.cardfx_scale, 200)
+        end
+  
+        if type(read_data.debug_mode) == "boolean" then
+          config.debug_mode = read_data.debug_mode
+        end
+        if type(read_data.show_fps) == "boolean" then
+          config.show_fps = read_data.show_fps
+        end
+        if type(read_data.show_ingame_infos) == "boolean" then
+          config.show_ingame_infos = read_data.show_ingame_infos
+        end
+        if type(read_data.ready_countdown_1P) == "boolean" then
+          config.ready_countdown_1P = read_data.ready_countdown_1P
+        end
+        if type(read_data.danger_music_changeback_delay) == "boolean" then
+          config.danger_music_changeback_delay = read_data.danger_music_changeback_delay
+        end
+        if type(read_data.enable_analytics) == "boolean" then
+          config.enable_analytics = read_data.enable_analytics
+        end
+        if type(read_data.popfx) == "boolean" then
+          config.popfx = read_data.popfx
+        end
+        if type(read_data.renderTelegraph) == "boolean" then
+          config.renderTelegraph = read_data.renderTelegraph
+        end
+        if type(read_data.renderAttacks) == "boolean" then
+          config.renderAttacks = read_data.renderAttacks
+        end
+  
+        if type(read_data.save_replays_publicly) == "string" and save_replays_values[read_data.save_replays_publicly] then
+          config.save_replays_publicly = read_data.save_replays_publicly
+        end
+  
+        if type(read_data.window_x) == "number" then
+          config.window_x = read_data.window_x
+        end
+        if type(read_data.window_y) == "number" then
+          config.window_y = read_data.window_y
+        end
+        if type(read_data.display) == "number" then
+          config.display = read_data.display
+        end
+        if type(read_data.fullscreen) == "boolean" then
+          config.fullscreen = read_data.fullscreen
+        end
+        if type(read_data.defaultPanelsCopied) == "boolean" then
+          config.defaultPanelsCopied = read_data.defaultPanelsCopied
+        end
+        if type(read_data.window) == "table" then
+          config.window = {}
+          if type(read_data.window.x) == "number" then
+            config.window.x = read_data.window.x
+          end
+          if type(read_data.window.y) == "number" then
+            config.window.y = read_data.window.y
+          end
+          if type(read_data.window.width) == "number" then
+            config.window.width = read_data.window.width
+          end
+          if type(read_data.window.height) == "number" then
+            config.window.height = read_data.window.height
+          end
+          if type(read_data.window.display) == "number" then
+            config.window.display = read_data.window.display
+          end
+          if type(read_data.window.fullscreen) == "boolean" then
+            config.window.fullscreen = read_data.window.fullscreen
+          end
+          if type(read_data.window.fullscreentype) == "string" then
+            config.window.fullscreentype = read_data.window.fullscreentype
+          end
+          if type(read_data.window.maximized) == "boolean" then
+            config.window.maximized = read_data.window.maximized
+          end
+        end
+  
+        file:close()
       end
-
-      file:close()
     end
   )
 end

--- a/save.lua
+++ b/save.lua
@@ -203,6 +203,33 @@ function read_conf_file()
       if type(read_data.defaultPanelsCopied) == "boolean" then
         config.defaultPanelsCopied = read_data.defaultPanelsCopied
       end
+      if type(read_data.window) == "table" then
+        config.window = {}
+        if type(read_data.window.x) == "number" then
+          config.window.x = read_data.window.x
+        end
+        if type(read_data.window.y) == "number" then
+          config.window.y = read_data.window.y
+        end
+        if type(read_data.window.width) == "number" then
+          config.window.width = read_data.window.width
+        end
+        if type(read_data.window.height) == "number" then
+          config.window.height = read_data.window.height
+        end
+        if type(read_data.window.display) == "number" then
+          config.window.display = read_data.window.display
+        end
+        if type(read_data.window.fullscreen) == "boolean" then
+          config.window.fullscreen = read_data.window.fullscreen
+        end
+        if type(read_data.window.fullscreentype) == "string" then
+          config.window.fullscreentype = read_data.window.fullscreentype
+        end
+        if type(read_data.window.maximized) == "boolean" then
+          config.window.maximized = read_data.window.maximized
+        end
+      end
 
       file:close()
     end


### PR DESCRIPTION
Solves #549 
While I was at it I also included true fullscreen support, meaning that by pressing Left Alt+Enter you now cycle through windowed, windowed borderless fullscreen and (exclusive) fullscreen.
I think using exclusive fullscreen may or may not be helpful for people on toasters like Zack.
Right now there is no perceivable difference between windowed borderless and exclusive fullscreen until you alt+tab so there should be a notification be displayed later on (#531)

Additionally I also reviewed the behaviour on first startup with regards to #549 because I felt it would be good if the game started in a workable size right away so the game will try to maximize itself now if there is no `conf.json` to be found. This is tracked in the new field `config.firstStartup` that we could utilize for future first startup shenanigans later on (e.g. directing them directly to the key configuration, maybe displaying a page that gives an overview what there is to discover, offering to enter the tutorial if they are new etc.)

I tested this on Windows and Linux Ubuntu, would be great if you could verify the functionality on Mac @JamesVanBoxtel 