### PR TITLE
Improve frametimes on good machines by collecting garbage instead of sleeping

### DIFF
--- a/CustomRun.lua
+++ b/CustomRun.lua
@@ -1,20 +1,24 @@
+local manualGc = require("libraries.batteries.manual_gc")
 
 local CustomRun = {}
 CustomRun.FRAME_RATE = 1 / 60
 CustomRun.runMetrics = {}
 CustomRun.runMetrics.previousSleepEnd = 0
 CustomRun.runMetrics.dt = 0
-CustomRun.runMetrics.sleepDuration = 0
 CustomRun.runMetrics.updateDuration = 0
+CustomRun.runMetrics.drawGraphDuration = 0
 CustomRun.runMetrics.drawDuration = 0
 CustomRun.runMetrics.presentDuration = 0
+CustomRun.runMetrics.gcDuration = 0
+CustomRun.runMetrics.sleepDuration = 0
+
 CustomRun.runTimeGraph = nil
 
 leftover_time = 0
 
 -- Sleeps just the right amount of time to make our next update step be one frame long.
 -- If we have leftover time that hasn't been run yet, it will sleep less to catchup.
-function CustomRun:sleep()
+function CustomRun.sleep()
 
   local targetDelay = CustomRun.FRAME_RATE
   -- We want leftover time to be above 0 but less than a quarter frame.
@@ -29,11 +33,19 @@ function CustomRun:sleep()
   local originalTime = love.timer.getTime()
   local currentTime = originalTime
 
-  -- Sleep a percentage of our time to wait to save cpu
-  local sleepRatio = .99
-  local sleepTime = (targetTime - currentTime) * sleepRatio
-  if love.timer and sleepTime > 0 then
-    love.timer.sleep(sleepTime)
+  local idleTime = targetTime - currentTime
+  -- Spend as much time as necessary collecting garbage, but at least 0.1ms
+  manualGc(math.max(0.0001, idleTime * 0.99))
+  currentTime = love.timer.getTime()
+  CustomRun.runMetrics.gcDuration = currentTime - originalTime
+  originalTime = currentTime
+  idleTime = targetTime - currentTime
+
+  -- Sleep any remaining amount of time to fill up the frametime
+  -- On most machines GC will have reduced the remaining idle time to near nothing
+  -- But strong machines may exit garbage collection early and need to sleep the remaining time
+  if idleTime > 0 then
+    love.timer.sleep(idleTime * 0.99)
   end
   currentTime = love.timer.getTime()
 
@@ -49,11 +61,6 @@ end
 -- This is our custom version of run that uses a custom sleep and records metrics.
 local dt = 0
 function CustomRun.innerRun()
-
-  if love.timer then
-    CustomRun.sleep()
-  end
-
   -- Process events.
   if love.event then
     love.event.pump()
@@ -85,6 +92,13 @@ function CustomRun.innerRun()
     love.graphics.origin()
     love.graphics.clear(love.graphics.getBackgroundColor())
 
+    -- draw the RunTimeGraph here so it doesn't contribute to the love.draw load
+    if CustomRun.runTimeGraph then
+      local preGraphDrawTime = love.timer.getTime()
+      CustomRun.runTimeGraph:draw()
+      CustomRun.runMetrics.drawGraphDuration = love.timer.getTime() - preGraphDrawTime
+    end
+
     if love.draw then
       local preDrawTime = love.timer.getTime()
       love.draw()
@@ -94,6 +108,10 @@ function CustomRun.innerRun()
     local prePresentTime = love.timer.getTime()
     love.graphics.present()
     CustomRun.runMetrics.presentDuration = love.timer.getTime() - prePresentTime
+  end
+
+  if love.timer then
+    CustomRun.sleep()
   end
 
   if CustomRun.runTimeGraph ~= nil then

--- a/CustomRun.lua
+++ b/CustomRun.lua
@@ -6,7 +6,7 @@ CustomRun.runMetrics = {}
 CustomRun.runMetrics.previousSleepEnd = 0
 CustomRun.runMetrics.dt = 0
 CustomRun.runMetrics.updateDuration = 0
