### PR TITLE
Android Startup

### DIFF
--- a/auto_updater/conf.lua
+++ b/auto_updater/conf.lua
@@ -1,52 +1,68 @@
+require("developer")
+
+local function readUseAndroidExternalStorage()
+  if love.filesystem.getInfo("UseAndroidExternalStorage", "file") then
+    local file = love.filesystem.newFile("conf.json")
+    file:open("r")
+    local result = file:read(file:getSize())
+    file:close()
+    return (result == "true" or result == "True")
+  else
+    return false
+  end
+end
+
 function love.conf(t)
-    t.identity = "Panel Attack"         -- The name of the save directory (string)
-    t.appendidentity = false            -- Search files in source directory before save directory (boolean)
-    t.version = "11.3"                  -- The LÖVE version this game was made for (string)
-    t.console = false                   -- Attach a console (boolean, Windows only)
-    t.accelerometerjoystick = false      -- Enable the accelerometer on iOS and Android by exposing it as a Joystick (boolean)
-    t.externalstorage = false           -- True to save files (and read from the save directory) in external storage on Android (boolean) 
-    t.gammacorrect = false              -- Enable gamma-correct rendering, when supported by the system (boolean)
- 
-    t.audio.mic = false                 -- Request and use microphone capabilities in Android (boolean)
-    t.audio.mixwithsystem = false        -- Keep background music playing when opening LOVE (boolean, iOS and Android only)
- 
-    t.window.title = "Panel Attack - Auto Updater"         -- The window title (string)
-    t.window.icon = nil                 -- Filepath to an image to use as the window's icon (string)
-    t.window.width = 800                -- The window width (number)
-    t.window.height = 600               -- The window height (number)
-    t.window.borderless = false         -- Remove all border visuals from the window (boolean)
-    t.window.resizable = false          -- Let the window be user-resizable (boolean)
-    t.window.minwidth = 1               -- Minimum window width if the window is resizable (number)
-    t.window.minheight = 1              -- Minimum window height if the window is resizable (number)
-    t.window.fullscreen = false         -- Enable fullscreen (boolean)
-    t.window.fullscreentype = "desktop" -- Choose between "desktop" fullscreen or "exclusive" fullscreen mode (string)
-    t.window.usedpiscale = true         -- Enable automatic DPI scaling (boolean)
-    t.window.vsync = 1                  -- Vertical sync mode (number)
-    t.window.msaa = 0                   -- The number of samples to use with multi-sampled antialiasing (number)
-    t.window.depth = nil                -- The number of bits per sample in the depth buffer
-    t.window.stencil = nil              -- The number of bits per sample in the stencil buffer
-    t.window.display = 1                -- Index of the monitor to show the window in (number)
-    t.window.highdpi = false            -- Enable high-dpi mode for the window on a Retina display (boolean)
-    t.window.x = nil                    -- The x-coordinate of the window's position in the specified display (number)
-    t.window.y = nil                    -- The y-coordinate of the window's position in the specified display (number)
-    t.window = nil
- 
-    t.modules.audio = false              -- Enable the audio module (boolean)
-    t.modules.data = true               -- Enable the data module (boolean, mandatory)
-    t.modules.event = true              -- Enable the event module (boolean)
-    t.modules.font = true               -- Enable the font module (boolean)
-    t.modules.graphics = true           -- Enable the graphics module (boolean)
-    t.modules.image = false              -- Enable the image module (boolean)
-    t.modules.joystick = false           -- Enable the joystick module (boolean)
-    t.modules.keyboard = false           -- Enable the keyboard module (boolean)
-    t.modules.math = false               -- Enable the math module (boolean)
-    t.modules.mouse = false              -- Enable the mouse module (boolean)
-    t.modules.physics = false            -- Enable the physics module (boolean)
-    t.modules.sound = false              -- Enable the sound module (boolean)
-    t.modules.system = false             -- Enable the system module (boolean)
-    t.modules.thread = true             -- Enable the thread module (boolean)
-    t.modules.timer = false              -- Enable the timer module (boolean), Disabling it will result 0 delta time in love.update
-    t.modules.touch = false              -- Enable the touch module (boolean)
-    t.modules.video = false              -- Enable the video module (boolean)
-    t.modules.window = true             -- Enable the window module (boolean)
+  UseAndroidExternalStorage = readUseAndroidExternalStorage()
+
+  t.identity = "Panel Attack" -- The name of the save directory (string)
+  t.appendidentity = false -- Search files in source directory before save directory (boolean)
+  t.version = "11.3" -- The LÖVE version this game was made for (string)
+  t.console = false -- Attach a console (boolean, Windows only)
+  t.accelerometerjoystick = false -- Enable the accelerometer on iOS and Android by exposing it as a Joystick (boolean)
+  t.externalstorage = UseAndroidExternalStorage -- True to save files (and read from the save directory) in external storage on Android (boolean)
+  t.gammacorrect = false -- Enable gamma-correct rendering, when supported by the system (boolean)
+
+  t.audio.mic = false -- Request and use microphone capabilities in Android (boolean)
+  t.audio.mixwithsystem = false -- Keep background music playing when opening LOVE (boolean, iOS and Android only)
+
+  t.window.title = "Panel Attack - Auto Updater" -- The window title (string)
+  t.window.icon = nil -- Filepath to an image to use as the window's icon (string)
+  t.window.width = 800 -- The window width (number)
+  t.window.height = 600 -- The window height (number)
+  t.window.borderless = false -- Remove all border visuals from the window (boolean)
+  t.window.resizable = false -- Let the window be user-resizable (boolean)
+  t.window.minwidth = 1 -- Minimum window width if the window is resizable (number)
+  t.window.minheight = 1 -- Minimum window height if the window is resizable (number)
+  t.window.fullscreen = false -- Enable fullscreen (boolean)
+  t.window.fullscreentype = "desktop" -- Choose between "desktop" fullscreen or "exclusive" fullscreen mode (string)
+  t.window.usedpiscale = true -- Enable automatic DPI scaling (boolean)
+  t.window.vsync = 1 -- Vertical sync mode (number)
+  t.window.msaa = 0 -- The number of samples to use with multi-sampled antialiasing (number)
+  t.window.depth = nil -- The number of bits per sample in the depth buffer
+  t.window.stencil = nil -- The number of bits per sample in the stencil buffer
+  t.window.display = 1 -- Index of the monitor to show the window in (number)
+  t.window.highdpi = false -- Enable high-dpi mode for the window on a Retina display (boolean)
+  t.window.x = nil -- The x-coordinate of the window's position in the specified display (number)
+  t.window.y = nil -- The y-coordinate of the window's position in the specified display (number)
+  t.window = nil
+
+  t.modules.audio = false -- Enable the audio module (boolean)
+  t.modules.data = true -- Enable the data module (boolean, mandatory)
+  t.modules.event = true -- Enable the event module (boolean)
+  t.modules.font = true -- Enable the font module (boolean)
+  t.modules.graphics = true -- Enable the graphics module (boolean)
+  t.modules.image = false -- Enable the image module (boolean)
+  t.modules.joystick = false -- Enable the joystick module (boolean)
+  t.modules.keyboard = false -- Enable the keyboard module (boolean)
+  t.modules.math = false -- Enable the math module (boolean)
+  t.modules.mouse = false -- Enable the mouse module (boolean)
+  t.modules.physics = false -- Enable the physics module (boolean)
+  t.modules.sound = false -- Enable the sound module (boolean)
+  t.modules.system = true -- Enable the system module (boolean)
+  t.modules.thread = true -- Enable the thread module (boolean)
+  t.modules.timer = false -- Enable the timer module (boolean), Disabling it will result 0 delta time in love.update
+  t.modules.touch = false -- Enable the touch module (boolean)
+  t.modules.video = false -- Enable the video module (boolean)
+  t.modules.window = true -- Enable the window module (boolean)
 end

