### PR TITLE
Reduce amount of unnecessary active garbage collection

### DIFF
--- a/RunTimeGraph.lua
+++ b/RunTimeGraph.lua
@@ -27,12 +27,12 @@ local RunTimeGraph = class(function(self)
 
   -- run loop graph
   self.graphs[#self.graphs + 1] = BarGraph(x, y, width, height, updateSpeed, consts.FRAME_RATE * 1, valueCount)
-  self.graphs[#self.graphs]:setFillColor({0, 1, 0, 1}, 1) -- love.update
-  self.graphs[#self.graphs]:setFillColor({1, 0.3, 0.3, 1}, 3) -- love.draw
-  self.graphs[#self.graphs]:setFillColor({0.5, 0.5, 0.5, 1}, 2) -- self:draw + self:updateWithMetrics
+  self.graphs[#self.graphs]:setFillColor({0, 0, 1, 1}, 1) -- love.update
+  self.graphs[#self.graphs]:setFillColor({1, 0.3, 0.3, 1}, 2) -- love.draw
+  self.graphs[#self.graphs]:setFillColor({0.5, 0.5, 0.5, 1}, 3) -- self:draw + self:updateWithMetrics
   self.graphs[#self.graphs]:setFillColor({1, 1, 1, 1}, 4) -- love.present
   self.graphs[#self.graphs]:setFillColor({0.2, 0.2, 1, 1}, 5) -- manualGc
-  self.graphs[#self.graphs]:setFillColor({0, 0, 1, 1}, 6) -- love.timer.sleep
+  self.graphs[#self.graphs]:setFillColor({0, 1, 0, 1}, 6) -- love.timer.sleep
 
   y = y + height + padding
 end)

--- a/libraries/batteries/manual_gc.lua
+++ b/libraries/batteries/manual_gc.lua
@@ -36,10 +36,14 @@ freely, subject to the following restrictions:
   time_budget - 1ms (1e-3)
     adjust down or up as needed. games that generate more garbage
     will need to spend longer on gc each frame.
+      during PA matches, CustomRun will pass in the remaining idle time each frame
+      clients will use the full remaining time until the step limit
   memory_ceiling - 64mb
     a good place to start, though some games will need much more.
     remember, this is lua memory, not the total memory consumption
     of your game.
+      for PA upped to 256 MB, 2 stacks with full rollback on long game durations takes up 100MB 
+      on slower machines this may pile up and break through even 128MB too easily
   disable_otherwise - false
     disabling the gc completely is dangerous - any big allocation
     event (eg - level gen) could push you to an out of memory
@@ -53,7 +57,10 @@ return function(time_budget, memory_ceiling, disable_otherwise)
   -- On weaker machines, it may pile up so quickly that even 128 may be breached (accumulating several MBs per second)
   -- so putting 256 MB for now
 	memory_ceiling = memory_ceiling or 256
-  local max_steps = 10000
+  -- original step limit was 10000
+  -- after some testing it turns out that machines in need of more garbage collection won't reach that many steps
+  -- while strong machines will just consume a lot more CPU; 5000 should be enough to guarantee performance
+  local max_steps = 5000
 	local steps = 0
 	local start_time = love.timer.getTime()
 	while


### PR DESCRIPTION
Basically this puts a condition before actively collecting garbage as part of our customRun to avoid high CPU usage even while the game is technically not doing anything (idle in menus/lobby).
Also saving a bit of battery on laptops while playing compared to before by setting a lower boundary of 20MB of lua memory before starting to collect. On my machine, while spectating in no-rollback latency scenarios, memory bounces between 4 and 11 MB so that should help most people on good connections with saving battery/energy.
I also reduced the step limit in `manualGc` as 10000 felt way overkill in a scenario where automatic GC is still doing work, causing higher CPU loads than necessary on strong machines.
Finally I added some more comments in various places.

Additionally I fixed a bug due to which graph data between graph draw and love draw was reversed.
I also swapped the colors between update and sleep because I cannot for my life tell apart sleep and GC while they're next to each other due to the contrast being way too low.