-CustomRun.runMetrics.drawGraphDuration = 0
+CustomRun.runMetrics.graphDuration = 0
 CustomRun.runMetrics.drawDuration = 0
 CustomRun.runMetrics.presentDuration = 0
 CustomRun.runMetrics.gcDuration = 0
@@ -96,7 +96,7 @@ function CustomRun.innerRun()
     if CustomRun.runTimeGraph then
       local preGraphDrawTime = love.timer.getTime()
       CustomRun.runTimeGraph:draw()
-      CustomRun.runMetrics.drawGraphDuration = love.timer.getTime() - preGraphDrawTime
+      CustomRun.runMetrics.graphDuration = CustomRun.runMetrics.graphDuration + (love.timer.getTime() - preGraphDrawTime)
     end
 
     if love.draw then
@@ -115,7 +115,9 @@ function CustomRun.innerRun()
   end
 
   if CustomRun.runTimeGraph ~= nil then
+    local preGraphUpdateTime = love.timer.getTime()
     CustomRun.runTimeGraph:updateWithMetrics(CustomRun.runMetrics)
+    CustomRun.runMetrics.graphDuration = love.timer.getTime() - preGraphUpdateTime
   end
 end
 

--- a/RunTimeGraph.lua
+++ b/RunTimeGraph.lua
@@ -26,10 +26,12 @@ local RunTimeGraph = class(function(self)
 
   -- run loop graph
   self.graphs[#self.graphs + 1] = BarGraph(x, y, width, height, updateSpeed, consts.FRAME_RATE * 1)
-  self.graphs[#self.graphs]:setFillColor({0, 1, 0, 1}, 1) -- update
-  self.graphs[#self.graphs]:setFillColor({1, 0.5, 0, 1}, 2) -- draw
-  self.graphs[#self.graphs]:setFillColor({0, 0, 1, 1}, 3) -- sleep
-  self.graphs[#self.graphs]:setFillColor({1, 1, 1, 1}, 4) -- present
+  self.graphs[#self.graphs]:setFillColor({0, 1, 0, 1}, 1) -- love.update
+  self.graphs[#self.graphs]:setFillColor({0, 0.5, 1, 1}, 2) -- self:RunTimeGraph
+  self.graphs[#self.graphs]:setFillColor({1, 0.5, 0, 1}, 3) -- love.draw
+  self.graphs[#self.graphs]:setFillColor({1, 1, 1, 1}, 4) -- love.present
+  self.graphs[#self.graphs]:setFillColor({1, 0, 1, 1}, 5) -- manualGc
+  self.graphs[#self.graphs]:setFillColor({0, 0, 1, 1}, 6) -- love.timer.sleep
   y = y + height + padding
 end)
 
@@ -45,7 +47,13 @@ function RunTimeGraph:updateWithMetrics(runMetrics)
 
   self.graphs[3]:updateGraph({leftover_time}, "leftover_time " .. leftover_time, dt)
 
-  self.graphs[4]:updateGraph({runMetrics.updateDuration, runMetrics.drawDuration, runMetrics.sleepDuration, runMetrics.presentDuration},
+  self.graphs[4]:updateGraph({runMetrics.updateDuration,
+                              runMetrics.drawGraphDuration,
+                              runMetrics.drawDuration,
+                              runMetrics.presentDuration,
+                              runMetrics.gcDuration,
+                              runMetrics.sleepDuration
+                            },
                              "Run Loop", dt)
 end
 

--- a/RunTimeGraph.lua
+++ b/RunTimeGraph.lua
@@ -27,11 +27,12 @@ local RunTimeGraph = class(function(self)
   -- run loop graph
   self.graphs[#self.graphs + 1] = BarGraph(x, y, width, height, updateSpeed, consts.FRAME_RATE * 1)
   self.graphs[#self.graphs]:setFillColor({0, 1, 0, 1}, 1) -- love.update
-  self.graphs[#self.graphs]:setFillColor({0, 0.5, 1, 1}, 2) -- self:RunTimeGraph
+  self.graphs[#self.graphs]:setFillColor({0, 0.5, 1, 1}, 2) -- self:draw + self:updateWithMetrics
   self.graphs[#self.graphs]:setFillColor({1, 0.5, 0, 1}, 3) -- love.draw
   self.graphs[#self.graphs]:setFillColor({1, 1, 1, 1}, 4) -- love.present
   self.graphs[#self.graphs]:setFillColor({1, 0, 1, 1}, 5) -- manualGc
   self.graphs[#self.graphs]:setFillColor({0, 0, 1, 1}, 6) -- love.timer.sleep
+
   y = y + height + padding
 end)
 
@@ -48,7 +49,7 @@ function RunTimeGraph:updateWithMetrics(runMetrics)
   self.graphs[3]:updateGraph({leftover_time}, "leftover_time " .. leftover_time, dt)
 
   self.graphs[4]:updateGraph({runMetrics.updateDuration,
-                              runMetrics.drawGraphDuration,
+                              runMetrics.graphDuration,
                               runMetrics.drawDuration,
                               runMetrics.presentDuration,
                               runMetrics.gcDuration,

--- a/libraries/batteries/manual_gc.lua
+++ b/libraries/batteries/manual_gc.lua
@@ -49,8 +49,11 @@ freely, subject to the following restrictions:
 
 return function(time_budget, memory_ceiling, disable_otherwise)
 	time_budget = time_budget or 1e-3
-	memory_ceiling = memory_ceiling or 64
-    local max_steps = 10000
+  -- 64 MB memory is too low for long replays, they are guaranteed to hit the limit
+  -- On weaker machines, it may pile up so quickly that even 128 may be breached (accumulating several MBs per second)
+  -- so putting 256 MB for now
+	memory_ceiling = memory_ceiling or 256
+  local max_steps = 10000
 	local steps = 0
 	local start_time = love.timer.getTime()
 	while

--- a/main.lua
+++ b/main.lua
@@ -2,7 +2,6 @@ require("class")
 socket = require("socket")
 GAME = require("game")
 require("match")
-local manualGC = require("libraries.batteries.manual_gc")
 local RunTimeGraph = require("RunTimeGraph")
 require("BattleRoom")
 require("util")
@@ -152,8 +151,6 @@ function love.update(dt)
 
   update_music()
   GAME.rich_presence:runCallbacks()
-  
-  manualGC(0.0001, nil, nil)
 end
 
 -- Called whenever the game needs to draw.
@@ -170,9 +167,7 @@ function love.draw()
 
   -- Draw the FPS if enabled
   if config ~= nil and config.show_fps then
-    if CustomRun.runTimeGraph then
-      CustomRun.runTimeGraph:draw()
-    else
+    if not CustomRun.runTimeGraph then
       gprintf("FPS: " .. love.timer.getFPS(), 1, 1)
     end
   end


### PR DESCRIPTION
This is the hopefully non-controversial version of #826 because it does not turn off the automatic garbage collection.

This essentially replaces sleep with manualGc (until you've done enough work) inside of `CustomRun.sleep`.

Additionally I did some changes to the RunTimeGraph:
It is now drawn in `innerRun` so its draw time does not contribute to the measured frametime of `love.draw`.
Additionally it measures its own draw+update time and displays it in light blue color.
I also measure the time spent on manually collecting garbage and display it in pink color.
Finally I readjusted the order of the displays in the frametime graph to match the order of execution (this is also why I changed the order of field declaration in CustomRun).

As a final change, I moved `CustomRun.sleep` from the start of `innerRun` to its end.
That doesn't make a difference for the `innerRun` itself.
```Lua
local targetTime = CustomRun.runMetrics.previousSleepEnd + targetDelay
``` 
should have the same result no matter whether it is placed at the start or end of `innerRun` and give us constant 60 FPS.
However, placing it at the start means that the gc/sleep time we're measuring for *this* frame is in fact the gc/sleep time of the *last* frame.
Due to that, the graph keeps coming out like this (dumb nonsense):
![screenshot_v046-2023-01-28-18-45-04](https://user-images.githubusercontent.com/22120694/215285697-846d3a58-ff25-4ea5-96e7-7c0cb69acd61.png)

With sleep at the end, the metrics record the sleep time correctly for the frame it was calculated for:
![screenshot_v046-2023-01-28-18-43-33](https://user-images.githubusercontent.com/22120694/215285760-50b50f8c-826e-4a85-9564-2e7a58537448.png)

