### PR TITLE
Fix filter error

### DIFF
--- a/graphics_util.lua
+++ b/graphics_util.lua
@@ -41,7 +41,7 @@ function GraphicsUtil.privateLoadImageWithExtensionAndScale(pathAndName, extensi
       -- We would like to use linear for shrinking and nearest for growing,
       -- but there is a bug in some drivers that doesn't allow for min and mag to be different
       -- to work around this, calculate if we are shrinking or growing and use the right filter on both.
-      if GAME.canvasXScale > scale then
+      if GAME.canvasXScale >= scale then
         result:setFilter("nearest", "nearest")
       else
         result:setFilter("linear", "linear")


### PR DESCRIPTION
Looking at some of the rendered panels for example, both at fixed x1 size.  The initial comparison could make the graphics very blurry

Before
![screenshot_v046-2022-08-02-04-46-51](https://user-images.githubusercontent.com/18148657/182296952-bfe86265-98ff-4d08-8d23-0575586cfbf1.png)

After
![screenshot_v046-2022-08-02-05-15-51](https://user-images.githubusercontent.com/18148657/182297135-dc67d49e-8b5a-4bdf-9bc3-daad7ca04a4d.png)

