### PR TITLE
Monitor active gc usage in debugmode and spend sleep time on garbage collection

### DIFF
--- a/CustomRun.lua
+++ b/CustomRun.lua
@@ -121,7 +121,8 @@ function CustomRun.innerRun()
   end
 
   local preGc1Time = love.timer.getTime()
-  CustomRun.runMetrics.gcCyclesFinished = CustomRun.runMetrics.gcCyclesFinished + manualGC(0.0001, 128, true)
+  -- always collect garbage for at least 1ms, even if we're already behind on time
+  CustomRun.runMetrics.gcCyclesFinished = CustomRun.runMetrics.gcCyclesFinished + manualGC(0.001, 128, true)
   CustomRun.runMetrics.gcDuration = love.timer.getTime() - preGc1Time
 end
 

--- a/CustomRun.lua
+++ b/CustomRun.lua
@@ -116,13 +116,13 @@ function CustomRun.innerRun()
     CustomRun.runMetrics.presentDuration = love.timer.getTime() - prePresentTime
   end
 
-  local preGc1Time = love.timer.getTime()
-  CustomRun.runMetrics.gcCyclesFinished = CustomRun.runMetrics.gcCyclesFinished + manualGC(0.0001, 128, true)
-  CustomRun.runMetrics.gcDuration = love.timer.getTime() - preGc1Time
-
   if CustomRun.runTimeGraph ~= nil then
     CustomRun.runTimeGraph:updateWithMetrics(CustomRun.runMetrics)
   end
+
+  local preGc1Time = love.timer.getTime()
+  CustomRun.runMetrics.gcCyclesFinished = CustomRun.runMetrics.gcCyclesFinished + manualGC(0.0001, 128, true)
+  CustomRun.runMetrics.gcDuration = love.timer.getTime() - preGc1Time
 end
 
 -- This is a copy of the outer run loop that love uses.

--- a/CustomRun.lua
+++ b/CustomRun.lua
@@ -8,6 +8,7 @@ CustomRun.runMetrics.dt = 0
 CustomRun.runMetrics.sleepDuration = 0
 CustomRun.runMetrics.updateDuration = 0
 CustomRun.runMetrics.drawDuration = 0
+CustomRun.runMetrics.drawGraphDuration = 0
 CustomRun.runMetrics.presentDuration = 0
 CustomRun.runMetrics.gcDuration = 0
 CustomRun.runMetrics.gcCyclesFinished = 0
@@ -36,7 +37,7 @@ function CustomRun.sleep()
   local gcRatio = 0.5
   local idleTime = targetTime - currentTime
   if love.timer and idleTime > 0 then
-    CustomRun.runMetrics.gcCyclesFinished = manualGC(idleTime * gcRatio)
+    CustomRun.runMetrics.gcCyclesFinished = manualGC(idleTime * gcRatio, nil, DEBUG_ENABLED)
     currentTime = love.timer.getTime()
     CustomRun.runMetrics.gcDuration = CustomRun.runMetrics.gcDuration + (currentTime - originalTime)
     originalTime = currentTime
@@ -95,6 +96,13 @@ function CustomRun.innerRun()
     love.graphics.origin()
     love.graphics.clear(love.graphics.getBackgroundColor())
 
+    -- draw the RunTimeGraph here so it doesn't contribute to the love.draw load
+    if CustomRun.runTimeGraph then
+      local preGraphDrawTime = love.timer.getTime()
+      CustomRun.runTimeGraph:draw()
+      CustomRun.runMetrics.drawGraphDuration = love.timer.getTime() - preGraphDrawTime
+    end
+
     if love.draw then
       local preDrawTime = love.timer.getTime()
       love.draw()
@@ -111,7 +119,7 @@ function CustomRun.innerRun()
   end
 
   local preGc1Time = love.timer.getTime()
-  CustomRun.runMetrics.gcCyclesFinished = CustomRun.runMetrics.gcCyclesFinished + manualGC(0.0001, nil, nil)
+  CustomRun.runMetrics.gcCyclesFinished = CustomRun.runMetrics.gcCyclesFinished + manualGC(0.0001, nil, DEBUG_ENABLED)
   CustomRun.runMetrics.gcDuration = love.timer.getTime() - preGc1Time
 end
 

