### PR TITLE
Enabled externalStorage for Android

### DIFF
--- a/auto_updater/conf.lua
+++ b/auto_updater/conf.lua
@@ -4,7 +4,7 @@ function love.conf(t)
     t.version = "11.3"                  -- The LÖVE version this game was made for (string)
     t.console = false                   -- Attach a console (boolean, Windows only)
     t.accelerometerjoystick = false      -- Enable the accelerometer on iOS and Android by exposing it as a Joystick (boolean)
-    t.externalstorage = false           -- True to save files (and read from the save directory) in external storage on Android (boolean) 
+    t.externalstorage = true           -- True to save files (and read from the save directory) in external storage on Android (boolean), greatly facilitates installing mod on Android
     t.gammacorrect = false              -- Enable gamma-correct rendering, when supported by the system (boolean)
  
     t.audio.mic = false                 -- Request and use microphone capabilities in Android (boolean)

--- a/conf.lua
+++ b/conf.lua
@@ -9,7 +9,7 @@ function love.conf(t)
   t.version = "11.3" -- The LÖVE version this game was made for (string)
   t.console = false -- Attach a console (boolean, Windows only)
   t.accelerometerjoystick = false -- Enable the accelerometer on iOS and Android by exposing it as a Joystick (boolean)
-  t.externalstorage = false -- True to save files (and read from the save directory) in external storage on Android (boolean)
+  t.externalstorage = true -- True to save files (and read from the save directory) in external storage on Android (boolean), greatly facilitates installing mod on Android
   t.gammacorrect = false -- Enable gamma-correct rendering, when supported by the system (boolean)
 
   t.audio.mic = false -- Request and use microphone capabilities in Android (boolean)


### PR DESCRIPTION
We discussed this in the Portable Mode thread in #feature-suggestions.
With external storage enabled, PA uses an exposed directory the user can write in which allows for the traditional way of installing mods instead of baking them into the panel-attack.zip and having the game move them into the protected folder where they are being installed right now.
As mentioned in the thread, I can confirm this to be working on my (non-rooted) device.

Should notify Android users in patch notes that they might have to reinstall / move their mods upon rolling out this version. I'm going to test the exact behaviour a bit more so we can make a definitive statement about it and change this PR from draft to an actual PR once I have a user recommendation.