### PR TITLE
Fix crash when room initialization fails

### DIFF
--- a/select_screen/select_screen.lua
+++ b/select_screen/select_screen.lua
@@ -303,7 +303,7 @@ function select_screen.awaitRoomInitializationMessage(self)
     gprint(loc("ss_init"), unpack(themes[config.theme].main_menu_screen_pos))
     wait()
     if not do_messages() then
-      return main_dumb_transition, {main_select_mode, loc("ss_disconnect") .. "\n\n" .. loc("ss_return"), 60, 300}
+      return {main_dumb_transition, {main_select_mode, loc("ss_disconnect") .. "\n\n" .. loc("ss_return"), 60, 300}}
     end
     retries = retries + 1
   end
@@ -312,7 +312,7 @@ function select_screen.awaitRoomInitializationMessage(self)
   if not self.roomInitializationMessage then
     -- abort due to timeout
     logger.warn(loc("ss_init_fail") .. "\n")
-    return main_dumb_transition, {main_select_mode, loc("ss_init_fail") .. "\n\n" .. loc("ss_return"), 60, 300}
+    return {main_dumb_transition, {main_select_mode, loc("ss_init_fail") .. "\n\n" .. loc("ss_return"), 60, 300}}
   end
 
   return nil
@@ -932,7 +932,7 @@ function select_screen.main(self, character_select_mode, roomInitializationMessa
     local abort = self:setupForNetPlay()
     if abort then
       -- abort due to connection loss or timeout
-      return abort
+      return unpack(abort)
     else
       self:initializeNetPlayRoom()
     end


### PR DESCRIPTION
This should fix #656.
Due to not wrapping the return values inside `awaitRoomInitializationMessage` inside a table, the intermediate function `setupForNetPlay` apparently only returns the function pointer and not the arguments inside the table causing args to be missing and the mainloop therefore missing on the followup func after going through the transition.