### PR TITLE
Fix blurry graphics

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -250,16 +250,18 @@ end
 
 -- Positions the stack draw position for the given player
 function Stack.moveForPlayerNumber(stack, player_num)
+  -- Position of elements should ideally be on even coordinates to avoid non pixel alignment
+  -- on 150% scale
   if player_num == 1 then
-    stack.pos_x = 81
-    stack.score_x = 547
+    stack.pos_x = 80
+    stack.score_x = 546
     stack.mirror_x = 1
     stack.origin_x = stack.pos_x
     stack.multiplication = 0
     stack.id = "_1P"
     stack.VAR_numbers = ""
   elseif player_num == 2 then
-    stack.pos_x = 249
+    stack.pos_x = 248
     stack.score_x = 642
     stack.mirror_x = -1
     stack.origin_x = stack.pos_x + (stack.canvas:getWidth() / GFX_SCALE) - 8

--- a/engine.lua
+++ b/engine.lua
@@ -60,7 +60,7 @@ Stack =
 
     -- frame.png dimensions
     if wantsCanvas then
-      s.canvas = love.graphics.newCanvas(104 * GFX_SCALE, 204 * GFX_SCALE, {dpiscale=GAME.canvasXScale})
+      s.canvas = love.graphics.newCanvas(104 * GFX_SCALE, 204 * GFX_SCALE, {dpiscale=GAME:newCanvasSnappedScale()})
     end
 
     if level then

--- a/game.lua
+++ b/game.lua
@@ -92,12 +92,18 @@ function Game:updateCanvasPositionAndScale(newWindowWidth, newWindowHeight)
   GAME.canvasYScale = h / canvas_height
 end
 
+-- Provides a scale that is on .5 boundary to make sure it renders well.
+-- Useful for creating new canvas with a solid DPI
+function Game:newCanvasSnappedScale()
+  local result = math.max(1, math.floor(self.canvasXScale*2)/2)
+end
+
 -- Reloads the canvas and all images / fonts for the new game scale
 function Game:refreshCanvasAndImagesForNewScale()
   GAME:drawLoadingString(loc("ld_characters"))
   coroutine.yield()
 
-  self.globalCanvas = love.graphics.newCanvas(canvas_width, canvas_height, {dpiscale=GAME.canvasXScale})
+  self.globalCanvas = love.graphics.newCanvas(canvas_width, canvas_height, {dpiscale=GAME:newCanvasSnappedScale()})
   -- We need to reload all assets and fonts to get the new scaling info and filters
 
   -- Reload theme to get the new resolution assets

--- a/game.lua
+++ b/game.lua
@@ -96,6 +96,7 @@ end
 -- Useful for creating new canvas with a solid DPI
 function Game:newCanvasSnappedScale()
   local result = math.max(1, math.floor(self.canvasXScale*2)/2)
+  return result
 end
 
 -- Reloads the canvas and all images / fonts for the new game scale

--- a/graphics_util.lua
+++ b/graphics_util.lua
@@ -34,12 +34,13 @@ function GraphicsUtil.nearestScaledImageForImage(image, manualScale)
 
   love.graphics.setCanvas(tempCanvas)
   love.graphics.clear()
-  love.graphics.setBlendMode("alpha")
+  love.graphics.setBlendMode("alpha", "alphamultiply")
   love.graphics.draw(image, 0, 0, 0, manualScale, manualScale)
   love.graphics.setCanvas()
 
   local data = tempCanvas:newImageData()
   local scaledImage = love.graphics.newImage(data, {dpiscale=image:getDPIScale()})
+  scaledImage:setFilter("nearest", "nearest")
   return scaledImage
 end
 
