### PR TITLE
Change debug hotkey to smash d

### DIFF
--- a/input.lua
+++ b/input.lua
@@ -295,7 +295,7 @@ function love.keypressed(key, scancode, rep)
   end
 
   local function toggleDebugMode()
-    if key == "f10" and (love.keyboard.isDown("rctrl") or love.keyboard.isDown("lctrl")) and (love.keyboard.isDown("lalt") or love.keyboard.isDown("ralt")) then
+    if key == "d" and (love.keyboard.isDown("rctrl") or love.keyboard.isDown("lctrl")) and (love.keyboard.isDown("lalt") or love.keyboard.isDown("ralt")) and (love.keyboard.isDown("lshift") or love.keyboard.isDown("rshift")) then
       config.debug_mode = not config.debug_mode
     end
   end


### PR DESCRIPTION
It came to my attention that Ctrl+Shift+F10 yeets Linux desktops into console mode so it is not suitable as a debug toggle.