### PR TITLE
Clear puzzle hotfix

### DIFF
--- a/Puzzle.lua
+++ b/Puzzle.lua
@@ -43,11 +43,19 @@ function Puzzle.validate(self)
     errMessage = "\nInvalid value for property 'doCountdown'"
   end
 
-  if string.len(self.stack) > 6*12 then
-    errMessage = errMessage ..
-     "\nPuzzlestring contains more panels than the playfield can contain." ..
-     "\nNumber of panels: " .. string.len(self.stack) ..
-     "\nMaximum allowed: " .. 6*12
+  local stackLength = string.len(self.stack)
+  if stackLength > 6*12 then
+    -- any encoded panels extending beyond the height of the playfield need to be garbage or empty
+    local overflowStack = self.stack:sub(1, stackLength - 72)
+    local matches = {}
+    for match in string.gmatch(overflowStack, "[1-9]") do
+      matches[#matches+1] = match
+    end
+    if #matches > 0 then
+      errMessage = errMessage ..
+     "\nThere cannot be any panels on above the top of the stack, only garbage and whitespace." ..
+     "\nPanels above the top identified: " .. table.concat(matches)
+    end
   end
 
   local illegalCharacters = {}

--- a/PuzzleTests.lua
+++ b/PuzzleTests.lua
@@ -39,7 +39,14 @@ function PuzzleTests.validationStackLength()
   local isValid, validationMessage = puzzle:validate()
 
   assert(not isValid)
-  assert(string.match(validationMessage, "Maximum allowed"))
+  assert(string.match(validationMessage, "Panels above the top"))
+end
+
+function PuzzleTests.validationStackLength2()
+  local puzzle = Puzzle("clear", false, 3, "[==================================]000060500014600011300024502542203135466243")
+  local isValid = puzzle:validate()
+
+  assert(isValid)
 end
 
 function PuzzleTests.validationGarbageCoherence1()
@@ -86,6 +93,7 @@ PuzzleTests.validationCountdown()
 PuzzleTests.validationPuzzleType()
 PuzzleTests.validationMoves()
 PuzzleTests.validationStackLength()
+PuzzleTests.validationStackLength2()
 PuzzleTests.validationStackCharacters()
 PuzzleTests.validationGarbageCoherence1()
 PuzzleTests.validationGarbageCoherence2()

--- a/engine.lua
+++ b/engine.lua
@@ -2214,7 +2214,7 @@ end
 
 function Stack.processPuzzleSwap(self)
   if self.puzzle then
-    if self.puzzle.remaining_moves == 0 and self.puzzle.puzzleType == "clear" then
+    if self.puzzle.remaining_moves == self.puzzle.moves and self.puzzle.puzzleType == "clear" then
       -- start depleting stop / shake time
       self.stop_time = self.puzzle.stop_time
       self.shake_time = self.puzzle.shake_time

--- a/engine.lua
+++ b/engine.lua
@@ -655,7 +655,6 @@ end
 
 
 function Stack.set_puzzle_state(self, puzzle)
-  
   -- Copy the puzzle into our state
   local boardSizeInPanels = self.width * self.height
   while string.len(puzzle.stack) < boardSizeInPanels do
@@ -682,9 +681,10 @@ function Stack.puzzleStringToPanels(self, puzzleString)
   local garbageStartColumn = nil
   local isMetal = false
   local connectedGarbagePanels = nil
+  local rowCount = string.len(puzzleString) / 6
   -- chunk the aprilstack into rows
   -- it is necessary to go bottom up because garbage block panels contain the offset relative to their bottom left corner
-  for row = 1, 12 do
+  for row = 1, rowCount do
       local rowString = string.sub(puzzleString, #puzzleString - 5, #puzzleString)
       puzzleString = string.sub(puzzleString, 1, #puzzleString - 6)
       -- copy the panels into the row
@@ -722,10 +722,12 @@ function Stack.puzzleStringToPanels(self, puzzleString)
               local height = connectedGarbagePanels[#connectedGarbagePanels].y_offset + 1
               -- this is disregarding the possible existence of irregularly shaped garbage
               local width = garbageStartColumn - column + 1
+              local shake_time = garbage_to_shake_time[width * height]
               for i = 1, #connectedGarbagePanels do
                 connectedGarbagePanels[i].x_offset = connectedGarbagePanels[i].x_offset - column
                 connectedGarbagePanels[i].height = height
                 connectedGarbagePanels[i].width = width
+                connectedGarbagePanels[i].shake_time = shake_time
                 -- panels are already in the main table and they should already be updated by reference
               end
               garbageStartRow = nil

--- a/engine.lua
+++ b/engine.lua
@@ -1220,7 +1220,7 @@ function Stack.simulate(self)
     if self.speed ~= 0 and not self.manual_raise and self.stop_time == 0 and not self.rise_lock then
       if self.match.mode == "puzzle" then
         -- only reduce health after the first swap to give the player a chance to strategize
-        if self.puzzle.puzzleType == "clear" and self.puzzle.remaining_moves - self.puzzle.moves < 0 then
+        if self.puzzle.puzzleType == "clear" and self.puzzle.remaining_moves - self.puzzle.moves < 0 and self.shake_time < 1 then
           self.health = self.health - 1
           -- no gameover because it can't return otherwise, exit is taken care of by puzzle_failed
         end


### PR DESCRIPTION
2 fixes that caused clear puzzles to show unintended behaviour:

Fixed a bug that caused clear puzzles with move restrictions to not load their stop time correctly because it was unreasonably assumed a move restriction wouldn't be set for this type of puzzle.

Fixed a bug that caused the player to lose health even if they still had shake time from their configuration.