### PR TITLE
Prevent nil crash on trying to stop combo_echo sfx

### DIFF
--- a/character.lua
+++ b/character.lua
@@ -382,11 +382,11 @@ function Character.reassignLegacySfx(self)
     end
     
     self:fillInMissingSounds(self.sounds.chain, "chain", maxIndex)
+  end
 
-    if #self.sounds.shock > 0 then
-      -- combo_echo won't get used if shock is present, so it shouldn't show up in sound test any longer
-      self.sounds.combo_echo = nil
-    end
+  if #self.sounds.shock > 0 then
+    -- combo_echo won't get used if shock is present, so it shouldn't show up in sound test any longer
+    self.sounds.combo_echo = nil
   end
 end
 

--- a/character.lua
+++ b/character.lua
@@ -594,14 +594,18 @@ function Character.playAttackSfx(self, attack)
         stopIfPlaying(v[i])
       end
     end
-    for i = 1, #self.sounds.combo_echo do
-      stopIfPlaying(self.sounds.combo_echo[i])
-    end
-    for _, v in pairs(self.sounds.shock) do
-      for i = 1, #v do
-        stopIfPlaying(v[i])
+    if table.length(self.sounds.shock) > 0 then
+      for _, v in pairs(self.sounds.shock) do
+        for i = 1, #v do
+          stopIfPlaying(v[i])
+        end
+      end
+    else
+      for i = 1, #self.sounds.combo_echo do
+        stopIfPlaying(self.sounds.combo_echo[i])
       end
     end
+
     for _, v in pairs(self.sounds.chain) do
       for i = 1, #v do
         stopIfPlaying(v[i])

--- a/character.lua
+++ b/character.lua
@@ -386,7 +386,7 @@ function Character.reassignLegacySfx(self)
 
   if #self.sounds.shock > 0 then
     -- combo_echo won't get used if shock is present, so it shouldn't show up in sound test any longer
-    self.sounds.combo_echo = nil
+    self.sounds.combo_echo = {}
   end
 end
 


### PR DESCRIPTION
While playing with a classic chain style character who had shock sfx, chaining would crash the game trying to stop combo_echo sfx because the combo_echo table got nilled while remapping the chain sounds to the internal array.

To make this more predictable, combo_echo now no longer gets nilled but set to an empty table instead as the general expectation for all sub tables in `sounds` is that there is at least a table so we never have to nil check.
Additionally I moved that part out of the control flow that only ran for classic chain style and this now always happens to make sure combo_echo is excluded from sound test correctly even with modern chain style.
Finally, the `stopPreviousSounds` now only stops either shock or combo_echo sounds, not unconditionally both of them.