### PR TITLE
Lock inputs to the first used input configuration during gameplay

### DIFF
--- a/input.lua
+++ b/input.lua
@@ -381,14 +381,10 @@ end
 
 -- Requests the next inputs assign configurations to players, up to the number of players passed in
 function Input.requestPlayerInputConfigurationAssignments(self, numberOfPlayers)
-  if numberOfPlayers == 1 then
-    self.playerInputConfigurationsMap[1] = self.inputConfigurations
-  else
-    if #input.playerInputConfigurationsMap < numberOfPlayers then
-      self.acceptingPlayerInputConfigurationAssignments = true
-      self.availableInputConfigurationsToAssign = deepcpy(self.inputConfigurations)
-      self.numberOfPlayersAcceptingInputConfiguration = numberOfPlayers
-    end
+  if #input.playerInputConfigurationsMap < numberOfPlayers then
+    self.acceptingPlayerInputConfigurationAssignments = true
+    self.availableInputConfigurationsToAssign = deepcpy(self.inputConfigurations)
+    self.numberOfPlayersAcceptingInputConfiguration = numberOfPlayers
   end
 end
 
@@ -419,6 +415,18 @@ function Input.getInputConfigurationsForPlayerNumber(self, playerNumber)
   return results
 end
 
+function Input.setSingleConfigInput(self, playerCount)
+  if playerCount == nil then
+    playerCount = 1
+  end
+  self:clearInputConfigurationsForPlayers()
+  self:requestPlayerInputConfigurationAssignments(playerCount)
+end
+
+function Input.setMultiConfigInput(self)
+  self.playerInputConfigurationsMap[1] = self.inputConfigurations
+end
+
 -- Makes a function that will return true if one of the fixed keys or configurable keys was pressed for the passed in player.
 -- Also returns the sound effect callback function
 -- fixed -- the set of key names that always work
@@ -445,7 +453,7 @@ local function input_key_func(fixed, configurable, query, sound, ...)
     end
 
     for i = 1, #configurable do
-      for index, inputConfiguration in ipairs(input:getInputConfigurationsForPlayerNumber(playerNumber)) do
+      for _, inputConfiguration in ipairs(input:getInputConfigurationsForPlayerNumber(playerNumber)) do
         local keyname = inputConfiguration[configurable[i]]
         if keyname then
           res = res or query(keyname, other_args) and not menu_reserved_keys[keyname]

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -180,8 +180,7 @@ do
     undo_stonermode()
     GAME.backgroundImage = themes[config.theme].images.bg_main
     GAME.battleRoom = nil
-    GAME.input:clearInputConfigurationsForPlayers()
-    GAME.input:requestPlayerInputConfigurationAssignments(1)
+    GAME.input:setMultiConfigInput()
     reset_filters()
     local menu_x, menu_y = unpack(themes[config.theme].main_menu_screen_pos)
     local main_menu
@@ -1470,8 +1469,7 @@ function main_local_vs_setup()
   GAME.battleRoom = BattleRoom()
   GAME.battleRoom.playerNames[1] = loc("player_n", "1")
   GAME.battleRoom.playerNames[2] = loc("player_n", "2")
-  GAME.input:clearInputConfigurationsForPlayers()
-  GAME.input:requestPlayerInputConfigurationAssignments(2)
+  GAME.input:setSingleConfigInput(2)
   return select_screen.main, {select_screen, "2p_local_vs"}
 end
 

--- a/select_screen/select_screen.lua
+++ b/select_screen/select_screen.lua
@@ -817,6 +817,8 @@ function select_screen.startNetPlayMatch(self, msg)
     P2.play_to_end = true
   end
 
+  GAME.input:setSingleConfigInput(1)
+
   -- Proceed to the game screen and start the game
   P1:starting_state()
   P2:starting_state()
@@ -862,6 +864,9 @@ function select_screen.start1pLocalMatch(self)
   current_stage = self.players[self.my_player_number].stage
   stage_loader_load(current_stage)
   stage_loader_wait()
+
+  GAME.input:setSingleConfigInput(1)
+
   P1:starting_state()
   return main_dumb_transition, {main_local_vs_yourself, "", 0, 0}
 end
@@ -881,6 +886,9 @@ function select_screen.start1pCpuMatch(self)
   stage_loader_load(current_stage)
   stage_loader_wait()
   P2:moveForPlayerNumber(2)
+
+  GAME.input:setSingleConfigInput(1)
+
   P1:starting_state()
   P2:starting_state()
   return main_dumb_transition, {main_local_vs, "", 0, 0}
@@ -934,7 +942,7 @@ function select_screen.main(self, character_select_mode, roomInitializationMessa
   self:setInitialCursors()
 
   -- Setup settings for Main Character Select for 2 Player over Network
-  if select_screen:isNetPlay() then
+  if self:isNetPlay() then
     local abort = self:setupForNetPlay()
     if abort then
       -- abort due to connection loss or timeout
@@ -949,6 +957,14 @@ function select_screen.main(self, character_select_mode, roomInitializationMessa
   if self:isMultiplayer() then
     self:setUpOpponentPlayer()
   end
+
+  -- 2p vs local needs to have its input properly divided in select screen already
+  -- meaning we do NOT want to reset to player 1 reacting to inputs from all configurations
+  -- for all others, the player can hold their decision until game start
+  if not self:isMultiplayer() or self:isNetPlay() then
+    GAME.input:setMultiConfigInput()
+  end
+
   self:refreshReadyStates()
 
   self.myPreviousConfig = deepcpy(self.players[self.my_player_number])

--- a/select_screen/select_screen.lua
+++ b/select_screen/select_screen.lua
@@ -933,6 +933,13 @@ end
 
 -- The main screen for selecting characters and settings for a match
 function select_screen.main(self, character_select_mode, roomInitializationMessage)
+  -- 2p vs local needs to have its input properly divided in select screen already
+  -- meaning we do NOT want to reset to player 1 reacting to inputs from all configurations
+  -- for all others, the player can hold their decision until game start
+  if not self:isMultiplayer() or self:isNetPlay() then
+    GAME.input:setMultiConfigInput()
+  end
+
   self.roomInitializationMessage = roomInitializationMessage
   self:initialize(character_select_mode)
   self:loadThemeAssets()
@@ -956,13 +963,6 @@ function select_screen.main(self, character_select_mode, roomInitializationMessa
 
   if self:isMultiplayer() then
     self:setUpOpponentPlayer()
-  end
-
-  -- 2p vs local needs to have its input properly divided in select screen already
-  -- meaning we do NOT want to reset to player 1 reacting to inputs from all configurations
-  -- for all others, the player can hold their decision until game start
-  if not self:isMultiplayer() or self:isNetPlay() then
-    GAME.input:setMultiConfigInput()
   end
 
   self:refreshReadyStates()


### PR DESCRIPTION
For now limited to game modes going through select_screen, deactivates every time you get back to character_select and should also cover room initialization errors and disconnects as both running into `select_screen.main` and `main_select_mode` will call `setMultiConfigInput` again (and respectively before the room initialization error can occur).
I'm not sure if this is the best way to implement it but I considered it a "nice touch" if you're able to easily switch your input method inbetween games.