### PR TITLE
Extract panel logic from Stack

### DIFF
--- a/Puzzle.lua
+++ b/Puzzle.lua
@@ -117,9 +117,9 @@ end
 
 function Puzzle.toPuzzleString(panels)
   local function getPanelColor(panel)
-    if panel.garbage then
+    if panel.type == Panel.types.garbage then
       local effectiveHeight = panel.height
-      if panel.state == "matched" then
+      if panel.state == Panel.states.matched then
         -- this is making the assumption that garbage that is currently clearing into panels is still to be included for the garbage block
         effectiveHeight = panel.height + 1
       end

--- a/dkjson.lua
+++ b/dkjson.lua
@@ -352,6 +352,8 @@ encode2 = function (value, indent, level, buffer, buflen, tables, globalorder, s
       buffer[buflen] = "}"
     end
     tables[value] = nil
+  elseif valtype == 'function' then
+    -- ignore this
   else
     return exception ('unsupported type', value, state, buffer, buflen,
       "type '" .. valtype .. "' is not supported by JSON.")

--- a/engine/panel.lua
+++ b/engine/panel.lua
@@ -1,0 +1,226 @@
+-- Represents an individual panel in the stack
+Panel =
+class(
+  function(p, id, row, column)
+    p:clear()
+    p.id = id
+    p.row = row
+    p.column = column
+  end
+)
+
+Panel.types = { empty = 0, panel = 1, garbage = 2}
+Panel.states = {
+  normal = 0,
+  swapping = 1,
+  matched = 2,
+  popping = 3,
+  popped = 4,
+  hovering = 5,
+  falling = 6,
+  landing = 7,
+  dimmed = 8,
+  dead = 9
+}
+
+function Panel.regularColorsArray()
+  return {
+    1, -- hearts
+    2, -- circles
+    3, -- triangles
+    4, -- stars
+    5, -- diamonds
+    6, -- inverse triangles
+  }
+  -- Note see the methods below for square, shock, and colorless
+end
+
+function Panel.extendedRegularColorsArray()
+  local result = Panel.regularColorsArray()
+  result[#result + 1] = 7 -- squares
+  return result
+end
+
+function Panel.allPossibleColorsArray()
+  local result = Panel.extendedRegularColorsArray()
+  result[#result + 1] = 8 -- shock
+  result[#result + 1] = 9 -- colorless
+  return result
+end
+
+-- Sets all variables to the default settings
+function Panel.clear(self)
+  -- color 0 is an empty panel.
+  -- colors 1-7 are normal colors, 8 is [!], 9 is garbage.
+  self.color = 0
+  -- A panel's timer indicates for how many more frames it will:
+  --  . be swapping
+  --  . sit in the MATCHED state before being set POPPING
+  --  . sit in the POPPING state before actually being POPPED
+  --  . sit and be POPPED before disappearing for good
+  --  . hover before FALLING
+  -- depending on which one of these states the panel is in.
+  self.timer = 0
+  -- is_swapping is set if the panel is swapping.
+  -- The panel's timer then counts down from 3 to 0,
+  -- causing the swap to end 3 frames later.
+  -- The timer is also used to offset the panel's
+  -- position on the screen.
+
+  self.initial_time = nil
+  self.pop_time = nil
+  self.pop_index = nil
+  self.x_offset = nil
+  self.y_offset = nil
+  self.width = nil
+  self.height = nil
+  self.type = nil
+  self.metal = nil
+  self.shake_time = nil
+  self.match_anyway = nil
+
+  -- Also flags
+  self:clear_flags()
+end
+
+-- states:
+-- swapping, matched, popping, popped, hovering,
+-- falling, dimmed, landing, normal
+-- flags:
+-- from_left
+-- dont_swap
+-- chaining
+
+local exclude_hover_set = {
+  matched = true,
+  popping = true,
+  popped = true,
+  hovering = true,
+  falling = true
+}
+function Panel.exclude_hover(self)
+  return exclude_hover_set[self.state] or self.type == Panel.types.garbage
+end
+
+local exclude_match_set = {
+  swapping = true,
+  matched = true,
+  popping = true,
+  popped = true,
+  dimmed = true,
+  falling = true
+}
+function Panel.exclude_match(self)
+  return exclude_match_set[self.state] or self.color == 0 or self.color == 9 or
+      (self.state == Panel.states.hovering and not self.match_anyway)
+end
+
+local exclude_swap_set = {
+  matched = true,
+  popping = true,
+  popped = true,
+  hovering = true,
+  dimmed = true
+}
+function Panel.exclude_swap(self)
+  return exclude_swap_set[self.state] or self.dont_swap or self.type == Panel.types.garbage
+end
+
+function Panel.support_garbage(self)
+  return self.color ~= 0 or self.hovering
+end
+
+-- "Block garbage fall" means
+-- "falling-ness should not propogate up through this panel"
+-- We need this because garbage doesn't hover, it just falls
+-- opportunistically.
+local block_garbage_fall_set = {
+  matched = true,
+  popping = true,
+  popped = true,
+  hovering = true,
+  swapping = true
+}
+function Panel.block_garbage_fall(self)
+  return block_garbage_fall_set[self.state] or self.color == 0
+end
+
+function Panel.dangerous(self)
+  return self.color ~= 0 and not (self.state == Panel.states.falling and self.type == Panel.types.garbage)
+end
+
+function Panel.has_flags(self)
+  return (self.state ~= Panel.states.normal) or self.isSwappingFromLeft or self.dont_swap or self.chaining
+end
+
+function Panel.clear_flags(self)
+  self.combo_index = nil
+  self.combo_size = nil
+  self.chain_index = nil
+  self.isSwappingFromLeft = nil
+  self.dont_swap = nil
+  self.chaining = nil
+  -- Animation timer for "bounce" after falling from garbage.
+  self.fell_from_garbage = nil
+  self.state = Panel.states.normal
+  self.changedState = false
+end
+
+function Panel.update(self, panels)
+  if self.stateChanged then
+    self.stateChanged = false
+  end
+
+  local panelBelow = panels[self.row - 1][self.column]
+
+  if panelBelow and panelBelow.stateChanged then
+    self:panelBelowChanged(panelBelow)
+  end
+
+  self:runStateAction(panels)
+end
+
+function Panel.swapStarted(self, isSwappingFromLeft, newColumn)
+  local chaining = self.chaining
+  self:clear_flags()
+  self.changedState = true
+  self.state = Panel.states.swapping
+  self.chaining = chaining
+  self.timer = 4
+  self.isSwappingFromLeft = isSwappingFromLeft
+  self.column = newColumn
+end
+
+function Panel.panelBelowChanged(self, panelBelow)
+  if self.state == Panel.states.normal then
+    if panelBelow.type == Panel.types.empty then
+      self:enterHoverState()
+    end
+  end
+end
+
+function Panel.enterHoverState(self)
+
+end
+
+-- panels in these states automatically transform when the timer reaches 0
+local timerBasedStates = {Panel.states.swapping, Panel.states.hovering, Panel.states.landing, Panel.states.matched, Panel.states.popping, Panel.states.popped}
+
+function Panel.runStateAction(self, panels)
+  if table.contains(timerBasedStates, self.state) then
+    -- decrement timer
+    if self.timer and self.timer > 0 then
+      self.timer = self.timer - 1
+      if self.timer == 0 then
+        self:timerRanOut()
+      end
+    end
+  elseif self.state == Panel.states.falling then
+    
+    self.stateChanged = true
+  end
+end
+
+function Panel.timerRanOut(self)
+  self.stateChanged = true
+end

--- a/engine/panel.lua
+++ b/engine/panel.lua
@@ -326,12 +326,11 @@ function Panel.enterHoverState(self, panelBelow)
       self.timer = self.framecounts.HOVER
       self.chaining = chaining or panelBelow.justPopped
     else
-      -- inherit hovertime and chaining state from panel below
+      -- inherit hovertime from panel below
       self.timer = panelBelow.timer
       self.chaining = chaining
     end
   end
-
 end
 
 -- panels in these states automatically transform when the timer reaches 0
@@ -347,7 +346,7 @@ function Panel.runStateAction(self, panels)
         self:timerRanOut(panels)
       end
     end
-  elseif self.state == Panel.states.falling then
+  elseif self.state == Panel.states.falling or self.state == Panel.states.normal then
     self:changeState(panels)
   end
 end
@@ -365,7 +364,7 @@ end
 function Panel.changeState(self, panels)
   local stateTable = nil
   if self.state == Panel.states.normal then
-    
+    stateTable = normalState
   elseif self.state == Panel.states.swapping then
     stateTable = swappingState
   elseif self.state == Panel.states.matched then

--- a/game.lua
+++ b/game.lua
@@ -12,7 +12,7 @@ Game =
     self.droppedFrames = 0
     self.puzzleSets = {} -- all the puzzles loaded into the game
     self.gameIsPaused = false -- game can be paused while playing on local
-    self.renderDuringPause = false -- if the game can render when you are paused
+    self.renderDuringPause = true -- if the game can render when you are paused
     self.currently_paused_tracks = {} -- list of tracks currently paused
     self.rich_presence = nil
     self.muteSoundEffects = false
@@ -34,7 +34,7 @@ function Game.clearMatch(self)
     self.match = nil
   end
   self.gameIsPaused = false
-  self.renderDuringPause = false
+  self.renderDuringPause = true
   self.preventSounds = false
   self.currently_paused_tracks = {}
   self.muteSoundEffects = false

--- a/graphics.lua
+++ b/graphics.lua
@@ -375,7 +375,7 @@ function Stack.render(self)
           end
           if panel.state == Panel.state.matched then
             local flash_time = panel.initial_time - panel.timer
-            if flash_time >= self.FRAMECOUNT_FLASH then
+            if flash_time >= self.FRAMECOUNTS.FLASH then
               if panel.timer > panel.pop_time then
                 if panel.metal then
                   draw(metals.left, draw_x, draw_y, 0, 8 / metall_w, 16 / metall_h)
@@ -403,8 +403,8 @@ function Stack.render(self)
           end
         else
           if panel.state == Panel.states.matched then
-            local flash_time = self.FRAMECOUNT_MATCH - panel.timer
-            if flash_time >= self.FRAMECOUNT_FLASH then
+            local flash_time = self.FRAMECOUNTS.MATCH - panel.timer
+            if flash_time >= self.FRAMECOUNTS.FLASH then
               draw_frame = 6
             elseif flash_time % 2 == 1 then
               draw_frame = 1
@@ -488,8 +488,28 @@ function Stack.render(self)
 
         -- Require hovering over a stack to show details
         if mx >= self.pos_x * GFX_SCALE and mx <= (self.pos_x + self.width * 16) * GFX_SCALE then
-          if panel.color ~= 0 and panel.state ~= Panel.states.popped then
-            gprint(panel.state, draw_x, draw_y)
+        
+            if panel.state == Panel.states.normal then
+              gprint("normal", draw_x, draw_y)
+            elseif panel.state == Panel.states.swapping then
+              gprint("swapping", draw_x, draw_y)
+            elseif panel.state == Panel.states.matched then
+              gprint("matched", draw_x, draw_y)
+            elseif panel.state == Panel.states.popping then
+              gprint("popping", draw_x, draw_y)
+            elseif panel.state == Panel.states.popped then
+              gprint("popped", draw_x, draw_y)
+            elseif panel.state == Panel.states.hovering then
+              gprint("hovering", draw_x, draw_y)
+            elseif panel.state == Panel.states.falling then
+              gprint("falling", draw_x, draw_y)
+            elseif panel.state == Panel.states.landing then
+              gprint("landing", draw_x, draw_y)
+            elseif panel.state == Panel.states.dimmed then
+              gprint("dimmed", draw_x, draw_y)
+            elseif panel.state == Panel.states.dead then
+              gprint("dead", draw_x, draw_y)
+            end
             if panel.match_anyway ~= nil then
               gprint(tostring(panel.match_anyway), draw_x, draw_y + 10)
               if panel.debug_tag then
@@ -500,7 +520,6 @@ function Stack.render(self)
               gprint("chaining", draw_x, draw_y + 30)
             end
           end
-        end
 
         if mx >= draw_x and mx < draw_x + 16 * GFX_SCALE and my >= draw_y and my < draw_y + 16 * GFX_SCALE then
           local str = loc("pl_panel_info", row, col)

--- a/graphics.lua
+++ b/graphics.lua
@@ -317,9 +317,9 @@ function Stack.render(self)
       local panel = self.panels[row][col]
       local draw_x = 4 + (col - 1) * 16
       local draw_y = 4 + (11 - (row)) * 16 + self.displacement - shake
-      if panel.color ~= 0 and panel.state ~= "popped" then
+      if panel.color ~= 0 and panel.state ~= Panel.states.popped then
         local draw_frame = 1
-        if panel.garbage then
+        if panel.type == Panel.types.garbage then
           local imgs = {flash = metals.flash}
           if not panel.metal then
             if not self.garbage_target then 
@@ -373,7 +373,7 @@ function Stack.render(self)
               draw(imgs.botright, draw_x + 16 * width - 8, draw_y + 13, 0, 8 / corner_w, 3 / corner_h)
             end
           end
-          if panel.state == "matched" then
+          if panel.state == Panel.state.matched then
             local flash_time = panel.initial_time - panel.timer
             if flash_time >= self.FRAMECOUNT_FLASH then
               if panel.timer > panel.pop_time then
@@ -402,7 +402,7 @@ function Stack.render(self)
             end
           end
         else
-          if panel.state == "matched" then
+          if panel.state == Panel.states.matched then
             local flash_time = self.FRAMECOUNT_MATCH - panel.timer
             if flash_time >= self.FRAMECOUNT_FLASH then
               draw_frame = 6
@@ -411,19 +411,19 @@ function Stack.render(self)
             else
               draw_frame = 5
             end
-          elseif panel.state == "popping" then
+          elseif panel.state == Panel.states.popping then
             draw_frame = 6
-          elseif panel.state == "landing" then
+          elseif panel.state == Panel.states.landing then
             draw_frame = bounce_table[panel.timer + 1]
-          elseif panel.state == "swapping" then
-            if panel.is_swapping_from_left then
+          elseif panel.state == Panel.states.swapping then
+            if panel.isSwappingFromLeft then
               draw_x = draw_x - panel.timer * 4
             else
               draw_x = draw_x + panel.timer * 4
             end
-          elseif panel.state == "dead" then
+          elseif panel.state == Panel.states.dead then
             draw_frame = 6
-          elseif panel.state == "dimmed" then
+          elseif panel.state == Panel.states.dimmed then
             draw_frame = 7
           elseif panel.fell_from_garbage then
             draw_frame = garbage_bounce_table[panel.fell_from_garbage] or 1
@@ -488,7 +488,7 @@ function Stack.render(self)
 
         -- Require hovering over a stack to show details
         if mx >= self.pos_x * GFX_SCALE and mx <= (self.pos_x + self.width * 16) * GFX_SCALE then
-          if panel.color ~= 0 and panel.state ~= "popped" then
+          if panel.color ~= 0 and panel.state ~= Panel.states.popped then
             gprint(panel.state, draw_x, draw_y)
             if panel.match_anyway ~= nil then
               gprint(tostring(panel.match_anyway), draw_x, draw_y + 10)


### PR DESCRIPTION
Would resolve #782 

This PR mainly aims at separating panel transitions from all the other fancy stuff the stack is doing.

To do that, the new file engine/panel.lua now takes care of everything around panel creation and state transitions.
Stack specific functions have been moved into callback functions that are called from inside the panel.lua without having to know anything about the stack.
As additional features, panels are now aware of their location in the stack as well as have an id. This is partially required to have most functions work without involving the stack object and partially just added convenience that would help with CPU development.

To make things less confusing overall, I changed the logic - specifically with setting hover states - to strictly go from bottom to top row by row so that frame times can be assigned consistently rather than having to compensate for the fact that panels further above will still decrement their timer on the same frame.

Right now nothing is really working aside from swaps and partially panels dropping but I figured I'd drop it like this for an impression as the groundwork is effectively done and the rest will just be ironing stuff out and developing a good testing method to confirm it works the same way as previously.

You can find a table of the state transitions I figured out through reading, I want to reformat this in markdown and add it as a doc later:
[state transitions panels.ods](https://github.com/panel-attack/panel-attack/files/10335205/state.transitions.panels.ods)
