### PR TITLE
Reuse tables of rollback clone better

### DIFF
--- a/table_util.lua
+++ b/table_util.lua
@@ -108,9 +108,6 @@ end
 function table.getKeys(tab)
   local keys = {}
   for key, _ in pairs(tab) do
-    if type(key) == "string" then
-      local phi = 0
-    end
     table.insert(keys, key)
   end
   table.sort(keys)

--- a/table_util.lua
+++ b/table_util.lua
@@ -108,6 +108,9 @@ end
 function table.getKeys(tab)
   local keys = {}
   for key, _ in pairs(tab) do
+    if type(key) == "string" then
+      local phi = 0
+    end
     table.insert(keys, key)
   end
   table.sort(keys)


### PR DESCRIPTION
Stops deepcopying garbage_cols for clones and only refreshes indices.

Implements an idea for creating rollback copies for combos/chains tables.
Will likely yield incorrect export results on attackpattern export though if rewind is used in a replay.