### PR TITLE
Auto updater handle dl failure

### DIFF
--- a/auto_updater/loadingIndicator.lua
+++ b/auto_updater/loadingIndicator.lua
@@ -1,0 +1,37 @@
+local loadingIndicator = {}
+
+loadingIndicator.timer = 0
+loadingIndicator.indicators = { false, false, false}
+
+function loadingIndicator.setDrawPosition(self, width, height)
+  self.width = width
+  self.height = height
+end
+
+function loadingIndicator.setFont(self, font)
+  self.font = font
+end
+
+function loadingIndicator.draw(self)
+  -- draw an indicator to indicate that the window is alive and kicking even during a download
+  self.timer = self.timer + 1
+  if self.timer % 60 == 20 then
+    self.indicators[1] = not self.indicators[1]
+  elseif self.timer % 60 == 40 then
+    self.indicators[2] = not self.indicators[2]
+  elseif self.timer % 60 == 0 then
+    self.indicators[3] = not self.indicators[3]
+  end
+
+  if self.indicators[1] then
+    love.graphics.print(".", self.font, self.width / 2 - 15, self.height * 0.75)
+  end
+  if self.indicators[2] then
+    love.graphics.print(".", self.font, self.width / 2     , self.height * 0.75)
+  end
+  if self.indicators[3] then
+    love.graphics.print(".", self.font, self.width / 2 + 15, self.height * 0.75)
+  end
+end
+
+return loadingIndicator


### PR DESCRIPTION
Fixes #817 
Through the new `startGame` function, the game tries to first mount whatever version the update routine deemed as the correct one. If that fails, the local version in the update failure is mounted. If that fails too, the embedded version is mounted. Only then will the auto_updater give up and throw an error but not before cleaning up old files to ensure that no bricked files remain.

Since I'm myself I couldn't help doing some refactorings:

The loading indicator now lives in its own file.
All references to `updateDirectory` have been replaced with a reference to `GAME_UPDATER.path`.
The startup delay for debug mode is now more self-contained inside its own function.
The embedded version string now gets initialized early on and functions will reference the local variable instead of the getter function.
If the embedded version is chosen as fallback it is no longer getting duplicated into the updater directory but instead mounted directly.
`logMessage` now follows our formatting rules
`GAME_UPDATER.change_version` is now only called after successfully mounting the file.