### PR TITLE
Improve RunTimeGraph

### DIFF
--- a/CustomRun.lua
+++ b/CustomRun.lua
@@ -11,12 +11,10 @@ CustomRun.runMetrics.drawDuration = 0
 CustomRun.runMetrics.presentDuration = 0
 CustomRun.runMetrics.gcDuration = 0
 CustomRun.runMetrics.sleepDuration = 0
-CustomRun.runMetrics.eventsMemAlloc = 0
 CustomRun.runMetrics.updateMemAlloc = 0
 CustomRun.runMetrics.graphMemAlloc = 0
 CustomRun.runMetrics.drawMemAlloc = 0
 CustomRun.runMetrics.presentMemAlloc = 0
-CustomRun.runMetrics.sleepMemCollect = 0
 
 CustomRun.runTimeGraph = nil
 
@@ -76,7 +74,6 @@ local dt = 0
 local mem = 0
 local prevMem = 0
 function CustomRun.innerRun()
-  mem = collectgarbage("count")
   -- Process events.
   if love.event then
     love.event.pump()
@@ -90,9 +87,7 @@ function CustomRun.innerRun()
     end
   end
 
-  prevMem = mem
   mem = collectgarbage("count")
-  CustomRun.runMetrics.eventsMemAlloc = mem - prevMem
 
   -- Update dt, as we'll be passing it to update
   if love.timer then
@@ -133,7 +128,7 @@ function CustomRun.innerRun()
       mem = collectgarbage("count")
       CustomRun.runMetrics.graphMemAlloc = CustomRun.runMetrics.graphMemAlloc + mem - prevMem
     end
-    
+
     local prePresentTime = love.timer.getTime()
     love.graphics.present()
     CustomRun.runMetrics.presentDuration = love.timer.getTime() - prePresentTime
@@ -144,9 +139,7 @@ function CustomRun.innerRun()
 
   if love.timer then
     CustomRun.sleep()
-    prevMem = mem
     mem = collectgarbage("count")
-    CustomRun.runMetrics.sleepMemCollect = mem - prevMem
   end
 
   if CustomRun.runTimeGraph ~= nil then

--- a/CustomRun.lua
+++ b/CustomRun.lua
@@ -11,6 +11,12 @@ CustomRun.runMetrics.drawDuration = 0
 CustomRun.runMetrics.presentDuration = 0
 CustomRun.runMetrics.gcDuration = 0
 CustomRun.runMetrics.sleepDuration = 0
+CustomRun.runMetrics.eventsMemAlloc = 0
+CustomRun.runMetrics.updateMemAlloc = 0
+CustomRun.runMetrics.graphMemAlloc = 0
+CustomRun.runMetrics.drawMemAlloc = 0
+CustomRun.runMetrics.presentMemAlloc = 0
+CustomRun.runMetrics.sleepMemCollect = 0
 
 CustomRun.runTimeGraph = nil
 
@@ -36,10 +42,11 @@ function CustomRun.sleep()
   local idleTime = targetTime - currentTime
   -- actively collecting garbage is very CPU intensive
   -- only do it while a match is on-going
-  if (GAME and GAME.match and GAME.focused and not GAME.gameIsPaused) then
+  if true or (GAME and GAME.match and GAME.focused and not GAME.gameIsPaused) then
     -- Spend as much time as necessary collecting garbage, but at least 0.1ms
     -- manualGc itself has a ceiling at which it will stop
-    manualGc(math.max(0.0001, idleTime * 0.99))
+    --manualGc(math.max(0.0001, idleTime * 0.99), 256, true)
+    manualGc(0, 256, true)
     currentTime = love.timer.getTime()
     CustomRun.runMetrics.gcDuration = currentTime - originalTime
     originalTime = currentTime
@@ -67,7 +74,10 @@ end
 
 -- This is our custom version of run that uses a custom sleep and records metrics.
 local dt = 0
+local mem = 0
+local prevMem = 0
 function CustomRun.innerRun()
+  mem = collectgarbage("count")
   -- Process events.
   if love.event then
     love.event.pump()
@@ -81,6 +91,10 @@ function CustomRun.innerRun()
     end
   end
 
+  prevMem = mem
+  mem = collectgarbage("count")
+  CustomRun.runMetrics.eventsMemAlloc = mem - prevMem
+
   -- Update dt, as we'll be passing it to update
   if love.timer then
     dt = love.timer.step()
