### PR TITLE
Make row 0 panels of puzzles solid

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -805,7 +805,7 @@ function Stack.puzzleStringToPanels(self, puzzleString)
   panels[0] = {}
   for column = 6, 1, -1 do
     local panel = Panel()
-    panel.color = 0
+    panel.color = 9
     panels[0][column] = panel
   end
 


### PR DESCRIPTION
orangetriangle reported a bug with this puzzle.
[garbage.txt](https://github.com/panel-attack/panel-attack/files/10441929/garbage.txt)
Garbage was falling into row 0 instead of stopping in row 1.
This fixes that issue by making the row 0 panel color 9 (unmatchable panels that can support garbage from below) instead of color 0 (blank, don't support garbage from below).