### PR TITLE
Reduce gfx q load

### DIFF
--- a/CustomRun.lua
+++ b/CustomRun.lua
@@ -35,7 +35,7 @@ function CustomRun.sleep()
 
   local idleTime = targetTime - currentTime
   -- Spend as much time as necessary collecting garbage, but at least 0.1ms
-  manualGc(math.max(0.0001, idleTime * 0.99))
+  manualGc(math.min(0.0001, idleTime * 0.99), 256, true)
   currentTime = love.timer.getTime()
   CustomRun.runMetrics.gcDuration = currentTime - originalTime
   originalTime = currentTime
@@ -92,17 +92,17 @@ function CustomRun.innerRun()
     love.graphics.origin()
     love.graphics.clear(love.graphics.getBackgroundColor())
 
+    if love.draw then
+      local preDrawTime = love.timer.getTime()
+      love.draw()
+      CustomRun.runMetrics.drawDuration = love.timer.getTime() - preDrawTime
+    end
+
     -- draw the RunTimeGraph here so it doesn't contribute to the love.draw load
     if CustomRun.runTimeGraph then
       local preGraphDrawTime = love.timer.getTime()
       CustomRun.runTimeGraph:draw()
       CustomRun.runMetrics.graphDuration = CustomRun.runMetrics.graphDuration + (love.timer.getTime() - preGraphDrawTime)
-    end
-
-    if love.draw then
-      local preDrawTime = love.timer.getTime()
-      love.draw()
-      CustomRun.runMetrics.drawDuration = love.timer.getTime() - preDrawTime
     end
 
     local prePresentTime = love.timer.getTime()

--- a/CustomRun.lua
+++ b/CustomRun.lua
@@ -1,20 +1,24 @@
+local manualGc = require("libraries.batteries.manual_gc")
 
 local CustomRun = {}
 CustomRun.FRAME_RATE = 1 / 60
 CustomRun.runMetrics = {}
 CustomRun.runMetrics.previousSleepEnd = 0
 CustomRun.runMetrics.dt = 0
-CustomRun.runMetrics.sleepDuration = 0
 CustomRun.runMetrics.updateDuration = 0
+CustomRun.runMetrics.drawGraphDuration = 0
 CustomRun.runMetrics.drawDuration = 0
 CustomRun.runMetrics.presentDuration = 0
+CustomRun.runMetrics.gcDuration = 0
+CustomRun.runMetrics.sleepDuration = 0
+
 CustomRun.runTimeGraph = nil
 
 leftover_time = 0
 
 -- Sleeps just the right amount of time to make our next update step be one frame long.
 -- If we have leftover time that hasn't been run yet, it will sleep less to catchup.
-function CustomRun:sleep()
+function CustomRun.sleep()
 
   local targetDelay = CustomRun.FRAME_RATE
   -- We want leftover time to be above 0 but less than a quarter frame.
@@ -29,11 +33,19 @@ function CustomRun:sleep()
   local originalTime = love.timer.getTime()
   local currentTime = originalTime
 
-  -- Sleep a percentage of our time to wait to save cpu
-  local sleepRatio = .99
-  local sleepTime = (targetTime - currentTime) * sleepRatio
-  if love.timer and sleepTime > 0 then
-    love.timer.sleep(sleepTime)
+  local idleTime = targetTime - currentTime
+  -- Spend as much time as necessary collecting garbage, but at least 0.1ms
+  manualGc(math.max(0.0001, idleTime * 0.99))
+  currentTime = love.timer.getTime()
+  CustomRun.runMetrics.gcDuration = currentTime - originalTime
+  originalTime = currentTime
+  idleTime = targetTime - currentTime
+
+  -- Sleep any remaining amount of time to fill up the frametime
+  -- On most machines GC will have reduced the remaining idle time to near nothing
+  -- But strong machines may exit garbage collection early and need to sleep the remaining time
+  if idleTime > 0 then
+    love.timer.sleep(idleTime * 0.99)
   end
   currentTime = love.timer.getTime()
 
@@ -49,11 +61,6 @@ end
 -- This is our custom version of run that uses a custom sleep and records metrics.
 local dt = 0
 function CustomRun.innerRun()
-
-  if love.timer then
-    CustomRun.sleep()
-  end
-
   -- Process events.
   if love.event then
     love.event.pump()
@@ -85,6 +92,13 @@ function CustomRun.innerRun()
     love.graphics.origin()
     love.graphics.clear(love.graphics.getBackgroundColor())
 
+    -- draw the RunTimeGraph here so it doesn't contribute to the love.draw load
+    if CustomRun.runTimeGraph then
+      local preGraphDrawTime = love.timer.getTime()
+      CustomRun.runTimeGraph:draw()
+      CustomRun.runMetrics.drawGraphDuration = love.timer.getTime() - preGraphDrawTime
+    end
+
     if love.draw then
       local preDrawTime = love.timer.getTime()
       love.draw()
@@ -94,6 +108,10 @@ function CustomRun.innerRun()
     local prePresentTime = love.timer.getTime()
     love.graphics.present()
     CustomRun.runMetrics.presentDuration = love.timer.getTime() - prePresentTime
+  end
+
+  if love.timer then
+    CustomRun.sleep()
   end
 
   if CustomRun.runTimeGraph ~= nil then

--- a/CustomRun.lua
+++ b/CustomRun.lua
@@ -6,7 +6,7 @@ CustomRun.runMetrics = {}
 CustomRun.runMetrics.previousSleepEnd = 0
 CustomRun.runMetrics.dt = 0
 CustomRun.runMetrics.updateDuration = 0
-CustomRun.runMetrics.drawGraphDuration = 0
+CustomRun.runMetrics.graphDuration = 0
 CustomRun.runMetrics.drawDuration = 0
 CustomRun.runMetrics.presentDuration = 0
 CustomRun.runMetrics.gcDuration = 0
@@ -96,7 +96,7 @@ function CustomRun.innerRun()
     if CustomRun.runTimeGraph then
       local preGraphDrawTime = love.timer.getTime()
       CustomRun.runTimeGraph:draw()
-      CustomRun.runMetrics.drawGraphDuration = love.timer.getTime() - preGraphDrawTime
+      CustomRun.runMetrics.graphDuration = CustomRun.runMetrics.graphDuration + (love.timer.getTime() - preGraphDrawTime)
     end
 
     if love.draw then
@@ -115,7 +115,9 @@ function CustomRun.innerRun()
   end
 
   if CustomRun.runTimeGraph ~= nil then
+    local preGraphUpdateTime = love.timer.getTime()
     CustomRun.runTimeGraph:updateWithMetrics(CustomRun.runMetrics)
+    CustomRun.runMetrics.graphDuration = love.timer.getTime() - preGraphUpdateTime
   end
 end
 