@@ -92,6 +106,9 @@ function CustomRun.innerRun()
     local preUpdateTime = love.timer.getTime()
     love.update(dt) -- will pass 0 if love.timer is disabled
     CustomRun.runMetrics.updateDuration = love.timer.getTime() - preUpdateTime
+    prevMem = mem
+    mem = collectgarbage("count")
+    CustomRun.runMetrics.updateMemAlloc = mem - prevMem
   end
 
   local graphicsActive = love.graphics and love.graphics.isActive()
@@ -103,6 +120,9 @@ function CustomRun.innerRun()
       local preDrawTime = love.timer.getTime()
       love.draw()
       CustomRun.runMetrics.drawDuration = love.timer.getTime() - preDrawTime
+      prevMem = mem
+      mem = collectgarbage("count")
+      CustomRun.runMetrics.drawMemAlloc = mem - prevMem
     end
 
     -- draw the RunTimeGraph here so it doesn't contribute to the love.draw load
@@ -110,21 +130,33 @@ function CustomRun.innerRun()
       local preGraphDrawTime = love.timer.getTime()
       CustomRun.runTimeGraph:draw()
       CustomRun.runMetrics.graphDuration = CustomRun.runMetrics.graphDuration + (love.timer.getTime() - preGraphDrawTime)
+      prevMem = mem
+      mem = collectgarbage("count")
+      CustomRun.runMetrics.graphMemAlloc = CustomRun.runMetrics.graphMemAlloc + mem - prevMem
     end
     
     local prePresentTime = love.timer.getTime()
     love.graphics.present()
     CustomRun.runMetrics.presentDuration = love.timer.getTime() - prePresentTime
+    prevMem = mem
+    mem = collectgarbage("count")
+    CustomRun.runMetrics.presentMemAlloc = mem - prevMem
   end
 
   if love.timer then
     CustomRun.sleep()
+    prevMem = mem
+    mem = collectgarbage("count")
+    CustomRun.runMetrics.sleepMemCollect = mem - prevMem
   end
 
   if CustomRun.runTimeGraph ~= nil then
     local preGraphUpdateTime = love.timer.getTime()
     CustomRun.runTimeGraph:updateWithMetrics(CustomRun.runMetrics)
     CustomRun.runMetrics.graphDuration = love.timer.getTime() - preGraphUpdateTime
+    prevMem = mem
+    mem = collectgarbage("count")
+    CustomRun.runMetrics.graphMemAlloc = mem - prevMem
   end
 end
 

--- a/CustomRun.lua
+++ b/CustomRun.lua
@@ -45,8 +45,7 @@ function CustomRun.sleep()
   if true or (GAME and GAME.match and GAME.focused and not GAME.gameIsPaused) then
     -- Spend as much time as necessary collecting garbage, but at least 0.1ms
     -- manualGc itself has a ceiling at which it will stop
-    --manualGc(math.max(0.0001, idleTime * 0.99), 256, true)
-    manualGc(0, 256, true)
+    manualGc(math.max(0.0001, idleTime * 0.99))
     currentTime = love.timer.getTime()
     CustomRun.runMetrics.gcDuration = currentTime - originalTime
     originalTime = currentTime

