### PR TITLE
Don't crash if a sfx is missing the index 1 variant

### DIFF
--- a/character.lua
+++ b/character.lua
@@ -527,7 +527,7 @@ end
 local function playRandomSfx(sfxTable, fallback)
   if not GAME.muteSoundEffects then
     if sfxTable and #sfxTable > 0 then
-      sfxTable[math.random(#sfxTable)]:play()
+      table.getRandomElement(sfxTable):play()
     elseif fallback then
       playRandomSfx(fallback)
     end


### PR DESCRIPTION
Since SFX were assigned by index to their respective sounds table, it could happen that if index 1 was missing, `#self.sounds.sound` would evaluate to 0 and then try to access a non existing 0 table.
To circumvent that problem, `playRandomSfx` now uses `table.getRandomElement` which checks for #table > 0 before using that to randomize and otherwise does a dictionary value random selection that should never crash due to index gaps.