### PR TITLE
Fix telegraph rollback copy

### DIFF
--- a/AttackEngine.lua
+++ b/AttackEngine.lua
@@ -8,7 +8,7 @@ AttackPattern =
     self.height = height
     self.startTime = startTime
     self.endsChain = endsChain
-    self.garbage = {width, height, metal or false, chain}
+    self.garbage = {width = width, height = height, isMetal = metal or false, isChain = chain}
   end
 )
 

--- a/engine.lua
+++ b/engine.lua
@@ -2646,7 +2646,7 @@ function Stack.check_matches(self)
       if metal_count >= 3 then
         -- Give a shock garbage for every shock block after 2
         for i = 3, metal_count do
-          self.telegraph:push({6, 1, true, false}, first_panel_col, first_panel_row, self.CLOCK)
+          self.telegraph:push({width = 6, height = 1, isMetal = true, isChain = false}, first_panel_col, first_panel_row, self.CLOCK)
           self:recordComboHistory(self.CLOCK, 6, 1, true)
         end
       end
@@ -2672,13 +2672,10 @@ function Stack.check_matches(self)
         for i=1,#combo_pieces do
           -- Give out combo garbage based on the lookup table, even if we already made shock garbage,
           -- OP! Too bad its hard to get shock panels in vs. :)
-          self.telegraph:push({combo_pieces[i], 1, false, false}, first_panel_col, first_panel_row, self.CLOCK)
+          self.telegraph:push({width = combo_pieces[i], height = 1, isMetal = false, isChain = false}, first_panel_col, first_panel_row, self.CLOCK)
           self:recordComboHistory(self.CLOCK, combo_pieces[i], 1, false)
         end
       end
-      --EnqueueConfetti(first_panel_col<<4+P1StackPosX+4,
-      --          first_panel_row<<4+P1StackPosY+self.displacement-9);
-      --TODO: this stuff ^
       first_panel_row = first_panel_row + 1 -- offset chain cards
     end
     if (is_chain) then
@@ -2693,7 +2690,7 @@ function Stack.check_matches(self)
     --EnqueueConfetti(first_panel_col<<4+P1StackPosX+4,
     --          first_panel_row<<4+P1StackPosY+self.displacement-9);
       if self.garbage_target and self.telegraph then
-        self.telegraph:push({6, self.chain_counter - 1, false, true}, first_panel_col, first_panel_row, self.CLOCK)
+        self.telegraph:push({width = 6, height = self.chain_counter - 1, isMetal = false, isChain = true}, first_panel_col, first_panel_row, self.CLOCK)
       end
     end
     local chain_bonus = self.chain_counter

--- a/engine/telegraph.lua
+++ b/engine/telegraph.lua
@@ -94,7 +94,7 @@ function Telegraph.rollbackCopy(source, other)
 
   other.garbage_queue = source.garbage_queue:makeCopy()
   other.stoppers = deepcpy(source.stoppers)
-  other.attacks = deepcpy(source.attacks)
+  --other.attacks = deepcpy(source.attacks)
   other.sender = source.sender
   other.pos_x = source.pos_x
   other.pos_y = source.pos_y
@@ -107,54 +107,45 @@ function Telegraph.rollbackCopy(source, other)
 end
 
 -- Adds a piece of garbage to the queue
-function Telegraph:push(garbage, attack_origin_col, attack_origin_row, frame_earned)
-
+function Telegraph:push(garbage, attackOriginCol, attackOriginRow, frameEarned)
   assert(self.sender ~= nil and self.owner ~= nil, "telegraph needs owner and sender set")
+  assert(frameEarned == self.sender.CLOCK, "expected sender clock to equal attack")
 
-  local timeAttackInteracts = frame_earned + 1
-  --logger.debug("Player " .. self.sender.which .. " attacked with " .. attack_type .. " at " .. frame_earned)
-
-  assert(frame_earned == self.sender.CLOCK, "expected sender clock to equal attack")
-
-  self:privatePush(garbage, attack_origin_col, attack_origin_row, timeAttackInteracts)
+  self:privatePush(garbage, attackOriginCol, attackOriginRow, frameEarned + 1)
 end
 
 -- Adds a piece of garbage to the queue
