### PR TITLE
Improve check_matches performance

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -2721,20 +2721,17 @@ function Stack.check_matches(self)
           -- we might have to remove its chain flag...!
           -- It can't actually chain the first frame it hovers,
           -- so it can keep its chaining flag in that case.
-          if not (panel.match_anyway or panel:exclude_match()) then
+          if panel.chaining and not (panel.match_anyway or panel:exclude_match()) then
             if row ~= 1 then
               -- a panel landed on the bottom row, so it surely
               -- loses its chain flag.
               -- no swapping panel below
               -- so this panel loses its chain flag
-              if panels[row - 1][col].state ~= "swapping" and panel.chaining then
-                --if panel.chaining then
+              if panels[row - 1][col].state ~= "swapping" then
                 panel.chaining = nil
-                self.n_chain_panels = self.n_chain_panels - 1
               end
-            elseif (panel.chaining) then
+            else
               panel.chaining = nil
-              self.n_chain_panels = self.n_chain_panels - 1
             end
           end
         end


### PR DESCRIPTION
An small and easy to understand but significant performance improvement.
Both inner conditions check for `panel.chaining` which is a cheap bool check compared to `excludeMatch` so it should come before everything else.

This is already implemented in #855 (among many other improvements) but I'm making an early separate PR so that the negative performance impact of #787 can be softened.