### PR TITLE
Fix position overwrite for ready position with selected character

### DIFF
--- a/select_screen/select_screen.lua
+++ b/select_screen/select_screen.lua
@@ -489,7 +489,7 @@ function select_screen.initializeFromMenuState(self, playerNumber, menuState)
   self.players[playerNumber].wants_ready = menuState.wants_ready or false
   self.players[playerNumber].ranked = menuState.ranked
   self.players[playerNumber].cursor.positionId = menuState.cursor
-  self.players[playerNumber].cursor.position = self.name_to_xy_per_page[self.current_page][menuState.cursor]
+  self.players[playerNumber].cursor.position = self.name_to_xy_per_page[self.current_page][menuState.cursor] and shallowcpy(self.name_to_xy_per_page[self.current_page][menuState.cursor]) or nil
 end
 
 function select_screen.setUpMyPlayer(self)

--- a/select_screen/select_screen.lua
+++ b/select_screen/select_screen.lua
@@ -489,7 +489,7 @@ function select_screen.initializeFromMenuState(self, playerNumber, menuState)
   self.players[playerNumber].wants_ready = menuState.wants_ready or false
   self.players[playerNumber].ranked = menuState.ranked
   self.players[playerNumber].cursor.positionId = menuState.cursor
-  self.players[playerNumber].cursor.position = self.name_to_xy_per_page[self.current_page][menuState.cursor] and shallowcpy(self.name_to_xy_per_page[self.current_page][menuState.cursor]) or nil
+  self.players[playerNumber].cursor.position = shallowcpy(self.name_to_xy_per_page[self.current_page][menuState.cursor])
 end
 
 function select_screen.setUpMyPlayer(self)

--- a/util.lua
+++ b/util.lua
@@ -86,6 +86,9 @@ end
 
 -- copy the table one key deep
 function shallowcpy(tab)
+  if tab == nil then
+    return nil
+  end
   local ret = {}
   for k, v in pairs(tab) do
     ret[k] = v


### PR DESCRIPTION
Fixes #563, initial sending of the menu state upon entering the room caused overwriting of the __Ready id on the map with the coordinate of the selected character because it was missing a shallowcpy.