### PR TITLE
Select screen duplicate character hotfix

### DIFF
--- a/character_loader.lua
+++ b/character_loader.lua
@@ -139,6 +139,10 @@ end
 
 -- Initializes the characters globals with data
 function characters_init()
+  characters = {} -- holds all characters, most of them will not be fully loaded
+  characters_ids = {} -- holds all characters ids
+  characters_ids_for_current_theme = {} -- holds characters ids for the current theme, those characters will appear in the lobby
+  characters_ids_by_display_names = {} -- holds keys to array of character ids holding that name
   add_characters_from_dir_rec("characters")
   fill_characters_ids()
 


### PR DESCRIPTION
Resets all the IDs on init

Hotfixes #843 