### PR TITLE
Fix x100 chain crash bug and allow usage of chain cards up to 99

### DIFF
--- a/analytics.lua
+++ b/analytics.lua
@@ -53,15 +53,15 @@ for i = 1, 72 do
   amount_of_garbages_lines_per_combo[i] = amount_of_garbages_lines_per_combo[i] or amount_of_garbages_lines_per_combo[i - 1]
 end
 
-local function compute_above_13(analytic)
+local function compute_above_chain_card_limit(analytic)
   --computing chain ? count
-  local chain_above_13 = 0
+  local chain_above_limit = 0
   for k, v in pairs(analytic.reached_chains) do
-    if k > 13 then
-      chain_above_13 = chain_above_13 + v
+    if k > themes[config.theme].chainCardLimit then
+      chain_above_limit = chain_above_limit + v
     end
   end
-  return chain_above_13
+  return chain_above_limit
 end
 
 local function refresh_sent_garbage_lines(analytic)
@@ -76,7 +76,7 @@ local function refresh_sent_garbage_lines(analytic)
       sent_garbage_lines_count = sent_garbage_lines_count + (i - 1) * analytic.reached_chains[i]
     end
   end
-  local chain_above_13 = compute_above_13(analytics.last_game)
+  local chain_above_13 = compute_above_chain_card_limit(analytics.last_game)
   sent_garbage_lines_count = sent_garbage_lines_count + 13 * chain_above_13
   analytic.sent_garbage_lines = sent_garbage_lines_count
 end
@@ -183,8 +183,8 @@ local function write_analytics_files()
   )
 end
 
-function AnalyticsInstance.compute_above_13(self)
-  return compute_above_13(self.data)
+function AnalyticsInstance.compute_above_chain_card_limit(self)
+  return compute_above_chain_card_limit(self.data)
 end
 
 function AnalyticsInstance.data_update_list(self)
@@ -213,8 +213,6 @@ function AnalyticsInstance.register_destroyed_panels(self, amount)
 end
 
 function AnalyticsInstance.register_chain(self, size)
-  local max_size = math.min(size, 13)
-
   local analytics_filters = self:data_update_list()
   for _, analytic in pairs(analytics_filters) do
     if not analytic.reached_chains[size] then
@@ -222,8 +220,7 @@ function AnalyticsInstance.register_chain(self, size)
     else
       analytic.reached_chains[size] = analytic.reached_chains[size] + 1
     end
-    size = math.min(size, 13)
-    analytic.sent_garbage_lines = analytic.sent_garbage_lines + (max_size - 1)
+    analytic.sent_garbage_lines = analytic.sent_garbage_lines + (size - 1)
   end
 end
 

--- a/graphics.lua
+++ b/graphics.lua
@@ -873,16 +873,16 @@ function Stack.render(self)
   
     -- Clean up the chain data so we only show chains up to the highest chain the user has done
     local chainData = {}
-    local chain_above_13 = analytic:compute_above_13()
+    local chain_above_limit = analytic:compute_above_chain_card_limit()
   
-    for i = 2, 13, 1 do
+    for i = 2, themes[config.theme].chainCardLimit, 1 do
       if not analytic.data.reached_chains[i] then
         chainData[i] = 0
       else
         chainData[i] = analytic.data.reached_chains[i]
       end
     end
-    table.insert(chainData, chain_above_13)
+    table.insert(chainData, chain_above_limit)
     for i = #chainData, 0, -1 do
       if chainData[i] and chainData[i] == 0 then
         chainData[i] = nil
@@ -892,7 +892,7 @@ function Stack.render(self)
     end
   
     -- Draw the chain images
-    for i = 2, 14 do
+    for i = 2, themes[config.theme].chainCardLimit + 1 do
       local chain_amount = chainData[i]
       if chain_amount and chain_amount > 0 then
         icon_width, icon_height = themes[config.theme].images.IMG_cards[true][i]:getDimensions()

--- a/theme.lua
+++ b/theme.lua
@@ -212,13 +212,31 @@ function Theme.graphics_init(self)
   for i = 4, 66 do
     self.images.IMG_cards[false][i] = load_theme_img("combo/combo" .. tostring(math.floor(i / 10)) .. tostring(i % 10) .. "")
   end
+  -- mystery chain
+  self.images.IMG_cards[true][0] = load_theme_img("chain/chain00")
   for i = 2, 13 do
+    -- with backup from default theme
     self.images.IMG_cards[true][i] = load_theme_img("chain/chain" .. tostring(math.floor(i / 10)) .. tostring(i % 10) .. "")
   end
 
-  self.images.IMG_cards[true][14] = load_theme_img("chain/chain00")
-  for i = 15, 99 do
-    self.images.IMG_cards[true][i] = self.images.IMG_cards[true][14]
+  -- load as many more chain cards as there are available until 99, start using the mystery card once the first is missing
+  local endOfChainCardsReached = false
+  for i = 14, 99 do
+    if endOfChainCardsReached == true then
+      -- use mystery chain card
+      self.images.IMG_cards[true][i] = self.images.IMG_cards[true][0]
+    else
+      -- without backup from default theme
+      self.images.IMG_cards[true][i] = load_theme_img("chain/chain" .. tostring(math.floor(i / 10)) .. tostring(i % 10) .. "", false)
+      if self.images.IMG_cards[true][i] == nil then
+        endOfChainCardsReached = true
+        self.images.IMG_cards[true][i] = self.images.IMG_cards[true][0]
+      end
+    end
+  end
+
+  for i = 100, 999 do
+    self.images.IMG_cards[true][i] = self.images.IMG_cards[true][0]
   end
 
   local MAX_SUPPORTED_PLAYERS = 2

--- a/theme.lua
+++ b/theme.lua
@@ -231,6 +231,7 @@ function Theme.graphics_init(self)
       if self.images.IMG_cards[true][i] == nil then
         endOfChainCardsReached = true
         self.images.IMG_cards[true][i] = self.images.IMG_cards[true][0]
+        self.chainCardLimit = i - 1
       end
     end
   end


### PR DESCRIPTION
Resolves #716 (I did not test this cause I'm too big of a dumb dumb to chain to 100)
Additionally I made chain cards beyond x13 available as some themes support them (PPL, Light, not sure about others).
Finally this fixes the bug that caused chains > x13 to have their lines sent in analytics erroneously cut down to 13 regardless of how much was actually sent. I don't think we had an issue for that one.
Reported by Mara [here](https://discord.com/channels/196674532491132937/362093490538020864/1034882114442764368).