### PR TITLE
Rename taunt_up and taunt_down

### DIFF
--- a/network.lua
+++ b/network.lua
@@ -309,15 +309,15 @@ end
 
 function Stack.handle_input_taunt(self)
 
-  if player_taunt_up(self.which) and self:can_taunt() and #characters[self.character].sounds.taunt_ups > 0 then
-    self.taunt_up = math.random(#characters[self.character].sounds.taunt_ups)
+  if player_taunt_up(self.which) and self:can_taunt() and #characters[self.character].sounds.taunt_up > 0 then
+    self.taunt_up = math.random(#characters[self.character].sounds.taunt_up)
     if TCP_sock then
-      json_send({taunt = true, type = "taunt_ups", index = self.taunt_up})
+      json_send({taunt = true, type = "taunt_up", index = self.taunt_up})
     end
-  elseif player_taunt_down(self.which) and self:can_taunt() and #characters[self.character].sounds.taunt_downs > 0 then
-    self.taunt_down = math.random(#characters[self.character].sounds.taunt_downs)
+  elseif player_taunt_down(self.which) and self:can_taunt() and #characters[self.character].sounds.taunt_down > 0 then
+    self.taunt_down = math.random(#characters[self.character].sounds.taunt_down)
     if TCP_sock then
-      json_send({taunt = true, type = "taunt_downs", index = self.taunt_down})
+      json_send({taunt = true, type = "taunt_down", index = self.taunt_down})
     end
   end
 end


### PR DESCRIPTION
Fixed an issue with taunt_ups and taunt_downs crashing the game when using taunts. Renamed to taunt_up and taunt_down as the previous variables are not defined.