### PR TITLE
1p random bundle crash

### DIFF
--- a/mainloop.lua
+++ b/mainloop.lua
@@ -315,7 +315,8 @@ end
 function Stack.wait_for_random_character(self)
   if self.character == random_character_special_value then
     self.character = table.getRandomElement(characters_ids_for_current_theme)
-  elseif characters[self.character]:is_bundle() then -- may have picked a bundle
+  end
+  if characters[self.character]:is_bundle() then -- may have picked a bundle
     self.character = table.getRandomElement(characters[self.character].sub_characters)
   end
   character_loader_load(self.character)


### PR DESCRIPTION
Solves #657.
The alternative to using `Stack.wait_for_random_character` would be to simply pass the stack into the new `refreshBasedOnOwnMods` global method in `select_screen`. Downside is that it does "more than necessary", upside is that we don't have an extra method for this.
Please check and tell me what you prefer.