### PR TITLE
rewrote leaderboard loop using ipairs and set rank by username comparison

### DIFF
--- a/mainloop.lua
+++ b/mainloop.lua
@@ -1057,9 +1057,10 @@ function main_net_vs_lobby()
           lobby_menu:show_controls(true)
         end
         leaderboard_report = msg.leaderboard_report
-        for key, value in ipairs(leaderboard_report) do
-          if value.user_name == config.name then
-            my_rank = key
+        for rank = #leaderboard_report, 1, -1 do
+          local user = leaderboard_report[rank]
+          if user.user_name == config.name then
+            my_rank = rank
           end
         end
         leaderboard_first_idx_to_show = math.max((my_rank or 1) - 8, 1)

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -1057,10 +1057,9 @@ function main_net_vs_lobby()
           lobby_menu:show_controls(true)
         end
         leaderboard_report = msg.leaderboard_report
-        for i = #leaderboard_report, 1, -1 do
-          local v = leaderboard_report[i]
-          if v.is_you then
-            my_rank = k
+        for key, value in ipairs(leaderboard_report) do
+          if value.user_name == config.name then
+            my_rank = key
           end
         end
         leaderboard_first_idx_to_show = math.max((my_rank or 1) - 8, 1)


### PR DESCRIPTION
## What

In this PR I rewrote the leader board loop that searches for the players ranks before displaying the report, and then picks the players rank based on their username

## Why

on inspection, the loop wasn't behaving as expected. so I rewrote it using `ipairs()` which is recommended for array iteration by lua's documentation. I also changed the condition for picking the rank to rely on the user_name as `is_you` data wasn't present in testing, and `is_you` looks needlessly intense for incoming data.

This relates to the first Item [here [Discord]](https://discord.com/channels/196674532491132937/936779157889777694/982408738260529212)