--- a/auto_updater/main.lua
+++ b/auto_updater/main.lua
@@ -70,7 +70,6 @@ local function correctAndroidStartupConfig()
     )
 
     if UseAndroidExternalStorage then
-      _G.UseAndroidExternalStorage = nil
       package.loaded.conf = nil
       love.conf = nil
       love.init()

--- a/conf.lua
+++ b/conf.lua
@@ -12,7 +12,14 @@ function love.conf(t)
   t.version = "11.3"                  -- The LÖVE version this game was made for (string)
   t.console = false                   -- Attach a console (boolean, Windows only)
   t.accelerometerjoystick = false     -- Enable the accelerometer on iOS and Android by exposing it as a Joystick (boolean)
-  t.externalstorage = false           -- True to save files (and read from the save directory) in external storage on Android (boolean) 
+  -- is loaded inside the auto updater
+  --- game and auto updater should always start inside the same storage for the config to read and write correctly
+  if UseAndroidExternalStorage then
+    t.externalstorage = UseAndroidExternalStorage    -- True to save files (and read from the save directory) in external storage on Android (boolean) 
+  else
+    -- game was started without auto_updater
+    t.externalstorage = true
+  end
   t.gammacorrect = false              -- Enable gamma-correct rendering, when supported by the system (boolean)
 
   t.audio.mic = false                 -- Request and use microphone capabilities in Android (boolean)


### PR DESCRIPTION
This branch does the following:
Lets existing android installations start from internal storage
Places fresh installs in external storage

The setting is transmitted down to the maingame via the UseAndroidInternalStorage global/file so that both components are guaranteed to live in the same storage so that there are no conflicts with reading/saving config, etc.

Additional changes:
I made 3 functions in auto_updater/main local and relocated their definition to the top so they are found inside of `load`/`update`.
I moved some of the initialization related to `game_updater` into `load` to prevent it from writing files before the storage check went through.
I ran the VSC format over conf.lua so it now follows the 2 space indent which is why everything is red and green in the diff.
