### PR TITLE
Allow modification of colorcount in local/1p modes that use select_screen

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -258,6 +258,10 @@ function Stack.setLevel(self, level)
   end
 end
 
+function Stack.overrideColorCount(self, count)
+  self.NCOLORS = count
+end
+
 -- Should be called prior to clearing the stack.
 -- Consider recycling any memory that might leave around a lot of garbage.
 -- Note: You can just leave the variables to clear / garbage collect on their own if they aren't large.

--- a/select_screen/select_screen.lua
+++ b/select_screen/select_screen.lua
@@ -488,6 +488,7 @@ function select_screen.initializeFromPlayerConfig(self, playerNumber)
   self.players[playerNumber].panels_dir = config.panels
   self.players[playerNumber].ready = false
   self.players[playerNumber].ranked = config.ranked
+  self.players[playerNumber].colorCountOffset = 0
 end
 
 function select_screen.initializeFromMenuState(self, playerNumber, menuState)
@@ -503,6 +504,7 @@ function select_screen.initializeFromMenuState(self, playerNumber, menuState)
   self.players[playerNumber].ranked = menuState.ranked
   self.players[playerNumber].cursor.positionId = menuState.cursor
   self.players[playerNumber].cursor.position = shallowcpy(self.name_to_xy_per_page[self.current_page][menuState.cursor])
+  self.players[playerNumber].colorCountOffset = 0
 end
 
 function select_screen.setUpMyPlayer(self)
@@ -589,10 +591,18 @@ function select_screen.handleInput(self)
       elseif menu_up(i) then
         if not cursor.selected then
           self:move_cursor(cursor, up)
+        else
+          if cursor.positionId == "__Panels" and not self:isNetPlay() then
+            player.colorCountOffset = bound(-1, player.colorCountOffset + 1,  1)
+          end
         end
       elseif menu_down(i) then
         if not cursor.selected then
           self:move_cursor(cursor, down)
+        else
+          if cursor.positionId == "__Panels" and not self:isNetPlay() then
+            player.colorCountOffset = bound(-1, player.colorCountOffset - 1,  1)
+          end
         end
       elseif menu_left(i) then
         if cursor.selected then
@@ -832,8 +842,14 @@ end
 function select_screen.start2pLocalMatch(self)
   GAME.match = Match("vs", GAME.battleRoom)
   P1 = Stack{which = 1, match = GAME.match, is_local = true, panels_dir = self.players[self.my_player_number].panels_dir, level = self.players[self.my_player_number].level, character = self.players[self.my_player_number].character, player_number = 1}
+  if self.players[1].colorCount then
+    P1:overrideColorCount(self.players[1].colorCount)
+  end
   GAME.match.P1 = P1
   P2 = Stack{which = 2, match = GAME.match, is_local = true, panels_dir = self.players[self.op_player_number].panels_dir, level = self.players[self.op_player_number].level, character = self.players[self.op_player_number].character, player_number = 2}
+  if self.players[2].colorCount then
+    P2:overrideColorCount(self.players[2].colorCount)
+  end
   GAME.match.P2 = P2
   P1:set_garbage_target(P2)
   P2:set_garbage_target(P1)
@@ -851,6 +867,9 @@ end
 function select_screen.start1pLocalMatch(self)
   GAME.match = Match("vs", GAME.battleRoom)
   P1 = Stack{which = 1, match = GAME.match, is_local = true, panels_dir = self.players[self.my_player_number].panels_dir, level = self.players[self.my_player_number].level, character = self.players[self.my_player_number].character, player_number = 1}
+  if self.players[1].colorCount then
+    P1:overrideColorCount(self.players[1].colorCount)
+  end
   if GAME.battleRoom.trainingModeSettings then
     self:initializeAttackEngine()
   end

--- a/select_screen/select_screen.lua
+++ b/select_screen/select_screen.lua
@@ -842,14 +842,10 @@ end
 function select_screen.start2pLocalMatch(self)
   GAME.match = Match("vs", GAME.battleRoom)
   P1 = Stack{which = 1, match = GAME.match, is_local = true, panels_dir = self.players[self.my_player_number].panels_dir, level = self.players[self.my_player_number].level, character = self.players[self.my_player_number].character, player_number = 1}