@@ -55,14 +56,6 @@ function GraphicsUtil.privateLoadImageWithExtensionAndScale(pathAndName, extensi
     local result = GraphicsUtil.privateLoadImage(fileName)
     if result then
       assert(result:getDPIScale() == scale)
-      -- We would like to use linear for shrinking and nearest for growing,
-      -- but there is a bug in some drivers that doesn't allow for min and mag to be different
-      -- to work around this, calculate if we are shrinking or growing and use the right filter on both.
-      if GAME.canvasXScale >= scale then
-        result:setFilter("nearest", "nearest")
-      else
-        result:setFilter("linear", "linear")
-      end
       return result
     end
     

--- a/graphics_util.lua
+++ b/graphics_util.lua
@@ -57,6 +57,14 @@ function GraphicsUtil.privateLoadImageWithExtensionAndScale(pathAndName, extensi
     local result = GraphicsUtil.privateLoadImage(fileName)
     if result then
       assert(result:getDPIScale() == scale)
+      -- We would like to use linear for shrinking and nearest for growing,
+      -- but there is a bug in some drivers that doesn't allow for min and mag to be different
+      -- to work around this, calculate if we are shrinking or growing and use the right filter on both.
+       if GAME.canvasXScale >= scale then
+        result:setFilter("nearest", "nearest")
+      else
+        result:setFilter("linear", "linear")
+      end
       return result
     end
     

--- a/graphics_util.lua
+++ b/graphics_util.lua
@@ -55,6 +55,14 @@ function GraphicsUtil.privateLoadImageWithExtensionAndScale(pathAndName, extensi
     local result = GraphicsUtil.privateLoadImage(fileName)
     if result then
       assert(result:getDPIScale() == scale)
+      -- We would like to use linear for shrinking and nearest for growing,
+      -- but there is a bug in some drivers that doesn't allow for min and mag to be different
+      -- to work around this, calculate if we are shrinking or growing and use the right filter on both.
+      if GAME.canvasXScale >= scale then
+        result:setFilter("nearest", "nearest")
+      else
+        result:setFilter("linear", "linear")
+      end
       return result
     end
     

--- a/graphics_util.lua
+++ b/graphics_util.lua
@@ -27,9 +27,10 @@ function GraphicsUtil.privateLoadImage(path_and_name)
 end
 
 -- Creates a new image object scaled up by the given scale with nearest neighbor filtering
--- Useful for converting legacy assets to the standard 1x scale PA scale.
-function GraphicsUtil.nearestScaledImageForImage(image, manualScale)
-  local tempCanvas = love.graphics.newCanvas(image:getWidth()*manualScale, image:getHeight()*manualScale, {dpiscale=image:getDPIScale()})
+-- Useful for making legacy "blocky" assets keep that look at higher resolutions
+function GraphicsUtil.nearestScaledImageForImage(image, manualScale, path, name)
+  local targetDPI = GAME:newCanvasSnappedScale()
+  local tempCanvas = love.graphics.newCanvas(image:getWidth()*manualScale, image:getHeight()*manualScale, {dpiscale=targetDPI})
   image:setFilter("nearest", "nearest")
 
   love.graphics.setCanvas(tempCanvas)
@@ -39,7 +40,7 @@ function GraphicsUtil.nearestScaledImageForImage(image, manualScale)
   love.graphics.setCanvas()
 
   local data = tempCanvas:newImageData()
-  local scaledImage = love.graphics.newImage(data, {dpiscale=image:getDPIScale()})
+  local scaledImage = love.graphics.newImage(data, {dpiscale=targetDPI})
   scaledImage:setFilter("nearest", "nearest")
   return scaledImage
 end

--- a/graphics_util.lua
+++ b/graphics_util.lua
@@ -26,25 +26,6 @@ function GraphicsUtil.privateLoadImage(path_and_name)
   return image
 end
 
--- Creates a new image object scaled up by the given scale with nearest neighbor filtering
--- Useful for making legacy "blocky" assets keep that look at higher resolutions
-function GraphicsUtil.nearestScaledImageForImage(image, manualScale, path, name)
-  local targetDPI = GAME:newCanvasSnappedScale()
-  local tempCanvas = love.graphics.newCanvas(image:getWidth()*manualScale, image:getHeight()*manualScale, {dpiscale=targetDPI})
-  image:setFilter("nearest", "nearest")
-
-  love.graphics.setCanvas(tempCanvas)
-  love.graphics.clear()
-  love.graphics.setBlendMode("alpha", "alphamultiply")
-  love.graphics.draw(image, 0, 0, 0, manualScale, manualScale)
-  love.graphics.setCanvas()
-
-  local data = tempCanvas:newImageData()
-  local scaledImage = love.graphics.newImage(data, {dpiscale=targetDPI})
-  scaledImage:setFilter("nearest", "nearest")
-  return scaledImage
-end
-
 function GraphicsUtil.privateLoadImageWithExtensionAndScale(pathAndName, extension, scale)
   local scaleSuffixString = "@" .. scale .. "x"
   if scale == 1 then

--- a/graphics_util.lua
+++ b/graphics_util.lua
@@ -41,7 +41,7 @@ function GraphicsUtil.privateLoadImageWithExtensionAndScale(pathAndName, extensi
       -- We would like to use linear for shrinking and nearest for growing,
       -- but there is a bug in some drivers that doesn't allow for min and mag to be different
       -- to work around this, calculate if we are shrinking or growing and use the right filter on both.
-       if GAME.canvasXScale >= scale then
+      if GAME.canvasXScale >= scale then
         result:setFilter("nearest", "nearest")
       else
         result:setFilter("linear", "linear")

--- a/graphics_util.lua
+++ b/graphics_util.lua
@@ -384,7 +384,7 @@ end
 local function privateMakeFont(fontPath, size)
   local f
   local hinting = "normal"
-  local dpi = math.max(1, math.floor(GAME.canvasXScale*2) / 2)
+  local dpi = GAME:newCanvasSnappedScale()
   if fontPath then
     f = love.graphics.newFont(fontPath, size, hinting, dpi)
   else

--- a/main.lua
+++ b/main.lua
@@ -58,7 +58,7 @@ function love.load()
   GAME.rich_presence:initialize("902897593049301004")
   mainloop = coroutine.create(fmainloop)
 
-  GAME.globalCanvas = love.graphics.newCanvas(canvas_width, canvas_height, {dpiscale=GAME.canvasXScale})
+  GAME.globalCanvas = love.graphics.newCanvas(canvas_width, canvas_height, {dpiscale=GAME:newCanvasSnappedScale()})
 end
 
 function love.focus(f)

--- a/panels.lua
+++ b/panels.lua
@@ -93,13 +93,13 @@ function Panels.load(self)
       end
     end
 
-    -- Height is expected to be 48 or more for all panel images including metal,
-    -- if its not, its legacy assets and we need to scale up with "nearest neighbor"
+    -- If height is exactly 48 for this panel image (including metal)
+    -- it is a 1x asset that isn't intended to be blocky (most likely)
+    -- use linear so it doesn't get jaggy
     local height = img:getHeight()*img:getDPIScale()
-    if height < 48 then
-      img = GraphicsUtil.nearestScaledImageForImage(img, 48 / height)
+    if height == 48 then
+      img:setFilter("linear", "linear")
     end
-    local newHeight = img:getHeight()*img:getDPIScale()
     return img
   end
 

--- a/panels.lua
+++ b/panels.lua
@@ -92,6 +92,14 @@ function Panels.load(self)
         error("Could not find default panel image")
       end
     end
+
+    -- Height is expected to be 48 or more for all panel images including metal,
+    -- if its not, its legacy assets and we need to scale up with "nearest neighbor"
+    local height = img:getHeight()*img:getDPIScale()
+    if height < 48 then
+      img = GraphicsUtil.nearestScaledImageForImage(img, 48 / height)
+    end
+    local newHeight = img:getHeight()*img:getDPIScale()
     return img
   end
 


### PR DESCRIPTION
We were creating canvases with non standard scales like "0.8654" when you were at odd zoom levels.
This creates all kinds of bad artifacts.
We were also creating fonts with bad scales.
Instead we want to snap DPI to reasonable boundaries. 1, 1.5, 2 etc

This makes almost all graphics look good, but we take special care with the legacy panels to upscale them equally using nearest neighbor so the pixels are consistent no matter where they are on canvas.
<img width="844" alt="Screen Shot 2022-08-07 at 8 43 35 PM" src="https://user-images.githubusercontent.com/8935453/183335183-49fb5369-df82-49f3-a943-f989f49caef5.png">
<img width="1378" alt="Screen Shot 2022-08-07 at 8 43 19 PM" src="https://user-images.githubusercontent.com/8935453/183335198-95d35908-50a9-4769-a1b6-bda3341cae8e.png">

