### PR TITLE
Fixed garbage sfx

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -1932,7 +1932,7 @@ function Stack.simulate(self)
         local popLevel = min(max(self.chain_counter, 1), 4)
         local popIndex = 1
         if SFX_Garbage_Pop_Play then
-          popIndex = SFX_Garbage_Pop_Play
+          popIndex = min(SFX_Garbage_Pop_Play + self.poppedPanelIndex, 10)
         else
           popIndex = min(self.poppedPanelIndex, 10)
         end


### PR DESCRIPTION
Garbage pop sound effect should not start with popx_1; it should continue after the last pop from the clear.
An example of proper garbage pop sound effects can be seen here: https://www.youtube.com/watch?v=iWFipEB64J8&t=123s

https://user-images.githubusercontent.com/7853187/193437310-8fc83804-3c85-454f-9f57-ac8bf828fc51.mp4

https://user-images.githubusercontent.com/7853187/193437314-82238cb7-61f2-44f4-82f4-cde558440f8b.mp4

