### PR TITLE
Discord link is now aligned center instead of left so it isn't WACK

### DIFF
--- a/graphics.lua
+++ b/graphics.lua
@@ -774,7 +774,7 @@ function Stack.render(self)
   local function drawCommunityMessage()
     -- Draw the community message
     if not config.debug_mode then
-      gprint(join_community_msg or "", main_infos_screen_pos.x - 45, main_infos_screen_pos.y + 550)
+      gprintf(join_community_msg or "", 0, main_infos_screen_pos.y + 550, canvas_width, "center")
     end
   end
 

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -1214,7 +1214,7 @@ function main_net_vs_lobby()
       if showing_leaderboard then
         gprint(leaderboard_string, lobby_menu_x[showing_leaderboard] + 400, lobby_menu_y)
       end
-      gprint(join_community_msg, themes[config.theme].main_menu_screen_pos[1] + 30, canvas_height - 50)
+      gprintf(join_community_msg, 0, 668, canvas_width,"center")
       lobby_menu:draw()
     end
     updated = false


### PR DESCRIPTION
I'm officially an expert programmer now