### PR TITLE
Allow unique sfx for unique shock and combo sizes

### DIFF
--- a/FileUtil.lua
+++ b/FileUtil.lua
@@ -25,3 +25,7 @@ function FileUtil.getFilteredDirectoryItems(path)
 
   return results
 end
+
+function FileUtil.getFileNameWithoutExtension(filename)
+  return filename:gsub("%..*", "")
+end

--- a/character.lua
+++ b/character.lua
@@ -184,24 +184,6 @@ function Character.json_init(self)
   return false
 end
 
-function Character.stop_sounds(self)
-  -- SFX
-  for _, sound_table in ipairs(self.sounds) do
-    if type(sound_table) == "table" then
-      for _, sound in pairs(sound_table) do
-        sound:stop()
-      end
-    end
-  end
-
-  -- music
-  for _, music in ipairs(self.musics) do
-    if self.musics[music] then
-      self.musics[music]:stop()
-    end
-  end
-end
-
 function Character.play_selection_sfx(self)
   if not GAME.muteSoundEffects and #self.sounds.selections ~= 0 then
     self.sounds.selections[math.random(#self.sounds.selections)]:play()

--- a/character.lua
+++ b/character.lua
@@ -372,8 +372,6 @@ The level of sound loading is determined via "mayHaveSubSfx"
 local mayHaveSubSfx = { chain = true, combo = true, shock = true}
 
 function Character.loadSfx(self, name, yields)
-  
-
   local sfx = {}
 
   local stringLen = string.len(name)

--- a/character.lua
+++ b/character.lua
@@ -197,6 +197,8 @@ function Character.playComboSfx(self, size)
   if self.sounds.combo[0] == nil then
     -- no combos loaded, try to fallback to the fallback chain sound
     if self.sounds.chain[0] == nil then
+      -- technically we should always have a default chain sound from the default_character
+      -- so if this error ever occurs, something is seriously cursed
       error("Found neither chain nor combo sfx upon trying to play combo sfx")
     else
       self.sounds.chain[0][math.random(#self.sounds.chain[0])]:play()
@@ -710,28 +712,6 @@ function Character.fillInMissingSounds(self, sfxTable,  name, maxIndex)
       end
     end
   end
-end
-
--- reminder func, these fallbacks should respectively be applied in their PlayXyzSfx function rather than juggling around pointers
-function Character.applyFallback(self)
-
-    -- fallback case: chain/combo can be used for the other one if missing and for the longer names versions ("combo" used for "combo_echo" for instance)
-    if not self.sounds.others[sfx] then
-      if sfx == "chain" then
-        self.sounds.others[sfx] = load_sound_from_supported_extensions(self.path .. "/combo", false)
-      elseif sfx == "combo" then
-        self.sounds.others[sfx] = self.sounds.others["chain"]
-      elseif sfx == "combo_echo" then
-        self.sounds.others[sfx] = self.sounds.others["combo"]
-      elseif string.find(sfx, "chain") then
-        self.sounds.others[sfx] = self.sounds.others["chain"]
-      elseif string.find(sfx, "combo") then
-        self.sounds.others[sfx] = self.sounds.others["combo"]
-      end
-    end
-    if not self.sounds.others[sfx] and defaulted_sfxs[sfx] and not self:is_bundle() then
-      self.sounds.others[sfx] = default_character.sounds.others[sfx] or zero_sound
-    end
 end
 
 function Character.sound_init(self, full, yields)

--- a/character.lua
+++ b/character.lua
@@ -553,39 +553,6 @@ function Character.graphics_uninit(self)
   self.telegraph_garbage_images = {}
 end
 
-function Character.init_sfx_variants(self, sfx_array, sfx_name, sfx_suffix_at_higher_count)
-  sfx_suffix_at_higher_count = sfx_suffix_at_higher_count or ""
-
-  -- be careful is we are to support chain2X sfx since chain21 will be found and used for chain2 (unwanted behavior), might be a future bug!
-  local sound_name = sfx_name .. sfx_suffix_at_higher_count .. 1
-  if self.sounds.others[sfx_name] then
-    -- "combo" in others will be stored in 'combos' and 'others' will be freed from it
-    sfx_array[1] = self.sounds.others[sfx_name]
-    self.sounds.others[sfx_name] = nil
-  elseif sfx_suffix_at_higher_count == "" then
-    local sound = load_sound_from_supported_extensions(self.path .. "/" .. sound_name, false)
-    if sound then
-      sfx_array[1] = sound
-    end
-  else
-    local sound = load_sound_from_supported_extensions(self.path .. "/" .. sfx_name, false)
-    if sound then
-      sfx_array[1] = sound
-    end
-  end
-
-  -- search for all variants
-  local sfx_count = 1
-  while sfx_array[sfx_count] do
-    sfx_count = sfx_count + 1
-    sound_name = sfx_name .. sfx_suffix_at_higher_count .. sfx_count
-    local sound = load_sound_from_supported_extensions(self.path .. "/" .. sound_name, false)
-    if sound then
-      sfx_array[sfx_count] = sound
-    end
-  end
-end
-
 function Character.apply_config_volume(self)
   set_volume(self.sounds, config.SFX_volume / 100)
   set_volume(self.musics, config.music_volume / 100)

--- a/character.lua
+++ b/character.lua
@@ -550,7 +550,7 @@ function Character.playShockSfx(self, size)
 end
 
 -- Stops old combo / chaing sounds and plays the appropriate chain or combo sound
-function Character.play_combo_chain_sfx(self, chain_combo)
+function Character.playAttackSfx(self, attack)
   local function stopPreviousSounds()
     local function stopIfPlaying(audioSource)
       if audioSource:isPlaying() then
@@ -590,12 +590,12 @@ function Character.play_combo_chain_sfx(self, chain_combo)
     stopPreviousSounds()
 
     -- play combos or chains
-    if chain_combo.type == e_chain_or_combo.combo then
-      self:playComboSfx(chain_combo.size)
-    elseif chain_combo.type == e_chain_or_combo.shock then
-      self:playShockSfx(chain_combo.size)
+    if attack.type == e_chain_or_combo.combo then
+      self:playComboSfx(attack.size)
+    elseif attack.type == e_chain_or_combo.shock then
+      self:playShockSfx(attack.size)
     else --elseif chain_combo.type == e_chain_or_combo.chain then
-      self:playChainSfx(chain_combo.size)
+      self:playChainSfx(attack.size)
     end
   end
 end

--- a/character.lua
+++ b/character.lua
@@ -3,11 +3,12 @@ General character informating, loading and unloading
 Graphics
 Sound
 ]]--
-
-require("character_loader")
 local logger = require("logger")
 
 local default_character = nil -- holds default assets fallbacks
+
+local chainStyle = {classic = 0, per_chain = 1}
+local comboStyle = {classic = 0, per_combo = 1}
 
 Character =
   class(
@@ -141,136 +142,6 @@ function Character.unload(self)
   self:sound_uninit()
   self.fully_loaded = false
   logger.trace("unloaded character " .. self.id)
-end
-
--- Adds all the characters recursively in a folder to the global characters variable
-local function add_characters_from_dir_rec(path)
-  local lfs = love.filesystem
-  local raw_dir_list = FileUtil.getFilteredDirectoryItems(path)
-  for i, v in ipairs(raw_dir_list) do
-    local start_of_v = string.sub(v, 0, string.len(prefix_of_ignored_dirs))
-    if start_of_v ~= prefix_of_ignored_dirs then
-      local current_path = path .. "/" .. v
-      if lfs.getInfo(current_path) and lfs.getInfo(current_path).type == "directory" then
-        -- call recursively: facade folder
-        add_characters_from_dir_rec(current_path)
-
-        -- init stage: 'real' folder
-        local character = Character(current_path, v)
-        local success = character:json_init()
-
-        if success then
-          if characters[character.id] ~= nil then
-            logger.trace(current_path .. " has been ignored since a character with this id has already been found")
-          else
-            -- logger.trace(current_path.." has been added to the character list!")
-            characters[character.id] = character
-            characters_ids[#characters_ids + 1] = character.id
-          end
-        end
-      end
-    end
-  end
-end
-
--- Loads all character IDs into the characters_ids global
-local function fill_characters_ids()
-  -- check validity of bundle characters
-  local invalid = {}
-  local copy_of_characters_ids = shallowcpy(characters_ids)
-  characters_ids = {} -- clean up
-  for _, character_id in ipairs(copy_of_characters_ids) do
-    local character = characters[character_id]
-    if #character.sub_characters > 0 then -- bundle character (needs to be filtered if invalid)
-      local copy_of_sub_characters = shallowcpy(character.sub_characters)
-      character.sub_characters = {}
-      for _, sub_character in ipairs(copy_of_sub_characters) do
-        if characters[sub_character] and #characters[sub_character].sub_characters == 0 then -- inner bundles are prohibited
-          character.sub_characters[#character.sub_characters + 1] = sub_character
-          logger.trace(character.id .. " has " .. sub_character .. " as part of its subcharacters.")
-        end
-      end
-
-      if #character.sub_characters < 2 then
-        invalid[#invalid + 1] = character_id -- character is invalid
-        logger.warn(character.id .. " (bundle) is being ignored since it's invalid!")
-      else
-        characters_ids[#characters_ids + 1] = character_id
-        logger.debug(character.id .. " (bundle) has been added to the character list!")
-      end
-    else -- normal character
-      characters_ids[#characters_ids + 1] = character_id
-      logger.debug(character.id .. " has been added to the character list!")
-    end
-  end
-
-  -- characters are removed outside of the loop since erasing while iterating isn't working
-  for _, invalid_character in pairs(invalid) do
-    characters[invalid_character] = nil
-  end
-end
-
--- Initializes the characters globals with data
-function characters_init()
-  characters = {} -- holds all characters, most of them will not be fully loaded
-  characters_ids = {} -- holds all characters ids
-  characters_ids_for_current_theme = {} -- holds characters ids for the current theme, those characters will appear in the lobby
-  characters_ids_by_display_names = {} -- holds keys to array of character ids holding that name
-
-  add_characters_from_dir_rec("characters")
-  fill_characters_ids()
-
-  if #characters_ids == 0 then
-    recursive_copy("default_data/characters", "characters")
-    add_characters_from_dir_rec("characters")
-    fill_characters_ids()
-  end
-
-  if love.filesystem.getInfo("themes/" .. config.theme .. "/characters.txt") then
-    for line in love.filesystem.lines("themes/" .. config.theme .. "/characters.txt") do
-      line = trim(line) -- remove whitespace
-      if characters[line] then
-        -- found at least a valid character in a characters.txt file
-        characters_ids_for_current_theme[#characters_ids_for_current_theme + 1] = line
-      end
-    end
-  else
-    for _, character_id in ipairs(characters_ids) do
-      if characters[character_id].is_visible then
-        characters_ids_for_current_theme[#characters_ids_for_current_theme + 1] = character_id
-      end
-    end
-  end
-
-  -- all characters case
-  if #characters_ids_for_current_theme == 0 then
-    characters_ids_for_current_theme = shallowcpy(characters_ids)
-  end
-
-  -- fix config character if it's missing
-  if not config.character or (config.character ~= random_character_special_value and not characters[config.character]) then
-    config.character = table.getRandomElement(characters_ids_for_current_theme)
-  end
-
-  -- actual init for all characters, starting with the default one
-  default_character = Character("characters/__default", "__default")
-  default_character:preload()
-  default_character:load(true)
-
-  for _, character in pairs(characters) do
-    character:preload()
-
-    if characters_ids_by_display_names[character.display_name] then
-      characters_ids_by_display_names[character.display_name][#characters_ids_by_display_names[character.display_name] + 1] = character.id
-    else
-      characters_ids_by_display_names[character.display_name] = {character.id}
-    end
-  end
-
-  if config.character ~= random_character_special_value and not characters[config.character]:is_bundle() then
-    character_loader_load(config.character)
-    character_loader_wait()
-  end
 end
 
 function Character.is_bundle(self)
@@ -429,9 +300,6 @@ local other_sfx = {
 local basic_musics = {}
 local other_musics = {"normal_music", "danger_music", "normal_music_start", "danger_music_start"}
 local defaulted_musics = {} -- those musics will be defaulted if missing
-
-local chainStyle = {classic = 0, per_chain = 1}
-local comboStyle = {classic = 0, per_combo = 1}
 
 function Character.sound_init(self, full, yields)
   -- SFX

--- a/character.lua
+++ b/character.lua
@@ -467,7 +467,7 @@ end
 function Character.sound_uninit(self)
   -- SFX
   for _, sound in ipairs(other_sfx) do
-    self.sounds.others[sound] = nil
+    self.sounds[sound] = nil
   end
 
   -- music
@@ -602,8 +602,8 @@ end
 -- sound playing / sound control
 
 function Character.play_selection_sfx(self)
-  if not GAME.muteSoundEffects and #self.sounds.selections ~= 0 then
-    self.sounds.selections[math.random(#self.sounds.selections)]:play()
+  if not GAME.muteSoundEffects and #self.sounds.selection ~= 0 then
+    self.sounds.selection[math.random(#self.sounds.selection)]:play()
     return true
   end
   return false

--- a/character.lua
+++ b/character.lua
@@ -487,6 +487,10 @@ function Character.play_selection_sfx(self)
   return false
 end
 
+local function defaultChainPlayback(character)
+  character.sounds.chain[0][math.random(#character.sounds.chain[0])]:play()
+end
+
 function Character.playComboSfx(self, size)
   -- self.sounds.combo[0] is the fallback combo sound which is guaranteed to be set if there is a combo sfx
   if self.sounds.combo[0] == nil then
@@ -496,7 +500,7 @@ function Character.playComboSfx(self, size)
       -- so if this error ever occurs, something is seriously cursed
       error("Found neither chain nor combo sfx upon trying to play combo sfx")
     else
-      self.sounds.chain[0][math.random(#self.sounds.chain[0])]:play()
+      defaultChainPlayback(self)
     end
   else
     -- combo sfx available!
@@ -519,23 +523,31 @@ function Character.playChainSfx(self, length)
   if self.chain_style == chainStyle.classic then
     if length < 4 then
       -- chain needs special indexing as it shares its table with per_chain style chain sfx
-      self.sounds.chain[1][math.random(#self.sounds.chain[1])]:play()
+      if self.sounds.chain[1] then
+        self.sounds.chain[1][math.random(#self.sounds.chain[1])]:play()
+      else
+        defaultChainPlayback(self)
+      end
     elseif length == 4 then
       -- chain needs special indexing as it shares its table with per_chain style chain sfx
-      self.sounds.chain[2][math.random(#self.sounds.chain[2])]:play()
+      if self.sounds.chain[2] then
+        self.sounds.chain[2][math.random(#self.sounds.chain[2])]:play()
+      else
+        defaultChainPlayback(self)
+      end
     elseif length == 5 then
       if #self.sounds.chain_echo > 0 then
         self.sounds.chain_echo[math.random(#self.sounds.chain_echo)]:play()
       else
         -- fallback to chain instead of its own fallback
-        self.sounds.chain[0][math.random(#self.sounds.chain[0])]:play()
+        defaultChainPlayback(self)
       end
     elseif length >= 6 then
       if #self.sounds.chain2_echo > 0 then
         self.sounds.chain2_echo[math.random(#self.sounds.chain2_echo)]:play()
       else
         -- fallback to chain instead of its own fallback
-        self.sounds.chain[0][math.random(#self.sounds.chain[0])]:play()
+        defaultChainPlayback(self)
       end
     end
   else --elseif self.chain_style == chainStyle.per_chain then
@@ -543,7 +555,7 @@ function Character.playChainSfx(self, length)
     if self.sounds.chain[length] then
       self.sounds.chain[length][math.random(#self.sounds.chain[length])]:play()
     else
-      self.sounds.chain[0][math.random(#self.sounds.chain[0])]:play()
+      defaultChainPlayback(self)
     end
   end
 end

--- a/character.lua
+++ b/character.lua
@@ -385,7 +385,7 @@ function Character.graphics_init(self, full, yields)
     if not self.telegraph_garbage_images["metal"] and default_character.telegraph_garbage_images["metal"] then
       self.telegraph_garbage_images["metal"] = default_character.telegraph_garbage_images["metal"]
       logger.debug("DEFAULT used for telegraph/6-wide-metal")
-    elseif not self.telegraph_garbage_images[1][garbage_w] then
+    elseif not self.telegraph_garbage_images["metal"] then
       logger.debug("FAILED TO LOAD: telegraph/6-wide-metal")
     end
     logger.debug("telegraph/attack")
@@ -393,7 +393,7 @@ function Character.graphics_init(self, full, yields)
     if not self.telegraph_garbage_images["attack"] and default_character.telegraph_garbage_images["attack"] then
       self.telegraph_garbage_images["attack"] = default_character.telegraph_garbage_images["attack"]
       logger.debug("DEFAULT used for telegraph/attack")
-    elseif not self.telegraph_garbage_images[1][garbage_w] then
+    elseif not self.telegraph_garbage_images["attack"] then
       logger.debug("FAILED TO LOAD: telegraph/attack")
     end
   end

--- a/character_loader.lua
+++ b/character_loader.lua
@@ -1,5 +1,7 @@
 require("queue")
 require("globals")
+require("character")
+local logger = require("logger")
 
 local loading_queue = Queue()
 
@@ -173,9 +175,7 @@ function characters_init()
   end
 
   -- actual init for all characters, starting with the default one
-  default_character = Character("characters/__default", "__default")
-  default_character:preload()
-  default_character:load(true)
+  Character.loadDefaultCharacter()
 
   for _, character in pairs(characters) do
     character:preload()

--- a/character_loader.lua
+++ b/character_loader.lua
@@ -5,6 +5,11 @@ local loading_queue = Queue()
 
 local loading_character = nil
 
+characters = {} -- holds all characters, most of them will not be fully loaded
+characters_ids = {} -- holds all characters ids
+characters_ids_for_current_theme = {} -- holds characters ids for the current theme, those characters will appear in the lobby
+characters_ids_by_display_names = {} -- holds keys to array of character ids holding that name
+
 -- queues a character to be loaded
 function character_loader_load(character_id)
   if characters[character_id] and not characters[character_id].fully_loaded then
@@ -60,5 +65,130 @@ function character_loader_clear()
     if character.fully_loaded and character_id ~= config.character and character_id ~= p2_local_character then
       character:unload()
     end
+  end
+end
+
+-- Adds all the characters recursively in a folder to the global characters variable
+local function add_characters_from_dir_rec(path)
+  local lfs = love.filesystem
+  local raw_dir_list = FileUtil.getFilteredDirectoryItems(path)
+  for i, v in ipairs(raw_dir_list) do
+    local start_of_v = string.sub(v, 0, string.len(prefix_of_ignored_dirs))
+    if start_of_v ~= prefix_of_ignored_dirs then
+      local current_path = path .. "/" .. v
+      if lfs.getInfo(current_path) and lfs.getInfo(current_path).type == "directory" then
+        -- call recursively: facade folder
+        add_characters_from_dir_rec(current_path)
+
+        -- init stage: 'real' folder
+        local character = Character(current_path, v)
+        local success = character:json_init()
+
+        if success then
+          if characters[character.id] ~= nil then
+            logger.trace(current_path .. " has been ignored since a character with this id has already been found")
+          else
+            -- logger.trace(current_path.." has been added to the character list!")
+            characters[character.id] = character
+            characters_ids[#characters_ids + 1] = character.id
+          end
+        end
+      end
+    end
+  end
+end
+
+-- Loads all character IDs into the characters_ids global
+local function fill_characters_ids()
+  -- check validity of bundle characters
+  local invalid = {}
+  local copy_of_characters_ids = shallowcpy(characters_ids)
+  characters_ids = {} -- clean up
+  for _, character_id in ipairs(copy_of_characters_ids) do
+    local character = characters[character_id]
+    if #character.sub_characters > 0 then -- bundle character (needs to be filtered if invalid)
+      local copy_of_sub_characters = shallowcpy(character.sub_characters)
+      character.sub_characters = {}
+      for _, sub_character in ipairs(copy_of_sub_characters) do
+        if characters[sub_character] and #characters[sub_character].sub_characters == 0 then -- inner bundles are prohibited
+          character.sub_characters[#character.sub_characters + 1] = sub_character
+          logger.trace(character.id .. " has " .. sub_character .. " as part of its subcharacters.")
+        end
+      end
+
+      if #character.sub_characters < 2 then
+        invalid[#invalid + 1] = character_id -- character is invalid
+        logger.warn(character.id .. " (bundle) is being ignored since it's invalid!")
+      else
+        characters_ids[#characters_ids + 1] = character_id
+        logger.debug(character.id .. " (bundle) has been added to the character list!")
+      end
+    else -- normal character
+      characters_ids[#characters_ids + 1] = character_id
+      logger.debug(character.id .. " has been added to the character list!")
+    end
+  end
+
+  -- characters are removed outside of the loop since erasing while iterating isn't working
+  for _, invalid_character in pairs(invalid) do
+    characters[invalid_character] = nil
+  end
+end
+
+-- Initializes the characters globals with data
+function characters_init()
+  add_characters_from_dir_rec("characters")
+  fill_characters_ids()
+
+  if #characters_ids == 0 then
+    recursive_copy("default_data/characters", "characters")
+    add_characters_from_dir_rec("characters")
+    fill_characters_ids()
+  end
+
+  if love.filesystem.getInfo("themes/" .. config.theme .. "/characters.txt") then
+    for line in love.filesystem.lines("themes/" .. config.theme .. "/characters.txt") do
+      line = trim(line) -- remove whitespace
+      if characters[line] then
+        -- found at least a valid character in a characters.txt file
+        characters_ids_for_current_theme[#characters_ids_for_current_theme + 1] = line
+      end
+    end
+  else
+    for _, character_id in ipairs(characters_ids) do
+      if characters[character_id].is_visible then
+        characters_ids_for_current_theme[#characters_ids_for_current_theme + 1] = character_id
+      end
+    end
+  end
+
+  -- all characters case
+  if #characters_ids_for_current_theme == 0 then
+    characters_ids_for_current_theme = shallowcpy(characters_ids)
+  end
+
+  -- fix config character if it's missing
+  if not config.character or (config.character ~= random_character_special_value and not characters[config.character]) then
+    config.character = table.getRandomElement(characters_ids_for_current_theme)
+  end
+
+  -- actual init for all characters, starting with the default one
+  default_character = Character("characters/__default", "__default")
+  default_character:preload()
+  default_character:load(true)
+
+  for _, character in pairs(characters) do
+    character:preload()
+
+    if characters_ids_by_display_names[character.display_name] then
+      characters_ids_by_display_names[character.display_name][#characters_ids_by_display_names[character.display_name] + 1] = character.id
+    else
+      characters_ids_by_display_names[character.display_name] = {character.id}
+    end
+  end
+
+  if config.character ~= random_character_special_value and not characters[config.character]:is_bundle() then
+    character_loader_load(config.character)
+    character_loader_wait()
   end
 end

--- a/consts.lua
+++ b/consts.lua
@@ -213,7 +213,7 @@ colors = {  red     = {220/255, 50/255,  47/255 },
             black   = {20/255,  20/255,  20/255 },
             dgray   = {28/255,  28/255,  28/255 }}
 
-e_chain_or_combo = { combo=0, chain=1 }
+e_chain_or_combo = { combo=0, chain=1, shock=2 }
             
 panel_color_number_to_upper = {"A", "B", "C", "D", "E", "F", "G", "H",[0]="0"}
 panel_color_number_to_lower = {"a", "b", "c", "d", "e", "f", "g", "h",[0]="0"}

--- a/engine.lua
+++ b/engine.lua
@@ -1956,7 +1956,7 @@ function Stack.simulate(self)
       if self.combo_chain_play then
         themes[config.theme].sounds.land:stop()
         themes[config.theme].sounds.pops[self.lastPopLevelPlayed][self.lastPopIndexPlayed]:stop()
-        characters[self.character]:play_combo_chain_sfx(self.combo_chain_play)
+        characters[self.character]:playAttackSfx(self.combo_chain_play)
         self.combo_chain_play = nil
       end
       if SFX_garbage_match_play then

--- a/engine.lua
+++ b/engine.lua
@@ -2696,9 +2696,9 @@ function Stack.check_matches(self)
       -- @CardsOfTheHeart says there are 4 chain sfx: --x2/x3, --x4, --x5 is x2/x3 with an echo effect, --x6+ is x4 with an echo effect
       if self:shouldChangeSoundEffects() then
         if is_chain then
-          self.combo_chain_play = {e_chain_or_combo.chain, self.chain_counter}
+          self.combo_chain_play = {type = e_chain_or_combo.chain, size = self.chain_counter}
         elseif combo_size > 3 then
-          self.combo_chain_play = {e_chain_or_combo.combo, "combos"}
+          self.combo_chain_play = {type = e_chain_or_combo.combo, size = combo_size}
         end
       end
       self.sfx_land = false
@@ -2710,10 +2710,8 @@ function Stack.check_matches(self)
     self.manual_raise = false
     --self.score_render=1;
     --Nope.
-    if metal_count > 5 then
-      self.combo_chain_play = {e_chain_or_combo.combo, "combo_echos"}
-    elseif metal_count > 2 then
-      self.combo_chain_play = {e_chain_or_combo.combo, "combos"}
+    if metal_count > 2 then
+      self.combo_chain_play = { type = e_chain_or_combo.shock, size = metal_count}
     end
   end
 end

--- a/engine.lua
+++ b/engine.lua
@@ -1668,17 +1668,11 @@ function Stack.simulate(self)
     -- TAUNTING
     if self:shouldChangeSoundEffects() then
       if self.taunt_up ~= nil then
-        for _, t in ipairs(characters[self.character].sounds.taunt_ups) do
-          t:stop()
-        end
-        characters[self.character].sounds.taunt_ups[self.taunt_up]:play()
+        characters[self.character]:playTauntUpSfx(self.taunt_up)
         self:taunt("taunt_up")
         self.taunt_up = nil
       elseif self.taunt_down ~= nil then
-        for _, t in ipairs(characters[self.character].sounds.taunt_downs) do
-          t:stop()
-        end
-        characters[self.character].sounds.taunt_downs[self.taunt_down]:play()
+        characters[self.character]:playTauntDownSfx(self.taunt_down)
         self:taunt("taunt_down")
         self.taunt_down = nil
       end
@@ -1960,12 +1954,7 @@ function Stack.simulate(self)
         self.combo_chain_play = nil
       end
       if SFX_garbage_match_play then
-        for _, v in pairs(characters[self.character].sounds.garbage_matches) do
-          v:stop()
-        end
-        if #characters[self.character].sounds.garbage_matches ~= 0 then
-          characters[self.character].sounds.garbage_matches[math.random(#characters[self.character].sounds.garbage_matches)]:play()
-        end
+        characters[self.character]:playGarbageMatchSfx()
         SFX_garbage_match_play = nil
       end
       if SFX_Fanfare_Play == 0 then
@@ -1991,11 +1980,8 @@ function Stack.simulate(self)
         else
           themes[config.theme].sounds.garbage_thud[self.sfx_garbage_thud]:play()
         end
-        if #characters[self.character].sounds.garbage_lands ~= 0 and interrupted_thud == nil then
-          for _, v in pairs(characters[self.character].sounds.garbage_lands) do
-            v:stop()
-          end
-          characters[self.character].sounds.garbage_lands[math.random(#characters[self.character].sounds.garbage_lands)]:play()
+        if interrupted_thud == nil then
+          characters[self.character]:playGarbageLandSfx()
         end
         self.sfx_garbage_thud = 0
       end
@@ -2213,8 +2199,8 @@ end
 
 -- Randomly returns a win sound if the character has one
 function Stack.pick_win_sfx(self)
-  if #characters[self.character].sounds.wins ~= 0 then
-    return characters[self.character].sounds.wins[math.random(#characters[self.character].sounds.wins)]
+  if #characters[self.character].sounds.win ~= 0 then
+    return characters[self.character].sounds.win[math.random(#characters[self.character].sounds.win)]
   else
     return themes[config.theme].sounds.fanfare1 -- TODO add a default win sound
   end

--- a/main.lua
+++ b/main.lua
@@ -11,7 +11,7 @@ local consts = require("consts")
 require("FileUtil")
 require("queue")
 require("globals")
-require("character") -- after globals!
+require("character_loader") -- after globals!
 require("stage") -- after globals!
 require("save")
 require("engine/GarbageQueue")

--- a/options.lua
+++ b/options.lua
@@ -539,13 +539,13 @@ local function audio_menu(button_idx)
               end
               musics_to_use = characters[tracks[index].id].musics
 
-              addSounds("combo", characters[tracks[index].id].sounds.combos, " ")
+              addSounds("combo", characters[tracks[index].id].sounds.combo, " ")
 
-              if next(characters[tracks[index].id].sounds.combos) and next(characters[tracks[index].id].sounds.combo_echos) and not (characters[tracks[index].id].sounds.combos[1] == characters[tracks[index].id].sounds.combo_echos[1]) then
+              if next(characters[tracks[index].id].sounds.combo) and next(characters[tracks[index].id].sounds.combo_echo) and not (characters[tracks[index].id].sounds.combo[1] == characters[tracks[index].id].sounds.combo_echo[1]) then
                 addSounds("combo echo", characters[tracks[index].id].sounds.combo_echos, " ")
               end
 
-              if next(characters[tracks[index].id].sounds.chains) == nil and next(characters[tracks[index].id].sounds.others) and not (characters[tracks[index].id].sounds.others["chain"] == characters[tracks[index].id].sounds.combos[1]) then
+              if next(characters[tracks[index].id].sounds.chain) == nil and next(characters[tracks[index].id].sounds.others) and not (characters[tracks[index].id].sounds.others["chain"] == characters[tracks[index].id].sounds.combo[1]) then
                 addSound("chain", characters[tracks[index].id].sounds.others["chain"])
                 if characters[tracks[index].id].sounds.others["chain"] ~= characters[tracks[index].id].sounds.others["chain2"] then
                   addSound("chain 2", characters[tracks[index].id].sounds.others["chain2"])
@@ -558,27 +558,27 @@ local function audio_menu(button_idx)
                 end
               else
                 for i=2,13 do
-                  if characters[tracks[index].id].sounds.chains[i] ~=nil and i==2 or not content_equal(characters[tracks[index].id].sounds.chains[i-1], characters[tracks[index].id].sounds.chains[i]) then
-                    addSounds("chain "..i, characters[tracks[index].id].sounds.chains[i], "-")
+                  if characters[tracks[index].id].sounds.chain[i] ~=nil and i==2 or not content_equal(characters[tracks[index].id].sounds.chain[i-1], characters[tracks[index].id].sounds.chain[i]) then
+                    addSounds("chain "..i, characters[tracks[index].id].sounds.chain[i], "-")
                   end
                 end
-                if characters[tracks[index].id].sounds.chains[0] ~=nil and not content_equal(characters[tracks[index].id].sounds.chains[13], characters[tracks[index].id].sounds.chains[0]) then
-                  addSounds("chain ?", characters[tracks[index].id].sounds.chains[0], "-")
+                if characters[tracks[index].id].sounds.chain[0] ~=nil and not content_equal(characters[tracks[index].id].sounds.chain[13], characters[tracks[index].id].sounds.chain[0]) then
+                  addSounds("chain ?", characters[tracks[index].id].sounds.chain[0], "-")
                 end
               end
 
-              addSounds("garbage match", characters[tracks[index].id].sounds.garbage_matches, " ")
-              addSounds("garbage land", characters[tracks[index].id].sounds.garbage_lands, " ")
+              addSounds("garbage match", characters[tracks[index].id].sounds.garbage_match, " ")
+              addSounds("garbage land", characters[tracks[index].id].sounds.garbage_land, " ")
               
               if next(characters[tracks[index].id].sounds.selections) == nil and tracks[index].parent_id then
-                addSounds("selection", characters[tracks[index].parent_id].sounds.selections, " ")
+                addSounds("selection", characters[tracks[index].parent_id].sounds.selection, " ")
               else
-                addSounds("selection", characters[tracks[index].id].sounds.selections, " ")
+                addSounds("selection", characters[tracks[index].id].sounds.selection, " ")
               end
 
-              addSounds("win", characters[tracks[index].id].sounds.wins, " ")
-              addSounds("taunt up", characters[tracks[index].id].sounds.taunt_ups, " ")
-              addSounds("taunt down", characters[tracks[index].id].sounds.taunt_downs, " ")
+              addSounds("win", characters[tracks[index].id].sounds.win, " ")
+              addSounds("taunt up", characters[tracks[index].id].sounds.taunt_up, " ")
+              addSounds("taunt down", characters[tracks[index].id].sounds.taunt_down, " ")
               
               current_sound_index = 1
 

--- a/readme_characters.txt
+++ b/readme_characters.txt
@@ -48,11 +48,41 @@ Other image assets:
 - "burst" or "fade": The image used for popfx. The image should be 9 equal sized frames in a row, first frame is the telegraph, frames 2 to 9 are the burst or fade animation
 
 ~~ [.mp3, .ogg, .wav, .it, .flac] optional sounds are in parenthesis ~~
-- "combo" (,"combo2", "combo3"...): combo [selected at random if more than one]
-- ("combo_echo", ("combo_echo2", "combo_echo3"...)): six metal blocks combo [selected at random if more than one]
-- Chain: depending on the current chain length and the defined mode, the appopriate sound file will be played:
-    classic system: x2/3 plays "chain",  x4 plays "chain2", x5 plays "chain_echo", x6+ plays "chain2_echo"
-    per_chain system: x2 "chain2"(, "chain2_2", "chain2_3"...), x3 "chain3"(, "chain3_2", "chain3_3"...), ..., x13 "chain13"(, "chain13_2", ...), x13+ "chain0"(, ...) [selected at random if more than one]
+- Combo: You may select one of two systems, to be specified in the config.json of your character.
+	classic system: 
+		"combo" (,"combo2", "combo3"...): combo [selected at random if more than one]
+	per_combo system: 
+		Provide a sfx for each combo size. More than one variation may be provided for each size by appending _# to the filename where # is a number. If that is the case, selection between the available files is random.
+		If no file is provided for a certain combo size the first available lower combo sfx will be played instead. This means the minimum of per_combo style sfx consists of only a single "combo4" sfx.
+		Example: 	+4 "combo4"(, "combo4_2", "combo4_3"...), 
+					+5 "combo5"(, "combo5_2, "combo5_3"...), 
+					...,
+					+20 "combo20"(, "combo20_2", ...)
+					+27 "combo27"(, "combo27_2", ...)
+		While the combo size you may provide files for is not limited, combos above +27 will not send any more garbage, having no added value as a sound cue.
+	If no combo sfx are provided at all, the default chain sound will be used instead.
+- Shock: For shock matches and combos, provide a sfx for each match/combo size. More than one variation may be provided for each size by appending _# to the filename where # is a number. If that is the case, selection between the available files is random.
+	Example:	+3 "shock3"(, "shock3_2, "shock3_3" ...),
+				+4 "shock4"(, "shock4_2, "shock4_3" ...),
+				...,
+				+7 "shock7"(, "shock7_2, ...)
+	[DEPRECATED] "combo_echo", ("combo_echo2", "combo_echo3"...) will get used upon a +6 or +7 shock combo. These files have no effect if shock files are present.
+- Chain: You may select one of two systems, to be specified in the config.json of your character. Per_chain is strongly suggested.
+    per_chain system: 
+		Provide a sfx for each chain length. More than one variation may be provided for each length by appending _# to the filename where # is a number. If that is the case, selection between the available files is random.
+		If no file is provided for a certain chain length the first available lower chain sfx will be played instead. This means the minimum of per_chain style sfx consists of only a single "chain" or "chain2" sfx.
+		Example: 	x2 "chain2"(, "chain2_2", "chain2_3"...), 
+					x3 "chain3"(, "chain3_2", "chain3_3"...), 
+					..., 
+					x13 "chain13"(, "chain13_2", ...), 
+					x13+ "chain0"(, ...)
+	classic system [DEPRECATED]: 
+		x2/3 plays "chain",  
+		x4 plays "chain2", 
+		x5 plays "chain_echo", 
+		x6+ plays "chain2_echo"
+	Due to backwards compatibility reason the classic system remains as the default.
+	If you wish to use classic style chain sounds, you can use the per_chain system and add "chain" as "chain2", "chain2" as "chain4", "chain_echo" as "chain5" and "chain2_echo" as "chain6".
 - ("garbage_match" (,"garbage_match2", "garbage_match3"...)): played when clearing garbage [selected at random if more than one]
 - ("garbage_land" (,"garbage_land2", "garbage_land3"...)): played when garbage lands on your side [selected at random if more than one]
 - ("selection", ("selection2", "selection3"...)): upon selection [selected at random if more than one]
@@ -61,5 +91,5 @@ Other image assets:
 - "normal_music": music that will be played while playing with this character if the option use_music_from's value is characters and your character gets picked
 - ("danger_music"): music that will be used when a player is in danger (top of the screen) if the option use_music_from's value is characters and your character gets picked
 
-Note: providing just a "chain" or just a "combo" SFX is OK. It would get used for all combos and chains.
+Note: providing just a "chain" SFX is OK. It would get used for all combos and chains.
 Note: if your music has an intro, cut it from the main music file, and name it "normal_music_start" or "danger_music_start"

--- a/readme_characters.txt
+++ b/readme_characters.txt
@@ -49,7 +49,7 @@ Other image assets:
 
 ~~ [.mp3, .ogg, .wav, .it, .flac] optional sounds are in parenthesis ~~
 - Combo: You may select one of two systems, to be specified in the config.json of your character.
-	classic system: 
+	classic system [DEFAULT]: 
 		"combo" (,"combo2", "combo3"...): combo [selected at random if more than one]
 	per_combo system: 
 		Provide a sfx for each combo size. More than one variation may be provided for each size by appending _# to the filename where # is a number. If that is the case, selection between the available files is random.
@@ -76,7 +76,7 @@ Other image assets:
 					..., 
 					x13 "chain13"(, "chain13_2", ...), 
 					x13+ "chain0"(, ...)
-	classic system [DEPRECATED]: 
+	classic system [DEPRECATED][DEFAULT]: 
 		x2/3 plays "chain",  
 		x4 plays "chain2", 
 		x5 plays "chain_echo", 

--- a/stage.lua
+++ b/stage.lua
@@ -71,16 +71,6 @@ function Stage.json_init(self)
   return false
 end
 
--- stops stage sounds
-function Stage.stop_sounds(self)
-  -- music
-  for _, music in ipairs(self.musics) do
-    if self.musics[music] then
-      self.musics[music]:stop()
-    end
-  end
-end
-
 -- preemptively loads a stage
 function Stage.preload(self)
   logger.trace("preloading stage " .. self.id)


### PR DESCRIPTION
I didn't sleep tonight.
Closes #429 and closes #521
I did successfully test some characters for compatibility so far (Phoenix, Ashley, Kurtupo) and I did test the shock3 playback.
For now as draft as I'm 100% sure sound test will either break or not function properly in parts and I still have to test combos properly.

In the process I took apart effectively the entire sound loading and playing part of character.lua

# Summary of changes

## Refactoring

### Removal of unused functions

Both stage.lua and character.lua had a stop_sounds function that was used nowhere. Stumbled over it due to the attack SFX func in character.lua having its own code for muting other sounds when I reorganised the sections

### Structure of character.lua

I moved `characters_init` and the attached local functions to `character_loader` as that function is ultimately about...loading characters on game start. Updated the requires accordingly.
I reordered the functions inside of characters.lua so that they're now ordered into general loading/unloading and character stuff, graphics and sound.

### Sound playback

Inside of engine I looked for all direct access to the character's `sounds` table and replaced these occurences with calls to new functions in character.lua, separating character sfx playback more cleanly from engine.

### Sound loading

I rewrote the process for SFX loading more or less from scratch. There is now a generic `loadSFX` method that returns a table of soundfiles for an asset name. As I strongly tied them to their file names I also changed the references on the sound table to use the same name as the asset name so that new assets can be loaded by as much trouble as adding them to the `other_sfx` table.
Due to that I had to rename references in various places.
As a side effect, PA can now load and play chain files up to infinity rather than forcefully stopping at x13, matching our chain cards and variant sfxs no longer need to be numbered sequentially (no idea if they really had to be before but now they definitely don't need to be).
Rather than using a metatable to cover chain and combo sizes for which files do not exists, I stuck to the "fallback to 0" strategy to continue to support the `chain0` file from the old spec without breaking genericity (is that a word?).

## Potential issues

With the way how I changed the loading process, bundle characters currently have all their assets loaded if called with `load(full)` which wasn't the case before. Since they usually get resolved into the sub characters by `refreshBasedOnOwnMods` before load(full) is called, I think that is okay for now. I eventually want to follow that up in regards to #555.

## Documentation

I did update the readme with relevant information.
As we do have scrolling on readme pages now, I felt like adding a bit of formatting but I'll have to revisit cause right now some lines are cutting off horizontally I think. And I think it doesn't look very good anyway yet so maybe someone can nudge me into the right direction in terms of text doc design.

## Bugfix

There were some incorrect references to an out-of-scope variable in code that ordinarily doesn't get reached when loading the telegraph images in `Character.graphics_init`.