-function Telegraph.privatePush(self, garbage, attack_origin_col, attack_origin_row, timeAttackInteracts)
-  local stuff_to_send
-  if garbage[4] then
-    stuff_to_send = self:grow_chain(timeAttackInteracts)
+function Telegraph.privatePush(self, garbage, attackOriginColumn, attackOriginRow, timeAttackInteracts)
+  local garbageToSend
+  if garbage.isChain then
+    garbageToSend = self:grow_chain(timeAttackInteracts)
   else
     -- get combo_garbage_widths, n_resulting_metal_garbage
-    stuff_to_send = self:add_combo_garbage(garbage, timeAttackInteracts)
-    stuff_to_send = deepcpy(stuff_to_send) -- we don't want to use the same object as in the garbage queue so they don't change each other
+    garbageToSend = self:add_combo_garbage(garbage, timeAttackInteracts)
+    garbageToSend = deepcpy(garbageToSend) -- we don't want to use the same object as in the garbage queue so they don't change each other
   end
   if not self.attacks[timeAttackInteracts] then
     self.attacks[timeAttackInteracts] = {}
   end
   self.attacks[timeAttackInteracts][#self.attacks[timeAttackInteracts]+1] =
-    {timeAttackInteracts=timeAttackInteracts, origin_col=attack_origin_col, origin_row= attack_origin_row, stuff_to_send=stuff_to_send}
+    {timeAttackInteracts=timeAttackInteracts, origin_col=attackOriginColumn, origin_row= attackOriginRow, stuff_to_send=garbageToSend}
 end
 
 function Telegraph.add_combo_garbage(self, garbage, timeAttackInteracts)
-  logger.debug("Telegraph.add_combo_garbage "..(garbage[1] or "nil").." "..(garbage[3] and "true" or "false"))
+  logger.debug("Telegraph.add_combo_garbage "..(garbage.width or "nil").." "..(garbage.isMetal and "true" or "false"))
   local stuff_to_send = {}
-  if garbage[3] and (GAME.battleRoom.trainingModeSettings == nil or not GAME.battleRoom.trainingModeSettings.mergeComboMetalQueue) then
+  if garbage.isMetal and (GAME.battleRoom.trainingModeSettings == nil or not GAME.battleRoom.trainingModeSettings.mergeComboMetalQueue) then
     stuff_to_send[#stuff_to_send+1] = {6, 1, true, false, timeAttackInteracts = timeAttackInteracts}
     self.stoppers.metal = timeAttackInteracts + GARBAGE_TRANSIT_TIME + GARBAGE_TELEGRAPH_TIME
   else
-    stuff_to_send[#stuff_to_send+1] = {garbage[1], garbage[2], garbage[3], garbage[4], timeAttackInteracts = timeAttackInteracts}
-    self.stoppers.combo[garbage[1]] = timeAttackInteracts + GARBAGE_TRANSIT_TIME + GARBAGE_TELEGRAPH_TIME
+    stuff_to_send[#stuff_to_send+1] = {garbage.width, garbage.height, garbage.isMetal, garbage.isChain, timeAttackInteracts = timeAttackInteracts}
+    self.stoppers.combo[garbage.width] = timeAttackInteracts + GARBAGE_TRANSIT_TIME + GARBAGE_TELEGRAPH_TIME
   end
   self.garbage_queue:push(stuff_to_send)
   return stuff_to_send
-  
 end
 
 function Telegraph:chainingEnded(frameEnded)
-
-  local timeAttackInteracts = frameEnded + 1
-
   logger.debug("Player " .. self.sender.which .. " chain ended at " .. frameEnded)
 
   if not GAME.battleRoom.trainingModeSettings then

--- a/engine/telegraph.lua
+++ b/engine/telegraph.lua
@@ -92,10 +92,8 @@ function Telegraph.rollbackCopy(source, other)
     end
   end
 
-  if config.renderTelegraph then
-    other.garbage_queue = source.garbage_queue:makeCopy()
-    other.stoppers = deepcpy(source.stoppers)
-  end
+  other.garbage_queue = source.garbage_queue:makeCopy()
+  other.stoppers = deepcpy(source.stoppers)
   if config.renderAttacks then
     other.attacks = deepcpy(source.attacks)
   end


### PR DESCRIPTION
`Telegraph.attacks` would get populated but never cleared if attacks were disabled in graphics option, leading to a gigantic nested table of growing proportions getting deepcopied on every single frame while watching replays or playing on a rollback connection.

The configuration option now gets checked for both populating and rollbackCopying as well.

I would love to do the same for the garbage queue copy but apparently that one is engine relevant (which imo it should *not* be) so postponing that for later as `Telegraph.attacks` is the prime reason for framedrops on my end.