--- a/RunTimeGraph.lua
+++ b/RunTimeGraph.lua
@@ -24,12 +24,18 @@ local RunTimeGraph = class(function(self)
   self.graphs[#self.graphs]:setFillColor({0, 1, 1, 1}, 1)
   y = y + height + padding
 
+  -- gc time
+  self.graphs[#self.graphs+1] = BarGraph(x, y, width, height, updateSpeed, 5)
+  self.graphs[#self.graphs]:setFillColor({1, 0, 1, 1}, 1)
+  y = y + height + padding
+
   -- run loop graph
   self.graphs[#self.graphs + 1] = BarGraph(x, y, width, height, updateSpeed, consts.FRAME_RATE * 1)
   self.graphs[#self.graphs]:setFillColor({0, 1, 0, 1}, 1) -- update
   self.graphs[#self.graphs]:setFillColor({1, 0.5, 0, 1}, 2) -- draw
   self.graphs[#self.graphs]:setFillColor({0, 0, 1, 1}, 3) -- sleep
   self.graphs[#self.graphs]:setFillColor({1, 1, 1, 1}, 4) -- present
+  self.graphs[#self.graphs]:setFillColor({1, 0, 1, 1}, 5) -- gc
   y = y + height + padding
 end)
 
@@ -45,7 +51,9 @@ function RunTimeGraph:updateWithMetrics(runMetrics)
 
   self.graphs[3]:updateGraph({leftover_time}, "leftover_time " .. leftover_time, dt)
 
-  self.graphs[4]:updateGraph({runMetrics.updateDuration, runMetrics.drawDuration, runMetrics.sleepDuration, runMetrics.presentDuration},
+  self.graphs[4]:updateGraph({gcCyclesFinished}, "finished gc cycle " .. gcCyclesFinished, dt)
+
+  self.graphs[5]:updateGraph({runMetrics.updateDuration, runMetrics.drawDuration, runMetrics.sleepDuration, runMetrics.presentDuration, runMetrics.gcDuration},
                              "Run Loop", dt)
 end
 

--- a/RunTimeGraph.lua
+++ b/RunTimeGraph.lua
@@ -25,7 +25,7 @@ local RunTimeGraph = class(function(self)
   y = y + height + padding
 
   -- gc time
-  self.graphs[#self.graphs+1] = BarGraph(x, y, width, height, updateSpeed, 5)
+  self.graphs[#self.graphs+1] = BarGraph(x, y, width, height, updateSpeed, 12)
   self.graphs[#self.graphs]:setFillColor({1, 0, 1, 1}, 1)
   y = y + height + padding
 

--- a/RunTimeGraph.lua
+++ b/RunTimeGraph.lua
@@ -33,9 +33,10 @@ local RunTimeGraph = class(function(self)
   self.graphs[#self.graphs + 1] = BarGraph(x, y, width, height, updateSpeed, consts.FRAME_RATE * 1)
   self.graphs[#self.graphs]:setFillColor({0, 1, 0, 1}, 1) -- update
   self.graphs[#self.graphs]:setFillColor({1, 0.5, 0, 1}, 2) -- draw
-  self.graphs[#self.graphs]:setFillColor({0, 0, 1, 1}, 3) -- sleep
-  self.graphs[#self.graphs]:setFillColor({1, 1, 1, 1}, 4) -- present
-  self.graphs[#self.graphs]:setFillColor({1, 0, 1, 1}, 5) -- gc
+  self.graphs[#self.graphs]:setFillColor({0, 0.5, 1, 1}, 3) -- draw RunTimeGraph
+  self.graphs[#self.graphs]:setFillColor({0, 0, 1, 1}, 4) -- sleep
+  self.graphs[#self.graphs]:setFillColor({1, 1, 1, 1}, 5) -- present
+  self.graphs[#self.graphs]:setFillColor({1, 0, 1, 1}, 6) -- gc
   y = y + height + padding
 end)
 
@@ -51,9 +52,9 @@ function RunTimeGraph:updateWithMetrics(runMetrics)
 
   self.graphs[3]:updateGraph({leftover_time}, "leftover_time " .. leftover_time, dt)
 
-  self.graphs[4]:updateGraph({gcCyclesFinished}, "finished gc cycle " .. gcCyclesFinished, dt)
+  self.graphs[4]:updateGraph({runMetrics.gcCyclesFinished}, "finished gc cycle " .. runMetrics.gcCyclesFinished, dt)
 
-  self.graphs[5]:updateGraph({runMetrics.updateDuration, runMetrics.drawDuration, runMetrics.sleepDuration, runMetrics.presentDuration, runMetrics.gcDuration},
+  self.graphs[5]:updateGraph({runMetrics.updateDuration, runMetrics.drawDuration, runMetrics.drawGraphDuration, runMetrics.sleepDuration, runMetrics.presentDuration, runMetrics.gcDuration},
                              "Run Loop", dt)
 end
 

--- a/libraries/batteries/manual_gc.lua
+++ b/libraries/batteries/manual_gc.lua
@@ -46,6 +46,7 @@ freely, subject to the following restrictions:
     situation and crash your game. test extensively before you
     ship a game with this set true.
 ]]
+local maxSteps = 10000
 
 return function(time_budget, memory_ceiling, disable_otherwise)
 	time_budget = time_budget or 1e-3
@@ -54,7 +55,8 @@ return function(time_budget, memory_ceiling, disable_otherwise)
 	local start_time = love.timer.getTime()
   local cyclesFinished = 0
 	while
-		love.timer.getTime() - start_time < time_budget
+		love.timer.getTime() - start_time < time_budget and
+    steps < maxSteps
 	do
     if collectgarbage("step", 1) then
       cyclesFinished = cyclesFinished + 1

--- a/libraries/batteries/manual_gc.lua
+++ b/libraries/batteries/manual_gc.lua
@@ -50,22 +50,25 @@ freely, subject to the following restrictions:
 return function(time_budget, memory_ceiling, disable_otherwise)
 	time_budget = time_budget or 1e-3
 	memory_ceiling = memory_ceiling or 64
-    local max_steps = 10000
 	local steps = 0
 	local start_time = love.timer.getTime()
+  local cyclesFinished = 0
 	while
-		love.timer.getTime() - start_time < time_budget and
-		steps < max_steps
+		love.timer.getTime() - start_time < time_budget
 	do
-		collectgarbage("step", 1)
+    if collectgarbage("step", 1) then
+      cyclesFinished = cyclesFinished + 1
+    end
 		steps = steps + 1
 	end
 	--safety net
 	if collectgarbage("count") / 1024 > memory_ceiling then
 		collectgarbage("collect")
+    cyclesFinished = cyclesFinished + 1
 	end
 	--don't collect gc outside this margin
 	if disable_otherwise then
 		collectgarbage("stop")
 	end
+  return cyclesFinished
 end

--- a/libraries/batteries/manual_gc.lua
+++ b/libraries/batteries/manual_gc.lua
@@ -56,7 +56,8 @@ return function(time_budget, memory_ceiling, disable_otherwise)
   local cyclesFinished = 0
 	while
 		love.timer.getTime() - start_time < time_budget and
-    steps < maxSteps
+    steps < maxSteps and
+    cyclesFinished < 10
 	do
     if collectgarbage("step", 1) then
       cyclesFinished = cyclesFinished + 1

--- a/main.lua
+++ b/main.lua
@@ -2,7 +2,6 @@ require("class")
 socket = require("socket")
 GAME = require("game")
 require("match")
-local manualGC = require("libraries.batteries.manual_gc")
 local RunTimeGraph = require("RunTimeGraph")
 require("BattleRoom")
 require("util")
@@ -152,8 +151,6 @@ function love.update(dt)
 
   update_music()
   GAME.rich_presence:runCallbacks()
-  
-  manualGC(0.0001, nil, nil)
 end
 
 -- Called whenever the game needs to draw.

--- a/main.lua
+++ b/main.lua
@@ -167,9 +167,7 @@ function love.draw()
 
   -- Draw the FPS if enabled
   if config ~= nil and config.show_fps then
-    if CustomRun.runTimeGraph then
-      CustomRun.runTimeGraph:draw()
-    else
+    if not CustomRun.runTimeGraph then
       gprintf("FPS: " .. love.timer.getFPS(), 1, 1)
     end
   end


### PR DESCRIPTION
Fixes https://github.com/panel-attack/panel-attack/issues/819
By turning off the automatic GC and running manual GC in our sleep time, we have full control over our frametimes. 
Even while collecting garbage manually, the automatic GC still runs in the background, causing spikes in the update and draw load that are actually owed to the automatic GC.

Effectively this adds a graph for showing when the GC completed a cycle.
As well as a bar to the overall frametime graph that shows GC time.

Finally it will spend 99% of the calculated sleep time on collecting garbage instead of sleeping. If it manages to complete 10 GC cycles on a frame it will quit manual garbage collection prematurely and then sleep the remaining time.
10 cycles is an experimental number that is a bit higher than I think would be sufficient. When running into the 64 MB memory limit during long replays before, the GC would need 5-6 frames (one frame = one `collectgarbage("collect")` which is one cycle from what I understood) to crack down the memory back down, so I figure 10 should be good for stronger machines while weaker machines won't manage to run 10 cycles in the remaining frame time to begin with (mine can manage about 5 during gameplay). That's an additional limit besides the maxSteps limit, both aiming at capping the amount of redundant GC work on a frame when there really is nothing left to do.

Additionally I increased the memory limit to 128 MB. That should give us some safety margin for latency situations in longer games where the GC is a bit slow to catch up and memory starts piling for some seconds before it can be cleaned up. The game will still run into that because the game still runs the GC for 1ms per frame, regardless of if we have any leftover time or not.