--- a/RunTimeGraph.lua
+++ b/RunTimeGraph.lua
@@ -12,51 +12,62 @@ local RunTimeGraph = class(function(self)
   self.graphs = {}
 
   -- fps graph
-  self.graphs[#self.graphs + 1] = BarGraph(x, y, width, height, updateSpeed, 60, valueCount)
+  self.graphs[#self.graphs + 1] = BarGraph(x, y, width, height, updateSpeed, 60, valueCount, 1)
   self.graphs[#self.graphs]:setFillColor({0, 1, 0, 1}, 1)
   y = y + height + padding
 
   -- memory graph
-  self.graphs[#self.graphs + 1] = BarGraph(x, y, width, height, updateSpeed, 256, valueCount)
+  self.graphs[#self.graphs + 1] = BarGraph(x, y, width, height, updateSpeed, 256, valueCount, 1)
   y = y + height + padding
 
   -- leftover time
-  self.graphs[#self.graphs + 1] = BarGraph(x, y, width, height, updateSpeed, consts.FRAME_RATE * 1, valueCount)
+  self.graphs[#self.graphs + 1] = BarGraph(x, y, width, height, updateSpeed, consts.FRAME_RATE * 1, valueCount, 1)
   self.graphs[#self.graphs]:setFillColor({0, 1, 1, 1}, 1)
   y = y + height + padding
 
   -- run loop graph
-  self.graphs[#self.graphs + 1] = BarGraph(x, y, width, height, updateSpeed, consts.FRAME_RATE * 1, valueCount)
+  self.graphs[#self.graphs + 1] = BarGraph(x, y, width, height, updateSpeed, consts.FRAME_RATE * 1, valueCount, 6)
   self.graphs[#self.graphs]:setFillColor({0, 0, 1, 1}, 1) -- love.update
   self.graphs[#self.graphs]:setFillColor({1, 0.3, 0.3, 1}, 2) -- love.draw
   self.graphs[#self.graphs]:setFillColor({0.5, 0.5, 0.5, 1}, 3) -- self:draw + self:updateWithMetrics
   self.graphs[#self.graphs]:setFillColor({1, 1, 1, 1}, 4) -- love.present
   self.graphs[#self.graphs]:setFillColor({0.2, 0.2, 1, 1}, 5) -- manualGc
   self.graphs[#self.graphs]:setFillColor({0, 1, 0, 1}, 6) -- love.timer.sleep
-
   y = y + height + padding
+
+  -- memory allocation graph
+  self.memAllocGraph = BarGraph(x, y, width, height, updateSpeed, 128, valueCount, 4)
+  self.memAllocGraph:setFillColor({0, 0, 1, 1}, 1) -- love.update
+  self.memAllocGraph:setFillColor({1, 0.3, 0.3, 1}, 2) -- love.draw
+  self.memAllocGraph:setFillColor({0.5, 0.5, 0.5, 1}, 3) -- self:draw + self:updateWithMetrics
+  self.memAllocGraph:setFillColor({1, 1, 1, 1}, 4) -- love.present
 end)
 
 function RunTimeGraph:updateWithMetrics(runMetrics)
   local dt = runMetrics.dt
   local fps = math.round(1.0 / dt, 1)
   local averageFPS = love.timer.getFPS()
-  self.graphs[1]:updateGraph({fps}, "FPS: " .. averageFPS .. " (" .. fps .. ")", dt)
+  local memAllocated = math.floor(runMetrics.updateMemAlloc + runMetrics.drawMemAlloc + runMetrics.graphMemAlloc + runMetrics.presentMemAlloc)
+  self.graphs[1]:updateGraph("FPS: " .. averageFPS .. " (" .. fps .. ")", dt, fps)
 
   local memoryCount = collectgarbage("count")
   memoryCount = round(memoryCount / 1024, 1)
-  self.graphs[2]:updateGraph({memoryCount}, "Memory: " .. memoryCount .. " Mb", dt)
+  self.graphs[2]:updateGraph("Memory: " .. memoryCount .. " Mb", dt, memoryCount)
 
-  self.graphs[3]:updateGraph({leftover_time}, "leftover_time " .. leftover_time, dt)
+  self.graphs[3]:updateGraph("leftover_time " .. leftover_time, dt, leftover_time)
 
-  self.graphs[4]:updateGraph({runMetrics.updateDuration,
-                              runMetrics.drawDuration,
-                              runMetrics.graphDuration,
-                              runMetrics.presentDuration,
-                              runMetrics.gcDuration,
-                              runMetrics.sleepDuration
-                            },
-                             "Run Loop", dt)
+  self.graphs[4]:updateGraph("Run Loop", dt, runMetrics.updateDuration,
+                                             runMetrics.drawDuration,
+                                             runMetrics.graphDuration,
+                                             runMetrics.presentDuration,
+                                             runMetrics.gcDuration,
+                                             runMetrics.sleepDuration
+                            )
+
+  self.memAllocGraph:updateGraph("Memory Alloc " .. memAllocated .. "kB", dt, runMetrics.updateMemAlloc,
+                                                                             runMetrics.drawMemAlloc,
+                                                                             runMetrics.graphMemAlloc,
+                                                                             runMetrics.presentMemAlloc)
 end
 
 function RunTimeGraph:draw()
@@ -68,6 +79,9 @@ function RunTimeGraph:draw()
   love.graphics.scale(GAME.canvasXScale, GAME.canvasYScale)
 
   BarGraph.drawGraphs(self.graphs)
+  if not GcIsRunning then
+    self.memAllocGraph:draw()
+  end
 
   love.graphics.pop()
 end

--- a/globals.lua
+++ b/globals.lua
@@ -52,3 +52,5 @@ SFX_GameOver_Play = 0
 global_op_state = nil
 
 current_use_music_from = "stage" -- either "stage" or "characters", no other values!
+
+GcIsRunning = true

--- a/libraries/BarGraph.lua
+++ b/libraries/BarGraph.lua
@@ -1,6 +1,6 @@
 -- Inspired by https://github.com/icrawler/FPSGraph but mostly rewritten.
 
-local BarGraph = class(function(self, x, y, width, height, delay, maxValue, valueCount)
+local BarGraph = class(function(self, x, y, width, height, delay, maxValue, valueCount, subValueCount)
   assert(width >= 10)
   assert(maxValue ~= nil)
   assert(valueCount > 1)
@@ -24,19 +24,25 @@ local BarGraph = class(function(self, x, y, width, height, delay, maxValue, valu
   self.label = "graph" -- the label of the graph (changes when called by an update function)
   self.fillColors = {}
   self.strokeColors = {}
+  -- how many values there are for each 
+  self.subValueCount = subValueCount or 1
 end)
 
 BarGraph.font = love.graphics.newFont(12)
 
-function BarGraph:updateGraph(val, label, dt)
-  assert(type(val) == "table")
-
+function BarGraph:updateGraph(label, dt, ...)
   self.cur_time = self.cur_time + dt
 
   while self.cur_time >= self.delay do
     self.cur_time = self.cur_time - self.delay
 
-    self.vals[self.currentIndex] = val
+    local values = self.vals[self.currentIndex]
+    for i = 1, self.subValueCount do
+      -- nil is allowed as a 0 equivalent
+      local val = select(i, ...) or 0
+      assert(type(val) == "number", "Unexpected value type " .. tostring(type(val)) .." in bar graph update")
+      values[i] = val
+    end
     if self.currentIndex == self.barCount then
       self.currentIndex = 1
     else
@@ -50,49 +56,56 @@ function BarGraph:setFillColor(color, index)
   self.fillColors[index] = color
 end
 
-function BarGraph.drawGraphs(graphs)
+local defaultStrokeColor = {0, 0, 0, 0.4}
+local defaultFillColor = {1, 1, 1, 0.8}
+
+function BarGraph.draw(graph)
   local oldFont = love.graphics.getFont()
   love.graphics.setFont(BarGraph.font)
 
-  -- loop through all of the graphs
-  for j = 1, #graphs do
-    local graph = graphs[j]
-    local maxVal = graph.maxValue
-
-    local xPosition = graph.x
-    for i = 1, graph.barCount do
-      local valueIndex = graph.currentIndex - 1 + i
-      if valueIndex > graph.barCount then
-        valueIndex = valueIndex - graph.barCount
-      end
+  local xPosition = graph.x
+  for i = 1, graph.barCount do
+    local valueIndex = graph.currentIndex - 1 + i
+    if valueIndex > graph.barCount then
+      valueIndex = valueIndex - graph.barCount
+    end
+    local yPosition = graph.y + graph.height
+    if type(graph.vals[valueIndex]) == "table" then
       local values = graph.vals[valueIndex]
-      assert(type(values) == "table")
-      local yPosition = graph.y + graph.height
-      for index, value in ipairs(values) do
-        local height = graph.height * (value / maxVal)
-        local fillColor = graph.fillColors[index] or {1, 1, 1, 0.8}
-        local strokeColor = graph.strokeColors[index] or {0, 0, 0, 0.4}
+      for index = 1, math.min(graph.subValueCount, #values) do
+        local value = values[index]
+        local height = graph.height * (value / graph.maxValue)
+        local fillColor = graph.fillColors[index] or defaultFillColor
+        local strokeColor = graph.strokeColors[index] or defaultStrokeColor
         love.graphics.setColor(unpack(fillColor))
         love.graphics.rectangle("fill", xPosition, yPosition - height, graph.barWidth, height)
         love.graphics.setColor(unpack(strokeColor))
         love.graphics.rectangle("line", xPosition + 0.5, yPosition - height + 0.5, graph.barWidth - 1, height - 1)
         yPosition = yPosition - height
       end
-      xPosition = xPosition + graph.barWidth
     end
-
-    love.graphics.setColor(1, 1, 1, 0.8)
-    love.graphics.rectangle("line", graph.x + 0.5, graph.y + 0.5, graph.width - 1, graph.height - 1)
-
-    love.graphics.setColor(0, 0, 0, 0.8)
-    love.graphics.rectangle("fill", graph.x, graph.height + graph.y + 8, graph.width, 20)
-
-    love.graphics.setColor(1, 1, 1, 1)
-    local padding = 4
-    love.graphics.print(graph.label, graph.x + padding, graph.height + graph.y + 8 + padding)
+    xPosition = xPosition + graph.barWidth
   end
 
+  love.graphics.setColor(1, 1, 1, 0.8)
+  love.graphics.rectangle("line", graph.x + 0.5, graph.y + 0.5, graph.width - 1, graph.height - 1)
+
+  love.graphics.setColor(0, 0, 0, 0.8)
+  love.graphics.rectangle("fill", graph.x, graph.height + graph.y + 8, graph.width, 20)
+
+  love.graphics.setColor(1, 1, 1, 1)
+  local padding = 4
+  love.graphics.print(graph.label, graph.x + padding, graph.height + graph.y + 8 + padding)
+
   love.graphics.setFont(oldFont)
+end
+
+function BarGraph.drawGraphs(graphs)
+  -- loop through all of the graphs
+  for j = 1, #graphs do
+    local graph = graphs[j]
+    graph:draw()
+  end
 end
 
 return BarGraph

--- a/libraries/batteries/manual_gc.lua
+++ b/libraries/batteries/manual_gc.lua
@@ -68,14 +68,19 @@ return function(time_budget, memory_ceiling, disable_otherwise)
 		steps < max_steps
 	do
 		collectgarbage("step", 1)
+    -- manually collecting garbage enables the GC again
+    GcIsRunning = true
 		steps = steps + 1
 	end
 	--safety net
 	if collectgarbage("count") / 1024 > memory_ceiling then
 		collectgarbage("collect")
+    -- manually collecting garbage enables the GC again
+    GcIsRunning = true
 	end
 	--don't collect gc outside this margin
 	if disable_otherwise then
 		collectgarbage("stop")
+    GcIsRunning = false
 	end
 end


### PR DESCRIPTION
Reason for doing this:
The current RunTimeGraph is allocating 10x as much memory as the rest of the game does, thus greatly distorting the results of its own display as it massively ramps up automatic GC work on the side, making it very difficult to measure any changes to the game code.

This PR comes with mainly 2 different changes:

# Reduction of throwaway table generation

## Color default values

Defining `defaultStrokeColor` as a local value saves a lot of memory and GC work as the value for the garbage index was never defined, leading to the creation of 540 color tables per frame.

## Graph updates

Instead of taking a table containing the values as the argument, `updateGraph` now accepts values as a parameter list.
When the defined delay is surpassed, the BarGraph now takes its now outdated table value at `currentIndex` and overwrites the values inside, therefore reusing a pool of 60 tables instead of throwing one away every frame.

# Measurement of memory allocation

In a [doc](https://www.lua.org/gems/sample.pdf) about lua specific optimization I found the following snip relating to how the automatic GC does work:
> Most recycling in Lua is done automatically by the garbage collector. Lua
uses an incremental garbage collector. That means that the collector performs
its task in small steps (incrementally) interleaved with the program execution.
The pace of these steps is proportional to memory allocation: for each amount
of memory allocated by Lua, the garbage collector does some proportional work.
The faster the program consumes memory, the faster the collector tries to recycle
it.

By extension, allocating more memory causes the garbage collector to work more, effectively increasing load.
To measure memory allocation I added a new graph that draws a graph similar to the Run Loop graph but with memory allocated for each part of `CustomRun.innerRun` and also used that to measure the success of reducing the graph's memory consumption (don't think I'd have found the strokeColor issue otherwise).
This graph is *only* visible if the automatic GC has been turned off via our `manual_gc.lua` library, indicated via the new global `GcIsRunning` (`collectgarbage("isRunning")` is only available from Lua 5.2), as the results with automatic GC on will be pure nonsense.