--- a/RunTimeGraph.lua
+++ b/RunTimeGraph.lua
@@ -26,10 +26,12 @@ local RunTimeGraph = class(function(self)
 
   -- run loop graph
   self.graphs[#self.graphs + 1] = BarGraph(x, y, width, height, updateSpeed, consts.FRAME_RATE * 1)
-  self.graphs[#self.graphs]:setFillColor({0, 1, 0, 1}, 1) -- update
-  self.graphs[#self.graphs]:setFillColor({1, 0.5, 0, 1}, 2) -- draw
-  self.graphs[#self.graphs]:setFillColor({0, 0, 1, 1}, 3) -- sleep
-  self.graphs[#self.graphs]:setFillColor({1, 1, 1, 1}, 4) -- present
+  self.graphs[#self.graphs]:setFillColor({0, 1, 0, 1}, 1) -- love.update
+  self.graphs[#self.graphs]:setFillColor({0, 0.5, 1, 1}, 2) -- self:RunTimeGraph
+  self.graphs[#self.graphs]:setFillColor({1, 0.5, 0, 1}, 3) -- love.draw
+  self.graphs[#self.graphs]:setFillColor({1, 1, 1, 1}, 4) -- love.present
+  self.graphs[#self.graphs]:setFillColor({1, 0, 1, 1}, 5) -- manualGc
+  self.graphs[#self.graphs]:setFillColor({0, 0, 1, 1}, 6) -- love.timer.sleep
   y = y + height + padding
 end)
 
@@ -45,7 +47,13 @@ function RunTimeGraph:updateWithMetrics(runMetrics)
 
   self.graphs[3]:updateGraph({leftover_time}, "leftover_time " .. leftover_time, dt)
 
-  self.graphs[4]:updateGraph({runMetrics.updateDuration, runMetrics.drawDuration, runMetrics.sleepDuration, runMetrics.presentDuration},
+  self.graphs[4]:updateGraph({runMetrics.updateDuration,
+                              runMetrics.drawGraphDuration,
+                              runMetrics.drawDuration,
+                              runMetrics.presentDuration,
+                              runMetrics.gcDuration,
+                              runMetrics.sleepDuration
+                            },
                              "Run Loop", dt)
 end
 

--- a/RunTimeGraph.lua
+++ b/RunTimeGraph.lua
@@ -27,11 +27,12 @@ local RunTimeGraph = class(function(self)
   -- run loop graph
   self.graphs[#self.graphs + 1] = BarGraph(x, y, width, height, updateSpeed, consts.FRAME_RATE * 1)
   self.graphs[#self.graphs]:setFillColor({0, 1, 0, 1}, 1) -- love.update
-  self.graphs[#self.graphs]:setFillColor({0, 0.5, 1, 1}, 2) -- self:RunTimeGraph
+  self.graphs[#self.graphs]:setFillColor({0, 0.5, 1, 1}, 2) -- self:draw + self:updateWithMetrics
   self.graphs[#self.graphs]:setFillColor({1, 0.5, 0, 1}, 3) -- love.draw
   self.graphs[#self.graphs]:setFillColor({1, 1, 1, 1}, 4) -- love.present
   self.graphs[#self.graphs]:setFillColor({1, 0, 1, 1}, 5) -- manualGc
   self.graphs[#self.graphs]:setFillColor({0, 0, 1, 1}, 6) -- love.timer.sleep
+
   y = y + height + padding
 end)
 
@@ -48,7 +49,7 @@ function RunTimeGraph:updateWithMetrics(runMetrics)
   self.graphs[3]:updateGraph({leftover_time}, "leftover_time " .. leftover_time, dt)
 
   self.graphs[4]:updateGraph({runMetrics.updateDuration,
-                              runMetrics.drawGraphDuration,
+                              runMetrics.graphDuration,
                               runMetrics.drawDuration,
                               runMetrics.presentDuration,
                               runMetrics.gcDuration,

--- a/engine/telegraph.lua
+++ b/engine/telegraph.lua
@@ -368,7 +368,7 @@ function Telegraph:render()
               -- TODO make this more performant?
               garbage_block.x, garbage_block.y = telegraph_to_render:telegraphLoopAttackPosition(garbage_block, frames_since_earned)
 
-              draw(characters[senderCharacter].telegraph_garbage_images["attack"], garbage_block.x, garbage_block.y, 0, atk_scale, atk_scale)
+              draw(characters[senderCharacter].telegraph_garbage_images["attack"], garbage_block.x, garbage_block.y, 0, atk_scale, atk_scale, true)
             else
               --move toward destination
 
@@ -380,7 +380,7 @@ function Telegraph:render()
               garbage_block.x = loopX + percent * (garbage_block.destination_x - loopX)
               garbage_block.y = loopY + percent * (garbage_block.destination_y - loopY)
 
-              draw(characters[senderCharacter].telegraph_garbage_images["attack"], garbage_block.x, garbage_block.y, 0, atk_scale, atk_scale)
+              draw(characters[senderCharacter].telegraph_garbage_images["attack"], garbage_block.x, garbage_block.y, 0, atk_scale, atk_scale, true)
             end
           end
         end
@@ -392,7 +392,7 @@ function Telegraph:render()
     
     -- Render if we are "currently chaining" for debug purposes
     if config.debug_mode and telegraph_to_render.senderCurrentlyChaining then
-      draw(characters[senderCharacter].telegraph_garbage_images["attack"], telegraph_to_render:telegraphRenderXPosition(-1), telegraph_to_render.pos_y, 0, atk_scale, atk_scale)
+      draw(characters[senderCharacter].telegraph_garbage_images["attack"], telegraph_to_render:telegraphRenderXPosition(-1), telegraph_to_render.pos_y, 0, atk_scale, atk_scale, true)
     end
 
     --then draw the telegraph's garbage queue, leaving an empty space until such a time as the attack arrives (earned_frame-GARBAGE_TRANSIT_TIME)
@@ -417,12 +417,12 @@ function Telegraph:render()
           local orig_grb_w, orig_grb_h = characters[senderCharacter].telegraph_garbage_images[height][current_block[1]]:getDimensions()
           local grb_scale_x = 24 / orig_grb_w
           local grb_scale_y = 16 / orig_grb_h
-          draw(characters[senderCharacter].telegraph_garbage_images[height--[[height]]][current_block[1]--[[width]]], draw_x, draw_y, 0, grb_scale_x, grb_scale_y)
+          draw(characters[senderCharacter].telegraph_garbage_images[height--[[height]]][current_block[1]--[[width]]], draw_x, draw_y, 0, grb_scale_x, grb_scale_y, true)
         else
           local orig_mtl_w, orig_mtl_h = characters[senderCharacter].telegraph_garbage_images["metal"]:getDimensions()
           local mtl_scale_x = 24 / orig_mtl_w
           local mtl_scale_y = 16 / orig_mtl_h
-          draw(characters[senderCharacter].telegraph_garbage_images["metal"], draw_x, draw_y, 0, mtl_scale_x, mtl_scale_y)
+          draw(characters[senderCharacter].telegraph_garbage_images["metal"], draw_x, draw_y, 0, mtl_scale_x, mtl_scale_y, true)
         end
         drewChain = drewChain or current_block[4]
 
@@ -444,7 +444,7 @@ function Telegraph:render()
           end
 
           if stopperTime then
-            gprintf(stopperTime, draw_x*GFX_SCALE, (draw_y-8)*GFX_SCALE, 70, "center", nil, 1, large_font)
+            gprintf(stopperTime, draw_x*GFX_SCALE, (draw_y-8)*GFX_SCALE, 70, "center", nil, 1, large_font, true)
           end
         end
 
@@ -460,11 +460,11 @@ function Telegraph:render()
       local orig_grb_w, orig_grb_h = characters[senderCharacter].telegraph_garbage_images[height][6]:getDimensions()
       local grb_scale_x = 24 / orig_grb_w
       local grb_scale_y = 16 / orig_grb_h
-      draw(characters[senderCharacter].telegraph_garbage_images[height][6], draw_x, draw_y, 0, grb_scale_x, grb_scale_y)
+      draw(characters[senderCharacter].telegraph_garbage_images[height][6], draw_x, draw_y, 0, grb_scale_x, grb_scale_y, true)
 
       -- Render a "G" for ghost
       if config.debug_mode then
-        gprintf("G", draw_x*GFX_SCALE, (draw_y-8)*GFX_SCALE, 70, "center", nil, 1, large_font)
+        gprintf("G", draw_x*GFX_SCALE, (draw_y-8)*GFX_SCALE, 70, "center", nil, 1, large_font, true)
       end
     end
 

--- a/graphics.lua
+++ b/graphics.lua
@@ -73,7 +73,7 @@ function Stack.draw_cards(self)
         for i = 1, 6, 1 do
           local cardfx_x = draw_x + math.cos(math.rad((i * 60) + (card.frame * 5))) * radius
           local cardfx_y = draw_y + math.sin(math.rad((i * 60) + (card.frame * 5))) * radius
-          qdraw(card.burstAtlas, card.burstParticle, cardfx_x, cardfx_y, 0, 16 / burstFrameDimension, 16 / burstFrameDimension)
+          qdraw(card.burstAtlas, card.burstParticle, cardfx_x, cardfx_y, 0, 16 / burstFrameDimension, 16 / burstFrameDimension, nil, nil, nil, true)
         end
       end
       -- draw card
@@ -85,7 +85,7 @@ function Stack.draw_cards(self)
       local icon_width, icon_height = cardImage:getDimensions()
       local fade = 1 - math.min(0.5 * ((card.frame-1) / 22), 0.5)
       set_color(1, 1, 1, fade)
-      draw(cardImage, draw_x, draw_y, 0, iconSize / icon_width, iconSize / icon_height)
+      draw(cardImage, draw_x, draw_y, 0, iconSize / icon_width, iconSize / icon_height, true)
       set_color(1, 1, 1, 1)
     end
   end
@@ -190,33 +190,33 @@ function Stack.draw_popfxs(self)
 
           -- four corner
           if big_position ~= 1 then
-            qdraw(burstParticle_atlas, burstParticle, positions[1].x, positions[1].y, 0, (16 / burstFrameDimension) * burstScale, (16 / burstFrameDimension) * burstScale, (burstFrameDimension * burstScale) / 2, (burstFrameDimension * burstScale) / 2)
+            qdraw(burstParticle_atlas, burstParticle, positions[1].x, positions[1].y, 0, (16 / burstFrameDimension) * burstScale, (16 / burstFrameDimension) * burstScale, (burstFrameDimension * burstScale) / 2, (burstFrameDimension * burstScale) / 2, nil, true)
           end
           if big_position ~= 2 then
-            qdraw(burstParticle_atlas, burstParticle, positions[2].x, positions[2].y, 0, -(16 / burstFrameDimension) * burstScale, (16 / burstFrameDimension) * burstScale, (burstFrameDimension * burstScale) / 2, (burstFrameDimension * burstScale) / 2)
+            qdraw(burstParticle_atlas, burstParticle, positions[2].x, positions[2].y, 0, -(16 / burstFrameDimension) * burstScale, (16 / burstFrameDimension) * burstScale, (burstFrameDimension * burstScale) / 2, (burstFrameDimension * burstScale) / 2, nil, true)
           end
           if big_position ~= 3 then
-            qdraw(burstParticle_atlas, burstParticle, positions[3].x, positions[3].y, 0, (16 / burstFrameDimension) * burstScale, -(16 / burstFrameDimension) * burstScale, (burstFrameDimension * burstScale) / 2, (burstFrameDimension * burstScale) / 2)
+            qdraw(burstParticle_atlas, burstParticle, positions[3].x, positions[3].y, 0, (16 / burstFrameDimension) * burstScale, -(16 / burstFrameDimension) * burstScale, (burstFrameDimension * burstScale) / 2, (burstFrameDimension * burstScale) / 2, nil, true)
           end
           if big_position ~= 4 then
-            qdraw(burstParticle_atlas, burstParticle, positions[4].x, positions[4].y, 0, -(16 / burstFrameDimension) * burstScale, -16 / burstFrameDimension * burstScale, (burstFrameDimension * burstScale) / 2, (burstFrameDimension * burstScale) / 2)
+            qdraw(burstParticle_atlas, burstParticle, positions[4].x, positions[4].y, 0, -(16 / burstFrameDimension) * burstScale, -16 / burstFrameDimension * burstScale, (burstFrameDimension * burstScale) / 2, (burstFrameDimension * burstScale) / 2, nil, true)
           end
           -- top and bottom
           if popfx.popsize == "big" or popfx.popsize == "giant" then
             if big_position ~= 5 then
-              qdraw(burstParticle_atlas, burstParticle, positions[5].x + 8, positions[5].y, topRot[1], topRot[2], topRot[3], (burstFrameDimension * burstScale) / 2, (burstFrameDimension * burstScale) / 2)
+              qdraw(burstParticle_atlas, burstParticle, positions[5].x + 8, positions[5].y, topRot[1], topRot[2], topRot[3], (burstFrameDimension * burstScale) / 2, (burstFrameDimension * burstScale) / 2, nil, true)
             end
             if big_position ~= 6 then
-              qdraw(burstParticle_atlas, burstParticle, positions[6].x + 8, positions[6].y, bottomRot[1], bottomRot[2], bottomRot[3], (burstFrameDimension * burstScale) / 2, (burstFrameDimension * burstScale) / 2)
+              qdraw(burstParticle_atlas, burstParticle, positions[6].x + 8, positions[6].y, bottomRot[1], bottomRot[2], bottomRot[3], (burstFrameDimension * burstScale) / 2, (burstFrameDimension * burstScale) / 2, nil, true)
             end
           end
           -- left and right
           if popfx.popsize == "giant" then
             if big_position ~= 7 then
-              qdraw(burstParticle_atlas, burstParticle, positions[7].x, positions[7].y + 8, leftRot[1], leftRot[2], leftRot[3], (burstFrameDimension * burstScale) / 2, (burstFrameDimension * burstScale) / 2)
+              qdraw(burstParticle_atlas, burstParticle, positions[7].x, positions[7].y + 8, leftRot[1], leftRot[2], leftRot[3], (burstFrameDimension * burstScale) / 2, (burstFrameDimension * burstScale) / 2, nil, true)
             end
             if big_position ~= 8 then
-              qdraw(burstParticle_atlas, burstParticle, positions[8].x, positions[8].y + 8, rightRot[1], rightRot[2], rightRot[3], (burstFrameDimension * burstScale) / 2, (burstFrameDimension * burstScale) / 2)
+              qdraw(burstParticle_atlas, burstParticle, positions[8].x, positions[8].y + 8, rightRot[1], rightRot[2], rightRot[3], (burstFrameDimension * burstScale) / 2, (burstFrameDimension * burstScale) / 2, nil, true)
             end
           end
         --big particle
@@ -234,7 +234,7 @@ function Stack.draw_popfxs(self)
         fadeFrame = popfx_fade_animation[popfx.frame]
         if (fadeFrame ~= nil) then
           fadeParticle:setViewport(fadeFrame * fadeFrameDimension, 0, fadeFrameDimension, fadeFrameDimension, fadeParticle_atlas:getDimensions())
-          qdraw(fadeParticle_atlas, fadeParticle, draw_x + 8, draw_y + 8, 0, (32 / fadeFrameDimension) * fadeScale, (32 / fadeFrameDimension) * fadeScale, fadeFrameDimension / 2, fadeFrameDimension / 2)
+          qdraw(fadeParticle_atlas, fadeParticle, draw_x + 8, draw_y + 8, 0, (32 / fadeFrameDimension) * fadeScale, (32 / fadeFrameDimension) * fadeScale, fadeFrameDimension / 2, fadeFrameDimension / 2, nil, true)
         end
       end
     end
@@ -266,10 +266,10 @@ function Stack.render(self)
     love.graphics.setShader()
   end
 
-  gfx_q:push({love.graphics.setCanvas, {{self.canvas, stencil = true}}})
-  gfx_q:push({love.graphics.clear, {}})
-  gfx_q:push({love.graphics.stencil, {frame_mask, "replace", 1}})
-  gfx_q:push({love.graphics.setStencilTest, {"greater", 0}})
+  love.graphics.setCanvas({self.canvas, stencil = true})
+  love.graphics.clear()
+  love.graphics.stencil(frame_mask, "replace", 1)
+  love.graphics.setStencilTest("greater", 0)
 
   -- draw inside stack's frame canvas
   local portrait_image = "portrait"
@@ -292,11 +292,11 @@ function Stack.render(self)
     end
   end
   if self.which == 1 or portrait_image == "portrait2" then
-    draw(characters[self.character].images[portrait_image], 4, 4, 0, 96 / portrait_w, 192 / portrait_h)
+    draw(characters[self.character].images[portrait_image], 4, 4, 0, 96 / portrait_w, 192 / portrait_h, true)
   else
-    draw(characters[self.character].images[portrait_image], 100, 4, 0, (96/portrait_w)*-1, 192/portrait_h)
+    draw(characters[self.character].images[portrait_image], 100, 4, 0, (96/portrait_w)*-1, 192/portrait_h, true)
   end
-  grectangle_color("fill", 4, 4, 96, 192, 0, 0, 0, self.portraitFade)
+  grectangle_color("fill", 4, 4, 96, 192, 0, 0, 0, self.portraitFade, true)
 
   local metals
   if self.garbage_target then
@@ -331,10 +331,10 @@ function Stack.render(self)
           if panel.x_offset == 0 and panel.y_offset == 0 then
             -- draw the entire block!
             if panel.metal then
-              draw(metals.left, draw_x, draw_y, 0, 8 / metall_w, 16 / metall_h)
-              draw(metals.right, draw_x + 16 * (panel.width - 1) + 8, draw_y, 0, 8 / metalr_w, 16 / metalr_h)
+              draw(metals.left, draw_x, draw_y, 0, 8 / metall_w, 16 / metall_h, true)
+              draw(metals.right, draw_x + 16 * (panel.width - 1) + 8, draw_y, 0, 8 / metalr_w, 16 / metalr_h, true)
               for i = 1, 2 * (panel.width - 1) do
-                draw(metals.mid, draw_x + 8 * i, draw_y, 0, 8 / metal_w, 16 / metal_h)
+                draw(metals.mid, draw_x + 8 * i, draw_y, 0, 8 / metal_w, 16 / metal_h, true)
               end
             else
               local height, width = panel.height, panel.width
@@ -343,7 +343,7 @@ function Stack.render(self)
               local filler_w, filler_h = imgs.filler1:getDimensions()
               for i = 0, height - 1 do
                 for j = 1, width - 1 do
-                  draw((use_1 or height < 3) and imgs.filler1 or imgs.filler2, draw_x + 16 * j - 8, top_y + 16 * i, 0, 16 / filler_w, 16 / filler_h)
+                  draw((use_1 or height < 3) and imgs.filler1 or imgs.filler2, draw_x + 16 * j - 8, top_y + 16 * i, 0, 16 / filler_w, 16 / filler_h, true)
                   use_1 = not use_1
                 end
               end
@@ -355,22 +355,22 @@ function Stack.render(self)
                   face = imgs.face
                 end
                 local face_w, face_h = face:getDimensions()
-                draw(face, draw_x + 8 * (width - 1), top_y + 16 * ((height - 1) / 2), 0, 16 / face_w, 16 / face_h)
+                draw(face, draw_x + 8 * (width - 1), top_y + 16 * ((height - 1) / 2), 0, 16 / face_w, 16 / face_h, true)
               else
                 local face_w, face_h = imgs.doubleface:getDimensions()
-                draw(imgs.doubleface, draw_x + 8 * (width - 1), top_y + 16 * ((height - 2) / 2), 0, 16 / face_w, 32 / face_h)
+                draw(imgs.doubleface, draw_x + 8 * (width - 1), top_y + 16 * ((height - 2) / 2), 0, 16 / face_w, 32 / face_h, true)
               end
               local corner_w, corner_h = imgs.topleft:getDimensions()
               local lr_w, lr_h = imgs.left:getDimensions()
               local topbottom_w, topbottom_h = imgs.top:getDimensions()
-              draw(imgs.left, draw_x, top_y, 0, 8 / lr_w, (1 / lr_h) * height * 16)
-              draw(imgs.right, draw_x + 16 * (width - 1) + 8, top_y, 0, 8 / lr_w, (1 / lr_h) * height * 16)
-              draw(imgs.top, draw_x, top_y, 0, (1 / topbottom_w) * width * 16, 2 / topbottom_h)
-              draw(imgs.bot, draw_x, draw_y + 14, 0, (1 / topbottom_w) * width * 16, 2 / topbottom_h)
-              draw(imgs.topleft, draw_x, top_y, 0, 8 / corner_w, 3 / corner_h)
-              draw(imgs.topright, draw_x + 16 * width - 8, top_y, 0, 8 / corner_w, 3 / corner_h)
-              draw(imgs.botleft, draw_x, draw_y + 13, 0, 8 / corner_w, 3 / corner_h)
-              draw(imgs.botright, draw_x + 16 * width - 8, draw_y + 13, 0, 8 / corner_w, 3 / corner_h)
+              draw(imgs.left, draw_x, top_y, 0, 8 / lr_w, (1 / lr_h) * height * 16, true)
+              draw(imgs.right, draw_x + 16 * (width - 1) + 8, top_y, 0, 8 / lr_w, (1 / lr_h) * height * 16, true)
+              draw(imgs.top, draw_x, top_y, 0, (1 / topbottom_w) * width * 16, 2 / topbottom_h, true)
+              draw(imgs.bot, draw_x, draw_y + 14, 0, (1 / topbottom_w) * width * 16, 2 / topbottom_h, true)
+              draw(imgs.topleft, draw_x, top_y, 0, 8 / corner_w, 3 / corner_h, true)
+              draw(imgs.topright, draw_x + 16 * width - 8, top_y, 0, 8 / corner_w, 3 / corner_h, true)
+              draw(imgs.botleft, draw_x, draw_y + 13, 0, 8 / corner_w, 3 / corner_h, true)
+              draw(imgs.botright, draw_x + 16 * width - 8, draw_y + 13, 0, 8 / corner_w, 3 / corner_h, true)
             end
           end
           if panel.state == "matched" then
@@ -378,27 +378,27 @@ function Stack.render(self)
             if flash_time >= self.FRAMECOUNT_FLASH then
               if panel.timer > panel.pop_time then
                 if panel.metal then
-                  draw(metals.left, draw_x, draw_y, 0, 8 / metall_w, 16 / metall_h)
-                  draw(metals.right, draw_x + 8, draw_y, 0, 8 / metalr_w, 16 / metalr_h)
+                  draw(metals.left, draw_x, draw_y, 0, 8 / metall_w, 16 / metall_h, true)
+                  draw(metals.right, draw_x + 8, draw_y, 0, 8 / metalr_w, 16 / metalr_h, true)
                 else
                   local popped_w, popped_h = imgs.pop:getDimensions()
-                  draw(imgs.pop, draw_x, draw_y, 0, 16 / popped_w, 16 / popped_h)
+                  draw(imgs.pop, draw_x, draw_y, 0, 16 / popped_w, 16 / popped_h, true)
                 end
               elseif panel.y_offset == -1 then
                 local p_w, p_h = panels[self.panels_dir].images.classic[panel.color][1]:getDimensions()
-                draw(panels[self.panels_dir].images.classic[panel.color][1], draw_x, draw_y, 0, 16 / p_w, 16 / p_h)
+                draw(panels[self.panels_dir].images.classic[panel.color][1], draw_x, draw_y, 0, 16 / p_w, 16 / p_h, true)
               end
             elseif flash_time % 2 == 1 then
               if panel.metal then
-                draw(metals.left, draw_x, draw_y, 0, 8 / metall_w, 16 / metall_h)
-                draw(metals.right, draw_x + 8, draw_y, 0, 8 / metalr_w, 16 / metalr_h)
+                draw(metals.left, draw_x, draw_y, 0, 8 / metall_w, 16 / metall_h, true)
+                draw(metals.right, draw_x + 8, draw_y, 0, 8 / metalr_w, 16 / metalr_h, true)
               else
                 local popped_w, popped_h = imgs.pop:getDimensions()
-                draw(imgs.pop, draw_x, draw_y, 0, 16 / popped_w, 16 / popped_h)
+                draw(imgs.pop, draw_x, draw_y, 0, 16 / popped_w, 16 / popped_h, true)
               end
             else
               local flashed_w, flashed_h = imgs.flash:getDimensions()
-              draw(imgs.flash, draw_x, draw_y, 0, 16 / flashed_w, 16 / flashed_h)
+              draw(imgs.flash, draw_x, draw_y, 0, 16 / flashed_w, 16 / flashed_h, true)
             end
           end
         else
@@ -433,7 +433,7 @@ function Stack.render(self)
             draw_frame = 1
           end
           local panel_w, panel_h = panels[self.panels_dir].images.classic[panel.color][draw_frame]:getDimensions()
-          draw(panels[self.panels_dir].images.classic[panel.color][draw_frame], draw_x, draw_y, 0, 16 / panel_w, 16 / panel_h)
+          draw(panels[self.panels_dir].images.classic[panel.color][draw_frame], draw_x, draw_y, 0, 16 / panel_w, 16 / panel_h, true)
         end
       end
     end
@@ -450,10 +450,10 @@ function Stack.render(self)
     wallImage = themes[config.theme].images.IMG_wall2P
   end
   if frameImage then
-    graphicsUtil.drawScaledImage(frameImage, 0, 0, 312, 612)
+    graphicsUtil.drawScaledImage(frameImage, 0, 0, 312, 612, true)
   end
   if wallImage then
-    graphicsUtil.drawScaledWidthImage(wallImage, 12, (4 - shake + self.height * 16)*GFX_SCALE, 288)
+    graphicsUtil.drawScaledWidthImage(wallImage, 12, (4 - shake + self.height * 16)*GFX_SCALE, 288, true)
   end
 
   -- Draw the cursor
@@ -467,11 +467,11 @@ function Stack.render(self)
   end
   -- ends here
 
-  gfx_q:push({love.graphics.setStencilTest, {}})
-  gfx_q:push({love.graphics.setCanvas, {GAME.globalCanvas}})
-  gfx_q:push({love.graphics.setBlendMode, {"alpha", "premultiplied"}})
-  gfx_q:push({love.graphics.draw, {self.canvas, (self.pos_x - 4) * GFX_SCALE, (self.pos_y - 4) * GFX_SCALE}})
-  gfx_q:push({love.graphics.setBlendMode, {"alpha", "alphamultiply"}})
+  love.graphics.setStencilTest()
+  love.graphics.setCanvas(GAME.globalCanvas)
+  love.graphics.setBlendMode("alpha", "premultiplied")
+  love.graphics.draw(self.canvas, (self.pos_x - 4) * GFX_SCALE, (self.pos_y - 4) * GFX_SCALE)
+  love.graphics.setBlendMode("alpha", "alphamultiply")
 
   self:draw_popfxs()
   self:draw_cards()
@@ -489,15 +489,15 @@ function Stack.render(self)
         -- Require hovering over a stack to show details
         if mx >= self.pos_x * GFX_SCALE and mx <= (self.pos_x + self.width * 16) * GFX_SCALE then
           if panel.color ~= 0 and panel.state ~= "popped" then
-            gprint(panel.state, draw_x, draw_y)
+            gprint(panel.state, draw_x, draw_y, nil, nil, true)
             if panel.match_anyway ~= nil then
-              gprint(tostring(panel.match_anyway), draw_x, draw_y + 10)
+              gprint(tostring(panel.match_anyway), draw_x, draw_y + 10, nil, nil, true)
               if panel.debug_tag then
-                gprint(tostring(panel.debug_tag), draw_x, draw_y + 20)
+                gprint(tostring(panel.debug_tag), draw_x, draw_y + 20, nil, nil, true)
               end
             end
             if panel.chaining then
-              gprint("chaining", draw_x, draw_y + 30)
+              gprint("chaining", draw_x, draw_y + 30, nil, nil, true)
             end
           end
         end
@@ -511,8 +511,8 @@ function Stack.render(self)
           local drawX = 30
           local drawY = 10
 
-          grectangle_color("fill", (drawX - 5) / GFX_SCALE, (drawY - 5) / GFX_SCALE, 100/GFX_SCALE, 100/GFX_SCALE, 0, 0, 0, 0.5)
-          gprintf(str, drawX, drawY)
+          grectangle_color("fill", (drawX - 5) / GFX_SCALE, (drawY - 5) / GFX_SCALE, 100/GFX_SCALE, 100/GFX_SCALE, 0, 0, 0, 0.5, true)
+          gprintf({str, drawX, drawY, drawDirectly = true})
         end
       end
     end
@@ -524,27 +524,27 @@ function Stack.render(self)
     -- draw outside of stack's frame canvas
     if self.match.mode == "puzzle" then
       --gprint(loc("pl_moves", self.puzzle.remaining_moves), self.score_x, self.score_y)
-      draw_label(themes[config.theme].images.IMG_moves, (self.origin_x + themes[config.theme].moveLabel_Pos[1]) / GFX_SCALE, (self.pos_y + themes[config.theme].moveLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].moveLabel_Scale)
+      draw_label(themes[config.theme].images.IMG_moves, (self.origin_x + themes[config.theme].moveLabel_Pos[1]) / GFX_SCALE, (self.pos_y + themes[config.theme].moveLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].moveLabel_Scale, nil, true)
       if self.puzzle.puzzleType == "moves" then
         -- display moves left
-        GraphicsUtil.draw_number(self.puzzle.remaining_moves, themes[config.theme].images.IMG_number_atlas_1P, self.move_quads, self.score_x + themes[config.theme].move_Pos[1], self.score_y + themes[config.theme].move_Pos[2], themes[config.theme].move_Scale, "center")
+        GraphicsUtil.draw_number(self.puzzle.remaining_moves, themes[config.theme].images.IMG_number_atlas_1P, self.move_quads, self.score_x + themes[config.theme].move_Pos[1], self.score_y + themes[config.theme].move_Pos[2], themes[config.theme].move_Scale, "center", true)
       else
         -- display total amount of moves
-        GraphicsUtil.draw_number(math.abs(self.puzzle.remaining_moves), themes[config.theme].images.IMG_number_atlas_1P, self.move_quads, self.score_x + themes[config.theme].move_Pos[1], self.score_y + themes[config.theme].move_Pos[2], themes[config.theme].move_Scale, "center")
+        GraphicsUtil.draw_number(math.abs(self.puzzle.remaining_moves), themes[config.theme].images.IMG_number_atlas_1P, self.move_quads, self.score_x + themes[config.theme].move_Pos[1], self.score_y + themes[config.theme].move_Pos[2], themes[config.theme].move_Scale, "center", true)
       end
     end
   end
 
   local function drawScore()
     --gprint(loc("pl_score", self.score), self.score_x, self.score_y-40)
-    draw_label(themes[config.theme].images["IMG_score" .. self.id], self.origin_x + (themes[config.theme].scoreLabel_Pos[1] * self.mirror_x), self.pos_y + themes[config.theme].scoreLabel_Pos[2], 0, themes[config.theme].scoreLabel_Scale, self.multiplication)
-    GraphicsUtil.draw_number(self.score, themes[config.theme].images["IMG_number_atlas" .. self.id], self.score_quads, (self.origin_x + (themes[config.theme].score_Pos[1] * self.mirror_x)) * GFX_SCALE, (self.pos_y + themes[config.theme].score_Pos[2]) * GFX_SCALE, themes[config.theme].score_Scale, "center")
+    draw_label(themes[config.theme].images["IMG_score" .. self.id], self.origin_x + (themes[config.theme].scoreLabel_Pos[1] * self.mirror_x), self.pos_y + themes[config.theme].scoreLabel_Pos[2], 0, themes[config.theme].scoreLabel_Scale, self.multiplication, true)
+    GraphicsUtil.draw_number(self.score, themes[config.theme].images["IMG_number_atlas" .. self.id], self.score_quads, (self.origin_x + (themes[config.theme].score_Pos[1] * self.mirror_x)) * GFX_SCALE, (self.pos_y + themes[config.theme].score_Pos[2]) * GFX_SCALE, themes[config.theme].score_Scale, "center", true)
   end
 
   local function drawSpeed()
     --gprint(loc("pl_speed", self.speed), self.score_x, self.score_y+45)
-    draw_label(themes[config.theme].images["IMG_speed" .. self.id], self.origin_x + themes[config.theme].speedLabel_Pos[1] * self.mirror_x, (self.pos_y + themes[config.theme].speedLabel_Pos[2]), 0, themes[config.theme].speedLabel_Scale, self.multiplication)
-    GraphicsUtil.draw_number(self.speed, themes[config.theme].images["IMG_number_atlas" .. self.id], self.speed_quads, (self.origin_x + (themes[config.theme].speed_Pos[1] * self.mirror_x)) * GFX_SCALE, (self.pos_y + themes[config.theme].speed_Pos[2]) * GFX_SCALE, themes[config.theme].speed_Scale, "center")
+    draw_label(themes[config.theme].images["IMG_speed" .. self.id], self.origin_x + themes[config.theme].speedLabel_Pos[1] * self.mirror_x, (self.pos_y + themes[config.theme].speedLabel_Pos[2]), 0, themes[config.theme].speedLabel_Scale, self.multiplication, true)
+    GraphicsUtil.draw_number(self.speed, themes[config.theme].images["IMG_number_atlas" .. self.id], self.speed_quads, (self.origin_x + (themes[config.theme].speed_Pos[1] * self.mirror_x)) * GFX_SCALE, (self.pos_y + themes[config.theme].speed_Pos[2]) * GFX_SCALE, themes[config.theme].speed_Scale, "center", true)
   end
 
   local function drawTimer()
@@ -561,16 +561,16 @@ function Stack.render(self)
         mins = mins + 1
       end
       --gprint(loc("pl_time", string.format("%01d:%02d",mins,secs)), self.score_x, self.score_y+60)
-      draw_label(themes[config.theme].images.IMG_time, (main_infos_screen_pos.x + themes[config.theme].timeLabel_Pos[1]) / GFX_SCALE, (main_infos_screen_pos.y + themes[config.theme].timeLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].timeLabel_Scale)
-      GraphicsUtil.draw_time(string.format("%01d:%02d", mins, secs), self.time_quads, main_infos_screen_pos.x + themes[config.theme].time_Pos[1], main_infos_screen_pos.y + themes[config.theme].time_Pos[2], themes[config.theme].time_Scale)
+      draw_label(themes[config.theme].images.IMG_time, (main_infos_screen_pos.x + themes[config.theme].timeLabel_Pos[1]) / GFX_SCALE, (main_infos_screen_pos.y + themes[config.theme].timeLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].timeLabel_Scale, nil, true)
+      GraphicsUtil.draw_time(string.format("%01d:%02d", mins, secs), self.time_quads, main_infos_screen_pos.x + themes[config.theme].time_Pos[1], main_infos_screen_pos.y + themes[config.theme].time_Pos[2], themes[config.theme].time_Scale, true)
     elseif self.match.mode == "puzzle" then
       -- puzzles don't have a timer...yet?
     else
       -- Draw the time for non time attack modes
       if self and self.which == 1 and self.game_stopwatch and tonumber(self.game_stopwatch) then
         --gprint(frames_to_time_string(self.game_stopwatch, self.match.mode == "endless"), main_infos_screen_pos.x+10, main_infos_screen_pos.y+6)
-        draw_label(themes[config.theme].images.IMG_time, (main_infos_screen_pos.x + themes[config.theme].timeLabel_Pos[1]) / GFX_SCALE, (main_infos_screen_pos.y + themes[config.theme].timeLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].timeLabel_Scale)
-        GraphicsUtil.draw_time(frames_to_time_string(self.game_stopwatch, self.match.mode == "endless"), self.time_quads, main_infos_screen_pos.x + themes[config.theme].time_Pos[1], main_infos_screen_pos.y + themes[config.theme].time_Pos[2], themes[config.theme].time_Scale)
+        draw_label(themes[config.theme].images.IMG_time, (main_infos_screen_pos.x + themes[config.theme].timeLabel_Pos[1]) / GFX_SCALE, (main_infos_screen_pos.y + themes[config.theme].timeLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].timeLabel_Scale, nil, true)
+        GraphicsUtil.draw_time(frames_to_time_string(self.game_stopwatch, self.match.mode == "endless"), self.time_quads, main_infos_screen_pos.x + themes[config.theme].time_Pos[1], main_infos_screen_pos.y + themes[config.theme].time_Pos[2], themes[config.theme].time_Scale, true)
       end
     end
   end
@@ -578,11 +578,11 @@ function Stack.render(self)
   local function drawLevel()
     if self.level then
       --gprint(loc("pl_level", self.level), self.score_x, self.score_y+70)
-      draw_label(themes[config.theme].images["IMG_level" .. self.id], self.origin_x + themes[config.theme].levelLabel_Pos[1] * self.mirror_x, self.pos_y + themes[config.theme].levelLabel_Pos[2], 0, themes[config.theme].levelLabel_Scale, self.multiplication)
+      draw_label(themes[config.theme].images["IMG_level" .. self.id], self.origin_x + themes[config.theme].levelLabel_Pos[1] * self.mirror_x, self.pos_y + themes[config.theme].levelLabel_Pos[2], 0, themes[config.theme].levelLabel_Scale, self.multiplication, true)
   
       level_atlas = themes[config.theme].images["IMG_levelNumber_atlas" .. self.id]
       self.level_quad:setViewport(tonumber(self.level - 1) * (level_atlas:getWidth() / 11), 0, level_atlas:getWidth() / 11, level_atlas:getHeight(), level_atlas:getDimensions())
-      qdraw(level_atlas, self.level_quad, (self.origin_x + themes[config.theme].level_Pos[1] * self.mirror_x), (self.pos_y + themes[config.theme].level_Pos[2]), 0, (28 / themes[config.theme].images["levelNumberWidth" .. self.id] * themes[config.theme].level_Scale) / GFX_SCALE, (26 / themes[config.theme].images["levelNumberHeight" .. self.id] * themes[config.theme].level_Scale / GFX_SCALE), 0, 0, self.multiplication)
+      qdraw(level_atlas, self.level_quad, (self.origin_x + themes[config.theme].level_Pos[1] * self.mirror_x), (self.pos_y + themes[config.theme].level_Pos[2]), 0, (28 / themes[config.theme].images["levelNumberWidth" .. self.id] * themes[config.theme].level_Scale) / GFX_SCALE, (26 / themes[config.theme].images["levelNumberHeight" .. self.id] * themes[config.theme].level_Scale / GFX_SCALE), 0, 0, self.multiplication, true)
     end
   end
 
@@ -604,14 +604,14 @@ function Stack.render(self)
     -- If we have a healthbar frame draw it.
     -- (It may be the absolute version or the normal version)
     if themes[config.theme].images["IMG_healthbar_frame" .. self.id] then
-      draw_label(themes[config.theme].images["IMG_healthbar_frame" .. self.id], self.origin_x + themes[config.theme].healthbar_frame_Pos[1] * self.mirror_x, self.pos_y + themes[config.theme].healthbar_frame_Pos[2], 0, themes[config.theme].healthbar_frame_Scale, self.multiplication)
+      draw_label(themes[config.theme].images["IMG_healthbar_frame" .. self.id], self.origin_x + themes[config.theme].healthbar_frame_Pos[1] * self.mirror_x, self.pos_y + themes[config.theme].healthbar_frame_Pos[2], 0, themes[config.theme].healthbar_frame_Scale, self.multiplication, true)
     end
 
     if not themes[config.theme].multibar_is_absolute then
       -- Healthbar
       local healthbar = self.health * (themes[config.theme].images.IMG_healthbar:getHeight() / self.max_health)
       self.healthQuad:setViewport(0, themes[config.theme].images.IMG_healthbar:getHeight() - healthbar, themes[config.theme].images.IMG_healthbar:getWidth(), healthbar)
-      qdraw(themes[config.theme].images.IMG_healthbar, self.healthQuad, self.origin_x + themes[config.theme].healthbar_Pos[1] * self.mirror_x, (self.pos_y + themes[config.theme].healthbar_Pos[2]) + (themes[config.theme].images.IMG_healthbar:getHeight() - healthbar), themes[config.theme].healthbar_Rotate, themes[config.theme].healthbar_Scale, themes[config.theme].healthbar_Scale, 0, 0, self.multiplication)
+      qdraw(themes[config.theme].images.IMG_healthbar, self.healthQuad, self.origin_x + themes[config.theme].healthbar_Pos[1] * self.mirror_x, (self.pos_y + themes[config.theme].healthbar_Pos[2]) + (themes[config.theme].images.IMG_healthbar:getHeight() - healthbar), themes[config.theme].healthbar_Rotate, themes[config.theme].healthbar_Scale, themes[config.theme].healthbar_Scale, 0, 0, self.multiplication, true)
     end
 
     --gprint(loc("pl_stop", stop_time), self.score_x, self.score_y+300)
@@ -659,11 +659,11 @@ function Stack.render(self)
       self.multi_prestopQuad:setViewport(0, themes[config.theme].images.IMG_multibar_prestop_bar:getHeight() - multi_prestop_bar, themes[config.theme].images.IMG_multibar_prestop_bar:getWidth(), multi_prestop_bar)
 
       --Shake
-      qdraw(themes[config.theme].images.IMG_multibar_shake_bar, self.multi_shakeQuad, self.origin_x + themes[config.theme].multibar_Pos[1] * self.mirror_x, ((self.pos_y + themes[config.theme].multibar_Pos[2]) + ((themes[config.theme].images.IMG_multibar_shake_bar:getHeight() - multi_shake_bar) / GFX_SCALE)), 0, themes[config.theme].multibar_Scale / GFX_SCALE, themes[config.theme].multibar_Scale / GFX_SCALE, 0, 0, self.multiplication)
+      qdraw(themes[config.theme].images.IMG_multibar_shake_bar, self.multi_shakeQuad, self.origin_x + themes[config.theme].multibar_Pos[1] * self.mirror_x, ((self.pos_y + themes[config.theme].multibar_Pos[2]) + ((themes[config.theme].images.IMG_multibar_shake_bar:getHeight() - multi_shake_bar) / GFX_SCALE)), 0, themes[config.theme].multibar_Scale / GFX_SCALE, themes[config.theme].multibar_Scale / GFX_SCALE, 0, 0, self.multiplication, true)
       --Stop
-      qdraw(themes[config.theme].images.IMG_multibar_stop_bar, self.multi_stopQuad, self.origin_x + themes[config.theme].multibar_Pos[1] * self.mirror_x, (((self.pos_y - (multi_shake_bar / GFX_SCALE)) + themes[config.theme].multibar_Pos[2]) + ((themes[config.theme].images.IMG_multibar_stop_bar:getHeight() - multi_stop_bar) / GFX_SCALE)), 0, themes[config.theme].multibar_Scale / GFX_SCALE, themes[config.theme].multibar_Scale / GFX_SCALE, 0, 0, self.multiplication)
+      qdraw(themes[config.theme].images.IMG_multibar_stop_bar, self.multi_stopQuad, self.origin_x + themes[config.theme].multibar_Pos[1] * self.mirror_x, (((self.pos_y - (multi_shake_bar / GFX_SCALE)) + themes[config.theme].multibar_Pos[2]) + ((themes[config.theme].images.IMG_multibar_stop_bar:getHeight() - multi_stop_bar) / GFX_SCALE)), 0, themes[config.theme].multibar_Scale / GFX_SCALE, themes[config.theme].multibar_Scale / GFX_SCALE, 0, 0, self.multiplication, true)
       -- Prestop
-      qdraw(themes[config.theme].images.IMG_multibar_prestop_bar, self.multi_prestopQuad, self.origin_x + (themes[config.theme].multibar_Pos[1] * self.mirror_x), (((self.pos_y - (multi_shake_bar / GFX_SCALE + multi_stop_bar / GFX_SCALE)) + themes[config.theme].multibar_Pos[2]) + ((themes[config.theme].images.IMG_multibar_prestop_bar:getHeight() - multi_prestop_bar) / GFX_SCALE)), 0, themes[config.theme].multibar_Scale / GFX_SCALE, themes[config.theme].multibar_Scale / GFX_SCALE, 0, 0, self.multiplication)
+      qdraw(themes[config.theme].images.IMG_multibar_prestop_bar, self.multi_prestopQuad, self.origin_x + (themes[config.theme].multibar_Pos[1] * self.mirror_x), (((self.pos_y - (multi_shake_bar / GFX_SCALE + multi_stop_bar / GFX_SCALE)) + themes[config.theme].multibar_Pos[2]) + ((themes[config.theme].images.IMG_multibar_prestop_bar:getHeight() - multi_prestop_bar) / GFX_SCALE)), 0, themes[config.theme].multibar_Scale / GFX_SCALE, themes[config.theme].multibar_Scale / GFX_SCALE, 0, 0, self.multiplication, true)
     else -- Absolute Multibar
       -- Healthbar
       local iconX = (self.origin_x + themes[config.theme].multibar_Pos[1] * self.mirror_x) * GFX_SCALE
@@ -688,7 +688,7 @@ function Stack.render(self)
       icon_width, icon_height = themes[config.theme].images.IMG_healthbar:getDimensions()
       iconXScale = (desiredWidth / GFX_SCALE) / icon_width * self.mirror_x
       iconYScale = -(healthBar / icon_height) / GFX_SCALE
-      draw(themes[config.theme].images.IMG_healthbar, iconX / GFX_SCALE, iconY / GFX_SCALE, 0, iconXScale, iconYScale)
+      draw(themes[config.theme].images.IMG_healthbar, iconX / GFX_SCALE, iconY / GFX_SCALE, 0, iconXScale, iconYScale, true)
 
       iconY = iconY - healthBar
 
@@ -696,33 +696,33 @@ function Stack.render(self)
       icon_width, icon_height = themes[config.theme].images.IMG_multibar_shake_bar:getDimensions()
       iconXScale = (desiredWidth / GFX_SCALE) / icon_width * self.mirror_x
       iconYScale = -(shakeTimeBar / icon_height) / GFX_SCALE
-      draw(themes[config.theme].images.IMG_multibar_shake_bar, iconX / GFX_SCALE, iconY / GFX_SCALE, 0, iconXScale, iconYScale)
+      draw(themes[config.theme].images.IMG_multibar_shake_bar, iconX / GFX_SCALE, iconY / GFX_SCALE, 0, iconXScale, iconYScale, true)
 
       --Stop
       icon_width, icon_height = themes[config.theme].images.IMG_multibar_stop_bar:getDimensions()
       iconXScale = (desiredWidth / GFX_SCALE) / icon_width * self.mirror_x
       iconYScale = -(stopTimeBar / icon_height) / GFX_SCALE
-      draw(themes[config.theme].images.IMG_multibar_stop_bar, iconX / GFX_SCALE, iconY / GFX_SCALE, 0, iconXScale, iconYScale)
+      draw(themes[config.theme].images.IMG_multibar_stop_bar, iconX / GFX_SCALE, iconY / GFX_SCALE, 0, iconXScale, iconYScale, true)
 
       -- Prestop
       icon_width, icon_height = themes[config.theme].images.IMG_multibar_prestop_bar:getDimensions()
       iconXScale = (desiredWidth / GFX_SCALE) / icon_width * self.mirror_x
       iconYScale = -(preStopBar / icon_height) / GFX_SCALE
       iconY = iconY - math.max(shakeTimeBar, stopTimeBar)
-      draw(themes[config.theme].images.IMG_multibar_prestop_bar, iconX / GFX_SCALE, iconY / GFX_SCALE, 0, iconXScale, iconYScale)
+      draw(themes[config.theme].images.IMG_multibar_prestop_bar, iconX / GFX_SCALE, iconY / GFX_SCALE, 0, iconXScale, iconYScale, true)
     end
 
     if config.debug_mode and self.danger then
-      gprint("danger", self.score_x, self.score_y + 135)
+      gprint({"danger", self.score_x, self.score_y + 135, drawDirectly = true})
     end
     if config.debug_mode and self.danger_music then
-      gprint("danger music", self.score_x, self.score_y + 150)
+      gprint({"danger music", self.score_x, self.score_y + 150, drawDirectly = true})
     end
     if config.debug_mode then
-      gprint(loc("pl_cleared", (self.panels_cleared or 0)), self.score_x, self.score_y + 165)
+      gprint({loc("pl_cleared", (self.panels_cleared or 0)), self.score_x, self.score_y + 165, drawDirectly = true})
     end
     if config.debug_mode then
-      gprint(loc("pl_metal", (self.metal_panels_queued or 0)), self.score_x, self.score_y + 180)
+      gprint({loc("pl_metal", (self.metal_panels_queued or 0)), self.score_x, self.score_y + 180, drawDirectly = true})
     end
     if config.debug_mode and (self.input_state or self.taunt_up or self.taunt_down) then
       local iraise, iswap, iup, idown, ileft, iright = unpack(base64decode[self.input_state])
@@ -751,7 +751,7 @@ function Stack.render(self)
       if self.taunt_up then
         inputs_to_print = inputs_to_print .. "\ntaunt_up"
       end
-      gprint(inputs_to_print, self.score_x, self.score_y + 195)
+      gprint({inputs_to_print, self.score_x, self.score_y + 195, drawDirectly = true})
     end
   end
 
@@ -766,7 +766,7 @@ function Stack.render(self)
         matchImage = themes[config.theme].images.IMG_casual
       end
       if matchImage then
-        draw_label(matchImage, (main_infos_screen_pos.x + themes[config.theme].matchtypeLabel_Pos[1]) / GFX_SCALE, (main_infos_screen_pos.y + themes[config.theme].matchtypeLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].matchtypeLabel_Scale)
+        draw_label(matchImage, (main_infos_screen_pos.x + themes[config.theme].matchtypeLabel_Pos[1]) / GFX_SCALE, (main_infos_screen_pos.y + themes[config.theme].matchtypeLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].matchtypeLabel_Scale, nil, true)
       end
     end
   end
@@ -774,7 +774,7 @@ function Stack.render(self)
   local function drawCommunityMessage()
     -- Draw the community message
     if not config.debug_mode then
-      gprintf(join_community_msg or "", 0, main_infos_screen_pos.y + 550, canvas_width, "center")
+      gprintf({join_community_msg or "", 0, main_infos_screen_pos.y + 550, canvas_width, "center", drawDirectly = true})
     end
   end
 
@@ -801,22 +801,22 @@ function Stack.render(self)
     local icon_height
   
     -- Background
-    grectangle_color("fill", x / GFX_SCALE - backgroundPadding, y / GFX_SCALE - backgroundPadding, 160/GFX_SCALE, 600/GFX_SCALE, 0, 0, 0, 0.5)
-  
+    grectangle_color("fill", x / GFX_SCALE - backgroundPadding, y / GFX_SCALE - backgroundPadding, 160/GFX_SCALE, 600/GFX_SCALE, 0, 0, 0, 0.5, true)
+
     -- Panels cleared
     icon_width, icon_height = panels[self.panels_dir].images.classic[1][6]:getDimensions()
-    draw(panels[self.panels_dir].images.classic[1][6], x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height)
-    gprintf(analytic.data.destroyed_panels, x + iconToTextSpacing, y + 0, canvas_width, "left", nil, 1, fontIncrement)
-  
+    draw(panels[self.panels_dir].images.classic[1][6], x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height, true)
+    gprintf(analytic.data.destroyed_panels, x + iconToTextSpacing, y + 0, canvas_width, "left", nil, 1, fontIncrement, true)
+
     y = y + nextIconIncrement
-  
+
     -- Garbage sent
     icon_width, icon_height = characters[self.character].images.face:getDimensions()
-    draw(characters[self.character].images.face, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height)
-    gprintf(analytic.data.sent_garbage_lines, x + iconToTextSpacing, y + 0, canvas_width, "left", nil, 1, fontIncrement)
-  
+    draw(characters[self.character].images.face, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height, true)
+    gprintf(analytic.data.sent_garbage_lines, x + iconToTextSpacing, y + 0, canvas_width, "left", nil, 1, fontIncrement, true)
+
     y = y + nextIconIncrement
-  
+
     -- GPM
     if analytic.lastGPM == 0 or math.fmod(self.CLOCK, 60) < self.max_runs_per_frame then
       if self.CLOCK > 0 and (analytic.data.sent_garbage_lines > 0) then
@@ -825,24 +825,24 @@ function Stack.render(self)
       end
     end
     icon_width, icon_height = themes[config.theme].images.IMG_gpm:getDimensions()
-    draw(themes[config.theme].images.IMG_gpm, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height)
-    gprintf(analytic.lastGPM .. "/m", x + iconToTextSpacing, y + 0, canvas_width, "left", nil, 1, fontIncrement)  
-  
+    draw(themes[config.theme].images.IMG_gpm, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height, true)
+    gprintf(analytic.lastGPM .. "/m", x + iconToTextSpacing, y + 0, canvas_width, "left", nil, 1, fontIncrement, true)
+
     y = y + nextIconIncrement
-  
+
     -- Moves
     icon_width, icon_height = themes[config.theme].images.IMG_cursorCount:getDimensions()
-    draw(themes[config.theme].images.IMG_cursorCount, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height)
-    gprintf(analytic.data.move_count, x + iconToTextSpacing, y + 0, canvas_width, "left", nil, 1, fontIncrement)
+    draw(themes[config.theme].images.IMG_cursorCount, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height, true)
+    gprintf(analytic.data.move_count, x + iconToTextSpacing, y + 0, canvas_width, "left", nil, 1, fontIncrement, true)
   
     y = y + nextIconIncrement
   
     -- Swaps
     if themes[config.theme].images.IMG_swap then
       icon_width, icon_height = themes[config.theme].images.IMG_swap:getDimensions()
-      draw(themes[config.theme].images.IMG_swap, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height)
+      draw(themes[config.theme].images.IMG_swap, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height, true)
     end
-    gprintf(analytic.data.swap_count, x + iconToTextSpacing, y + 0, canvas_width, "left", nil, 1, fontIncrement)
+    gprintf(analytic.data.swap_count, x + iconToTextSpacing, y + 0, canvas_width, "left", nil, 1, fontIncrement, true)
   
     y = y + nextIconIncrement
   
@@ -855,9 +855,9 @@ function Stack.render(self)
     end
     if themes[config.theme].images.IMG_apm then
       icon_width, icon_height = themes[config.theme].images.IMG_apm:getDimensions()
-      draw(themes[config.theme].images.IMG_apm, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height)
+      draw(themes[config.theme].images.IMG_apm, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height, true)
     end
-    gprintf(analytic.lastAPM .. "/m", x + iconToTextSpacing, y + 0, canvas_width, "left", nil, 1, fontIncrement)
+    gprintf(analytic.lastAPM .. "/m", x + iconToTextSpacing, y + 0, canvas_width, "left", nil, 1, fontIncrement, true)
   
     y = y + nextIconIncrement
   
@@ -892,8 +892,8 @@ function Stack.render(self)
           cardImage = themes[config.theme].images.IMG_cards[true][0]
         end
         icon_width, icon_height = cardImage:getDimensions()
-        draw(cardImage, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height)
-        gprintf(chain_amount, x + iconToTextSpacing, y + 0, canvas_width, "left", nil, 1, fontIncrement)
+        draw(cardImage, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height, true)
+        gprintf(chain_amount, x + iconToTextSpacing, y + 0, canvas_width, "left", nil, 1, fontIncrement, true)
         y = y + nextIconIncrement
       end
     end
@@ -920,8 +920,8 @@ function Stack.render(self)
     for i, combo_amount in pairs(comboData) do
       if combo_amount and combo_amount > 0 then
         icon_width, icon_height = themes[config.theme].images.IMG_cards[false][i]:getDimensions()
-        draw(themes[config.theme].images.IMG_cards[false][i], xCombo / GFX_SCALE, yCombo / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height)
-        gprintf(combo_amount, xCombo + iconToTextSpacing, yCombo + 0, canvas_width, "left", nil, 1, fontIncrement)
+        draw(themes[config.theme].images.IMG_cards[false][i], xCombo / GFX_SCALE, yCombo / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height, true)
+        gprintf(combo_amount, xCombo + iconToTextSpacing, yCombo + 0, canvas_width, "left", nil, 1, fontIncrement, true)
         yCombo = yCombo + nextIconIncrement
       end
     end
@@ -964,10 +964,10 @@ function Stack.render_cursor(self)
 
   if self.countdown_timer then
     if self.CLOCK % 2 == 0 then
-      draw(themes[config.theme].images.IMG_cursor[1], (self.cur_col - 1) * 16, (11 - (self.cur_row)) * 16 + self.displacement - shake, 0, scale_x, scale_y)
+      draw(themes[config.theme].images.IMG_cursor[1], (self.cur_col - 1) * 16, (11 - (self.cur_row)) * 16 + self.displacement - shake, 0, scale_x, scale_y, true)
     end
   else
-    draw(cursorImage, (self.cur_col - 1) * 16, (11 - (self.cur_row)) * 16 + self.displacement - shake, 0, scale_x, scale_y)
+    draw(cursorImage, (self.cur_col - 1) * 16, (11 - (self.cur_row)) * 16 + self.displacement - shake, 0, scale_x, scale_y, true)
   end
 end
 
@@ -981,17 +981,17 @@ function Stack.render_countdown(self)
     local countdown_y = 68
     if self.countdown_CLOCK <= 8 then
       local ready_y = initial_ready_y + (self.CLOCK - 1) * ready_y_drop_speed
-      draw(themes[config.theme].images.IMG_ready, ready_x, ready_y)
+      draw(themes[config.theme].images.IMG_ready, ready_x, ready_y, true)
       if self.countdown_CLOCK == 8 then
         self.ready_y = ready_y
       end
     elseif self.countdown_CLOCK >= 9 and self.countdown_timer and self.countdown_timer > 0 then
       if self.countdown_timer >= 100 then
-        draw(themes[config.theme].images.IMG_ready, ready_x, self.ready_y or initial_ready_y + 8 * 6)
+        draw(themes[config.theme].images.IMG_ready, ready_x, self.ready_y or initial_ready_y + 8 * 6, true)
       end
       local IMG_number_to_draw = themes[config.theme].images.IMG_numbers[math.ceil(self.countdown_timer / 60)]
       if IMG_number_to_draw then
-        draw(IMG_number_to_draw, countdown_x, countdown_y)
+        draw(IMG_number_to_draw, countdown_x, countdown_y, true)
       end
     end
   end

--- a/libraries/BarGraph.lua
+++ b/libraries/BarGraph.lua
@@ -45,7 +45,7 @@ end
 
 function BarGraph.drawGraphs(graphs)
   local oldFont = love.graphics.getFont()
-  gfx_q:push({love.graphics.setFont, {BarGraph.font}})
+  love.graphics.setFont(BarGraph.font)
 
   -- loop through all of the graphs
   for j = 1, #graphs do
@@ -60,24 +60,24 @@ function BarGraph.drawGraphs(graphs)
         local height = graph.height * (value / maxVal)
         local fillColor = graph.fillColors[index] or {1, 1, 1, 0.8}
         local strokeColor = graph.strokeColors[index] or {0, 0, 0, 0.4}
-        gfx_q:push({love.graphics.setColor, fillColor})
-        gfx_q:push({love.graphics.rectangle, {"fill", xPosition, yPosition - height, graph.barWidth, height}})
-        gfx_q:push({love.graphics.setColor, strokeColor})
-        gfx_q:push({love.graphics.rectangle, {"line", xPosition + 0.5, yPosition - height + 0.5, graph.barWidth - 1, height - 1}})
+        love.graphics.setColor(fillColor)
+        love.graphics.rectangle("fill", xPosition, yPosition - height, graph.barWidth, height)
+        love.graphics.setColor(strokeColor)
+        love.graphics.rectangle("line", xPosition + 0.5, yPosition - height + 0.5, graph.barWidth - 1, height - 1)
         yPosition = yPosition - height
       end
       xPosition = xPosition + graph.barWidth
     end
 
-    gfx_q:push({love.graphics.setColor, {1, 1, 1, 0.8}})
-    gfx_q:push({love.graphics.rectangle, {"line", graph.x + 0.5, graph.y + 0.5, graph.width - 1, graph.height - 1}})
+    love.graphics.setColor(1, 1, 1, 0.8)
+    love.graphics.rectangle("line", graph.x + 0.5, graph.y + 0.5, graph.width - 1, graph.height - 1)
 
-    gfx_q:push({love.graphics.setColor, {1, 1, 1, 1}})
+    love.graphics.setColor(1, 1, 1, 1)
 
-    gfx_q:push({love.graphics.print, {graph.label, graph.x, graph.height + graph.y + 8}})
+    love.graphics.print(graph.label, graph.x, graph.height + graph.y + 8)
   end
 
-  gfx_q:push({love.graphics.setFont, {oldFont}})
+  love.graphics.setFont(oldFont)
 end
 
 return BarGraph

--- a/libraries/batteries/manual_gc.lua
+++ b/libraries/batteries/manual_gc.lua
@@ -49,8 +49,11 @@ freely, subject to the following restrictions:
 
 return function(time_budget, memory_ceiling, disable_otherwise)
 	time_budget = time_budget or 1e-3
-	memory_ceiling = memory_ceiling or 64
-    local max_steps = 10000
+  -- 64 MB memory is too low for long replays, they are guaranteed to hit the limit
+  -- On weaker machines, it may pile up so quickly that even 128 may be breached (accumulating several MBs per second)
+  -- so putting 256 MB for now
+	memory_ceiling = memory_ceiling or 256
+  local max_steps = 10000
 	local steps = 0
 	local start_time = love.timer.getTime()
 	while

--- a/main.lua
+++ b/main.lua
@@ -176,6 +176,7 @@ function love.draw()
     gprintf("STONER", 1, 1 + (11 * 4))
   end
 
+  print("graphics queue contains " .. gfx_q:len() .. " draw instructions")
   for i = gfx_q.first, gfx_q.last do
     gfx_q[i][1](unpack(gfx_q[i][2]))
   end

--- a/main.lua
+++ b/main.lua
@@ -2,7 +2,6 @@ require("class")
 socket = require("socket")
 GAME = require("game")
 require("match")
-local manualGC = require("libraries.batteries.manual_gc")
 local RunTimeGraph = require("RunTimeGraph")
 require("BattleRoom")
 require("util")
@@ -152,8 +151,6 @@ function love.update(dt)
 
   update_music()
   GAME.rich_presence:runCallbacks()
-  
-  manualGC(0.0001, nil, nil)
 end
 
 -- Called whenever the game needs to draw.
@@ -170,9 +167,7 @@ function love.draw()
 
   -- Draw the FPS if enabled
   if config ~= nil and config.show_fps then
-    if CustomRun.runTimeGraph then
-      CustomRun.runTimeGraph:draw()
-    else
+    if not CustomRun.runTimeGraph then
       gprintf("FPS: " .. love.timer.getFPS(), 1, 1)
     end
   end

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -464,7 +464,7 @@ local function runMainGameLoop(updateFunction, variableStepFunction, abortGameFu
 
     -- Render only if we are not catching up to a current spectate match
     if not (P1 and P1.play_to_end) and not (P2 and P2.play_to_end) then
-      GAME.match:render()
+      gfx_q:push({Match.render, {GAME.match}})
       wait()
     end
 
@@ -2003,7 +2003,7 @@ function game_over_transition(next_func, text, winnerSFX, timemax, keepMusic, ar
   end
 
   while true do
-    GAME.match:render()
+    gfx_q:push({Match.render, {GAME.match}})
     gprint(text, (canvas_width - font:getWidth(text)) / 2, 10)
     gprint(button_text, (canvas_width - font:getWidth(button_text)) / 2, 10 + 30)
     wait()

--- a/match.lua
+++ b/match.lua
@@ -283,7 +283,7 @@ function Match.render(self)
   local P2 = self.P2
   
   if GAME.droppedFrames > 10 and config.show_fps then
-    gprint("Dropped Frames: " .. GAME.droppedFrames, 1, 12)
+    gprint("Dropped Frames: " .. GAME.droppedFrames, 1, 12, nil, nil, true)
   end
 
   if config.show_fps and P1 and P2 then
@@ -293,10 +293,10 @@ function Match.render(self)
     local behind = math.abs(P1.CLOCK - P2.CLOCK)
 
     if P1Behind > 0 then
-      gprint("P1 Average Latency: " .. P1Behind, 1, 23)
+      gprint("P1 Average Latency: " .. P1Behind, 1, 23, nil, nil, true)
     end
     if P2Behind > 0 then
-      gprint("P2 Average Latency: " .. P2Behind, 1, 34)
+      gprint("P2 Average Latency: " .. P2Behind, 1, 34, nil, nil, true)
     end
     
     if GAME.battleRoom.spectating and behind > MAX_LAG * 0.75 then
@@ -304,7 +304,7 @@ function Match.render(self)
       local icon_width, icon_height = themes[config.theme].images.IMG_bug:getDimensions()
       local x = (canvas_width / 2) - (iconSize / 2)
       local y = (canvas_height / 2) - (iconSize / 2)
-      draw(themes[config.theme].images.IMG_bug, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height)
+      draw(themes[config.theme].images.IMG_bug, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height, true)
     end
   end
   
@@ -314,20 +314,20 @@ function Match.render(self)
   -- Draw VS HUD
   if self.battleRoom and (GAME.gameIsPaused == false or GAME.renderDuringPause) then
     -- P1 username
-    gprint((GAME.battleRoom.playerNames[1] or ""), P1.score_x + themes[config.theme].name_Pos[1], P1.score_y + themes[config.theme].name_Pos[2])
+    gprint((GAME.battleRoom.playerNames[1] or ""), P1.score_x + themes[config.theme].name_Pos[1], P1.score_y + themes[config.theme].name_Pos[2], nil, nil, true)
     if P2 then
       -- P1 win count graphics
-      draw_label(themes[config.theme].images.IMG_wins, (P1.score_x + themes[config.theme].winLabel_Pos[1]) / GFX_SCALE, (P1.score_y + themes[config.theme].winLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].winLabel_Scale)
-      GraphicsUtil.draw_number(GAME.battleRoom:getPlayerWinCount(P1.player_number), themes[config.theme].images.IMG_number_atlas_1P, P1_win_quads, P1.score_x + themes[config.theme].win_Pos[1], P1.score_y + themes[config.theme].win_Pos[2], themes[config.theme].win_Scale, "center")
+      draw_label(themes[config.theme].images.IMG_wins, (P1.score_x + themes[config.theme].winLabel_Pos[1]) / GFX_SCALE, (P1.score_y + themes[config.theme].winLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].winLabel_Scale, nil, true)
+      GraphicsUtil.draw_number(GAME.battleRoom:getPlayerWinCount(P1.player_number), themes[config.theme].images.IMG_number_atlas_1P, P1_win_quads, P1.score_x + themes[config.theme].win_Pos[1], P1.score_y + themes[config.theme].win_Pos[2], themes[config.theme].win_Scale, "center", true)
       -- P2 username
-      gprint((GAME.battleRoom.playerNames[2] or ""), P2.score_x + themes[config.theme].name_Pos[1], P2.score_y + themes[config.theme].name_Pos[2])
+      gprint((GAME.battleRoom.playerNames[2] or ""), P2.score_x + themes[config.theme].name_Pos[1], P2.score_y + themes[config.theme].name_Pos[2], nil, nil, true)
       -- P2 win count graphics
-      draw_label(themes[config.theme].images.IMG_wins, (P2.score_x + themes[config.theme].winLabel_Pos[1]) / GFX_SCALE, (P2.score_y + themes[config.theme].winLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].winLabel_Scale)
-      GraphicsUtil.draw_number(GAME.battleRoom:getPlayerWinCount(P2.player_number), themes[config.theme].images.IMG_number_atlas_2P, P2_win_quads, P2.score_x + themes[config.theme].win_Pos[1], P2.score_y + themes[config.theme].win_Pos[2], themes[config.theme].win_Scale, "center")
+      draw_label(themes[config.theme].images.IMG_wins, (P2.score_x + themes[config.theme].winLabel_Pos[1]) / GFX_SCALE, (P2.score_y + themes[config.theme].winLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].winLabel_Scale, nil, true)
+      GraphicsUtil.draw_number(GAME.battleRoom:getPlayerWinCount(P2.player_number), themes[config.theme].images.IMG_number_atlas_2P, P2_win_quads, P2.score_x + themes[config.theme].win_Pos[1], P2.score_y + themes[config.theme].win_Pos[2], themes[config.theme].win_Scale, "center", true)
     end
 
     if not config.debug_mode then --this is printed in the same space as the debug details
-      gprint(spectators_string, themes[config.theme].spectators_Pos[1], themes[config.theme].spectators_Pos[2])
+      gprint(spectators_string, themes[config.theme].spectators_Pos[1], themes[config.theme].spectators_Pos[2], nil, nil, true)
     end
 
     if match_type == "Ranked" then
@@ -337,9 +337,9 @@ function Match.render(self)
           rating_to_print = self.room_ratings[self.my_player_number].new
         end
         --gprint(rating_to_print, P1.score_x, P1.score_y-30)
-        draw_label(themes[config.theme].images.IMG_rating_1P, (P1.score_x + themes[config.theme].ratingLabel_Pos[1]) / GFX_SCALE, (P1.score_y + themes[config.theme].ratingLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].ratingLabel_Scale)
+        draw_label(themes[config.theme].images.IMG_rating_1P, (P1.score_x + themes[config.theme].ratingLabel_Pos[1]) / GFX_SCALE, (P1.score_y + themes[config.theme].ratingLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].ratingLabel_Scale, nil, true)
         if type(rating_to_print) == "number" then
-          GraphicsUtil.draw_number(rating_to_print, themes[config.theme].images.IMG_number_atlas_1P, P1_rating_quads, P1.score_x + themes[config.theme].rating_Pos[1], P1.score_y + themes[config.theme].rating_Pos[2], themes[config.theme].rating_Scale, "center")
+          GraphicsUtil.draw_number(rating_to_print, themes[config.theme].images.IMG_number_atlas_1P, P1_rating_quads, P1.score_x + themes[config.theme].rating_Pos[1], P1.score_y + themes[config.theme].rating_Pos[2], themes[config.theme].rating_Scale, "center", true)
         end
       end
       if self.room_ratings and self.room_ratings[self.op_player_number] and self.room_ratings[self.op_player_number].new then
@@ -348,9 +348,9 @@ function Match.render(self)
           op_rating_to_print = self.room_ratings[self.op_player_number].new
         end
         --gprint(op_rating_to_print, P2.score_x, P2.score_y-30)
-        draw_label(themes[config.theme].images.IMG_rating_2P, (P2.score_x + themes[config.theme].ratingLabel_Pos[1]) / GFX_SCALE, (P2.score_y + themes[config.theme].ratingLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].ratingLabel_Scale)
+        draw_label(themes[config.theme].images.IMG_rating_2P, (P2.score_x + themes[config.theme].ratingLabel_Pos[1]) / GFX_SCALE, (P2.score_y + themes[config.theme].ratingLabel_Pos[2]) / GFX_SCALE, 0, themes[config.theme].ratingLabel_Scale, nil, true)
         if type(op_rating_to_print) == "number" then
-          GraphicsUtil.draw_number(op_rating_to_print, themes[config.theme].images.IMG_number_atlas_2P, P2_rating_quads, P2.score_x + themes[config.theme].rating_Pos[1], P2.score_y + themes[config.theme].rating_Pos[2], themes[config.theme].rating_Scale, "center")
+          GraphicsUtil.draw_number(op_rating_to_print, themes[config.theme].images.IMG_number_atlas_2P, P2_rating_quads, P2.score_x + themes[config.theme].rating_Pos[1], P2.score_y + themes[config.theme].rating_Pos[2], themes[config.theme].rating_Scale, "center", true)
         end
       end
     end
@@ -362,19 +362,19 @@ function Match.render(self)
     local drawY = 10
     local padding = 14
 
-    grectangle_color("fill", (drawX - 5) / GFX_SCALE, (drawY - 5) / GFX_SCALE, 1000/GFX_SCALE, 100/GFX_SCALE, 0, 0, 0, 0.5)
+    grectangle_color("fill", (drawX - 5) / GFX_SCALE, (drawY - 5) / GFX_SCALE, 1000/GFX_SCALE, 100/GFX_SCALE, 0, 0, 0, 0.5, true)
     
-    gprintf("Clock " .. P1.CLOCK, drawX, drawY)
+    gprintf("Clock " .. P1.CLOCK, drawX, drawY, nil, nil, nil, nil, nil, true)
 
 
     drawY = drawY + padding
-    gprintf("Confirmed " .. #P1.confirmedInput , drawX, drawY)
+    gprintf("Confirmed " .. #P1.confirmedInput , drawX, drawY, nil, nil, nil, nil, nil, true)
 
     drawY = drawY + padding
-    gprintf("input_buffer " .. #P1.input_buffer , drawX, drawY)
+    gprintf("input_buffer " .. #P1.input_buffer , drawX, drawY, nil, nil, nil, nil, nil, true)
 
     drawY = drawY + padding
-    gprintf("rollbackCount " .. P1.rollbackCount , drawX, drawY)
+    gprintf("rollbackCount " .. P1.rollbackCount , drawX, drawY, nil, nil, nil, nil, nil, true)
 
     -- drawY = drawY + padding
     -- gprintf("P1 Panels: " .. P1.panel_buffer, drawX, drawY)
@@ -393,11 +393,11 @@ function Match.render(self)
 
     if P1.game_over_clock > 0 then
       drawY = drawY + padding
-      gprintf("game_over_clock " .. P1.game_over_clock, drawX, drawY)
+      gprintf("game_over_clock " .. P1.game_over_clock, drawX, drawY, nil, nil, nil, nil, nil, true)
     end
 
     drawY = drawY + padding
-    gprintf("chain panels " .. P1.n_chain_panels, drawX, drawY)
+    gprintf("chain panels " .. P1.n_chain_panels, drawX, drawY, nil, nil, nil, nil, nil, true)
 
     -- if P1.telegraph then
     --   drawY = drawY + padding
@@ -423,20 +423,20 @@ function Match.render(self)
     drawY = drawY + padding
     local totalTime = love.timer.getTime() - self.createTime
     local timePercent = round(self.timeSpentRunning / totalTime, 5)
-    gprintf("Time Percent Running Match: " .. timePercent, drawX, drawY)
+    gprintf("Time Percent Running Match: " .. timePercent, drawX, drawY, nil, nil, nil, nil, nil, true)
 
     drawY = drawY + padding
     local maxTime = round(self.maxTimeSpentRunning, 5)
-    gprintf("Max Stack Update: " .. maxTime, drawX, drawY)
+    gprintf("Max Stack Update: " .. maxTime, drawX, drawY, nil, nil, nil, nil, nil, true)
 
     drawY = drawY + padding
-    gprintf("Seed " .. GAME.match.seed, drawX, drawY)
+    gprintf("Seed " .. GAME.match.seed, drawX, drawY, nil, nil, nil, nil, nil, true)
 
     local gameEndedClockTime = self:gameEndedClockTime()
 
     if gameEndedClockTime > 0 then
       drawY = drawY + padding
-      gprintf("gameEndedClockTime " .. gameEndedClockTime, drawX, drawY)
+      gprintf("gameEndedClockTime " .. gameEndedClockTime, drawX, drawY, nil, nil, nil, nil, nil, true)
     end
 
     -- drawY = drawY + padding
@@ -452,24 +452,24 @@ function Match.render(self)
       drawY = 10 - padding
 
       drawY = drawY + padding
-      gprintf("Clock " .. P2.CLOCK, drawX, drawY)
+      gprintf("Clock " .. P2.CLOCK, drawX, drawY, nil, nil, nil, nil, nil, true)
 
       drawY = drawY + padding
       local framesAhead = P1.CLOCK - P2.CLOCK
-      gprintf("P1 Ahead: " .. framesAhead, drawX, drawY)
+      gprintf("P1 Ahead: " .. framesAhead, drawX, drawY, nil, nil, nil, nil, nil, true)
 
       drawY = drawY + padding
-      gprintf("Confirmed " .. #P2.confirmedInput , drawX, drawY)
+      gprintf("Confirmed " .. #P2.confirmedInput , drawX, drawY, nil, nil, nil, nil, nil, true)
 
       drawY = drawY + padding
-      gprintf("input_buffer " .. #P2.input_buffer , drawX, drawY)
+      gprintf("input_buffer " .. #P2.input_buffer , drawX, drawY, nil, nil, nil, nil, nil, true)
 
       drawY = drawY + padding
-      gprintf("rollbackCount " .. P2.rollbackCount , drawX, drawY)
+      gprintf("rollbackCount " .. P2.rollbackCount , drawX, drawY, nil, nil, nil, nil, nil, true)
 
       if P2.game_over_clock > 0 then
         drawY = drawY + padding
-        gprintf("game_over_clock " .. P2.game_over_clock, drawX, drawY)
+        gprintf("game_over_clock " .. P2.game_over_clock, drawX, drawY, nil, nil, nil, nil, nil, true)
       end
 
       -- if P2.telegraph then
@@ -523,7 +523,7 @@ function Match.render(self)
     local icon_width, icon_height = themes[config.theme].images.IMG_bug:getDimensions()
     local x = 5
     local y = 5
-    draw(themes[config.theme].images.IMG_bug, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height)
-    gprint("A warning has occurred, please post your warnings.txt file and this replay to #panel-attack-bugs in the discord.", x + iconSize, y)
+    draw(themes[config.theme].images.IMG_bug, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height, true)
+    gprint("A warning has occurred, please post your warnings.txt file and this replay to #panel-attack-bugs in the discord.", x + iconSize, y, nil, nil, true)
   end
 end


### PR DESCRIPTION
Based on an idea from tonight.
Match render creates about 600 tables on every frame of Match.render (in 2p) with the sole purpose of pushing them into the gfx Q so that it can unpack and render these things.
RunTimeGraph.draw() creates about 3600 tables on every `innerRun`.
The creation of this huge amount of tables hogs a lot of memory and most importantly puts a lot of pressure on the garbage collector.

So why not just pass Match.render directly into the graphics queue and draw everything inside directly?
That's what this does. It's more of a proof of concept (and built on #833) for now but I'll draft PR it to play around with.
In 2p vs, the gfx Q only has 3 tables left, of which one is the Match.render call itself!

With this build I can play Time Attack while automatic GC is off and manual GC is restricted to 0.2ms per frame and PA's memory will keep itself leveled around 10-20MB.
On #833 itself it accumulates around 11-12MB of memory per second and reaches the 256MB memory ceiling every 20-22 seconds, causing a cleanup spike.

Apparently there is some problem with drawing panels on this build as they'll often be drawn in their landing state despite being perfectly still. Not sure why yet.