-  if self.players[1].colorCount then
-    P1:overrideColorCount(self.players[1].colorCount)
-  end
+  P1:overrideColorCount(level_to_ncolors_vs[self.players[1].level] + self.players[1].colorCountOffset)
   GAME.match.P1 = P1
   P2 = Stack{which = 2, match = GAME.match, is_local = true, panels_dir = self.players[self.op_player_number].panels_dir, level = self.players[self.op_player_number].level, character = self.players[self.op_player_number].character, player_number = 2}
-  if self.players[2].colorCount then
-    P2:overrideColorCount(self.players[2].colorCount)
-  end
+  P2:overrideColorCount(level_to_ncolors_vs[self.players[2].level] + self.players[2].colorCountOffset)
   GAME.match.P2 = P2
   P1:set_garbage_target(P2)
   P2:set_garbage_target(P1)
@@ -867,9 +863,7 @@ end
 function select_screen.start1pLocalMatch(self)
   GAME.match = Match("vs", GAME.battleRoom)
   P1 = Stack{which = 1, match = GAME.match, is_local = true, panels_dir = self.players[self.my_player_number].panels_dir, level = self.players[self.my_player_number].level, character = self.players[self.my_player_number].character, player_number = 1}
-  if self.players[1].colorCount then
-    P1:overrideColorCount(self.players[1].colorCount)
-  end
+  P1:overrideColorCount(level_to_ncolors_vs[self.players[1].level] + self.players[1].colorCountOffset)
   if GAME.battleRoom.trainingModeSettings then
     self:initializeAttackEngine()
   end

--- a/select_screen/select_screen_graphics.lua
+++ b/select_screen/select_screen_graphics.lua
@@ -427,10 +427,9 @@ end
 function select_screen_graphics.draw_panels(self, player, player_number, y_padding)
   local panels_max_width = 0.25 * self.button_height
   local panels_width = math.min(panels_max_width, 20)
+  local colorCount = level_to_ncolors_vs[player.level] + (player.colorCountOffset or 0)
   local padding_x = 0.5 * self.button_width - 3 * panels_width -- center them, not 3.5 mysteriously?
-  if player.level >= 9 then
-    padding_x = padding_x - 0.5 * panels_width
-  end
+  padding_x = padding_x - (0.5 * panels_width * (colorCount - 5))
   local is_selected = player.cursor.selected and player.cursor.positionId == "__Panels"
   if is_selected then
     padding_x = padding_x - panels_width
@@ -440,16 +439,22 @@ function select_screen_graphics.draw_panels(self, player, player_number, y_paddi
   padding_x = padding_x + panels_width
   if is_selected then
     gprintf("<", self.render_x + padding_x - 0.5 * panels_width, self.render_y + y_padding - 0.5 * self.text_height, panels_width, "center")
+    gprintf("^", self.render_x + 100 - self.spacing, self.render_y + y_padding * 0.4, panels_width, "center")
     padding_x = padding_x + panels_width
   end
   for i = 1, 8 do
-    if i ~= 7 and (i ~= 6 or player.level >= 9) then
+    if i <= colorCount or i == 8 then
       menu_drawf(panels[player.panels_dir].images.classic[i][1], self.render_x + padding_x, self.render_y + y_padding, "center", "center", 0, panels_scale, panels_scale)
       padding_x = padding_x + panels_width
     end
   end
   if is_selected then
     gprintf(">", self.render_x + padding_x - 0.5 * panels_width, self.render_y + y_padding - 0.5 * self.text_height, panels_width, "center")
+    if #self.select_screen.players == 1 then
+      gprintf("v", self.render_x + 100 - self.spacing, self.render_y + y_padding * 1.3, panels_width, "center")
+    else
+      gprintf("v", self.render_x + 100 - self.spacing, self.render_y + y_padding * 2, panels_width, "center")
+    end
   end
 end
 


### PR DESCRIPTION
For now restricted to +-1 color relative to level and only available in game modes that go through select_screen, excluding netplay.
Contributes to #591 but doesn't implement it for time attack / endless yet.