### PR TITLE
Spectate hotfix

### DIFF
--- a/select_screen.lua
+++ b/select_screen.lua
@@ -96,7 +96,7 @@ end
 -- Resolve the current character if it is random
 local function resolve_character_random(state)
   if state.character_is_random ~= nil then
-    if state.character_is_random == random_character_special_value then
+    if state.character_is_random == random_character_special_value or characters[state.character_is_random] == nil then
       state.character = table.getRandomElement(characters_ids_for_current_theme)
       if characters[state.character]:is_bundle() then -- may pick a bundle
         state.character = table.getRandomElement(characters[state.character].sub_characters)
@@ -112,7 +112,7 @@ end
 -- Resolve the current stage if it is random
 local function resolve_stage_random(state)
   if state.stage_is_random ~= nil then
-    if state.stage_is_random == random_stage_special_value then
+    if state.stage_is_random == random_stage_special_value or stage[state.stage_is_random] == nil then
       state.stage = table.getRandomElement(stages_ids_for_current_theme)
       if stages[state.stage]:is_bundle() then
         state.stage = table.getRandomElement(stages[state.stage].sub_stages)

--- a/select_screen.lua
+++ b/select_screen.lua
@@ -112,7 +112,7 @@ end
 -- Resolve the current stage if it is random
 local function resolve_stage_random(state)
   if state.stage_is_random ~= nil then
-    if state.stage_is_random == random_stage_special_value or stage[state.stage_is_random] == nil then
+    if state.stage_is_random == random_stage_special_value or stages[state.stage_is_random] == nil then
       state.stage = table.getRandomElement(stages_ids_for_current_theme)
       if stages[state.stage]:is_bundle() then
         state.stage = table.getRandomElement(stages[state.stage].sub_stages)

--- a/select_screen.lua
+++ b/select_screen.lua
@@ -102,11 +102,11 @@ local function resolve_character_random(state)
         state.character = table.getRandomElement(characters[state.character].sub_characters)
       end
     else
-      state.character = table.getRandomElement(characters[state.character_is_random].sub_characters)
+      if characters[state.character_is_random]:is_bundle() then
+        state.character = table.getRandomElement(characters[state.character_is_random].sub_characters)
+      end
     end
-    return true
   end
-  return false
 end
 
 -- Resolve the current stage if it is random
@@ -118,7 +118,9 @@ local function resolve_stage_random(state)
         state.stage = table.getRandomElement(stages[state.stage].sub_stages)
       end
     else
-      state.stage = table.getRandomElement(stages[state.stage_is_random].sub_stages)
+      if stages[state.stage]:is_bundle() then
+        state.stage = table.getRandomElement(stages[state.stage_is_random].sub_stages)
+      end
     end
   end
 end
@@ -332,9 +334,8 @@ function select_screen.main()
     }
   end
 
-  if resolve_character_random(cursor_data[1].state) then
-    character_loader_load(cursor_data[1].state.character)
-  end
+  resolve_character_random(cursor_data[1].state)
+  character_loader_load(cursor_data[1].state.character)
   cursor_data[1].state.character_display_name = characters[cursor_data[1].state.character].display_name
 
   resolve_stage_random(cursor_data[1].state)


### PR DESCRIPTION
Think this should fix #644, not entirely sure yet because there was none to spectate so far (and I've been too lazy to fix Windows detecting PA as a trojan the moment I start to play online with myself).
Essentially make the game check if the character/stage is a bundle before you pick a random entry from the subtable.