### PR TITLE
Fix puzzle countdown being ignored

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -673,7 +673,7 @@ function Stack.set_puzzle_state(self, puzzle)
 
   self.puzzle = puzzle
   self.panels = self:puzzleStringToPanels(puzzleString)
-  self.do_countdown = puzzle.do_countdown or false
+  self.do_countdown = puzzle.doCountdown or false
   self.puzzle.remaining_moves = puzzle.moves
 
   -- transform any cleared garbage into colorless garbage panels


### PR DESCRIPTION
There was some mismatch in which variables already got camelcased between engine and puzzles, resulting in the countdown setting being ignored and always using the config setting, causing chain puzzles to potentially start instantly.