### PR TITLE
Add reload hotkey for mods

### DIFF
--- a/character.lua
+++ b/character.lua
@@ -158,7 +158,8 @@ end
 -- GRAPHICS
 
 local basic_images = {"icon"}
-local other_images = {
+local all_images = {
+  "icon",
   "topleft",
   "botleft",
   "topright",
@@ -217,7 +218,7 @@ function characters_reload_graphics()
 end
 
 function Character.graphics_init(self, full, yields)
-  local character_images = full and other_images or basic_images
+  local character_images = full and all_images or basic_images
   for _, image_name in ipairs(character_images) do
     self.images[image_name] = GraphicsUtil.loadImageFromSupportedExtensions(self.path .. "/" .. image_name)
     if not self.images[image_name] and defaulted_images[image_name] and not self:is_bundle() then
@@ -277,7 +278,7 @@ function Character.graphics_init(self, full, yields)
 end
 
 function Character.graphics_uninit(self)
-  for _, image_name in ipairs(other_images) do
+  for _, image_name in ipairs(all_images) do
     self.images[image_name] = nil
   end
   self.telegraph_garbage_images = {}

--- a/character.lua
+++ b/character.lua
@@ -278,8 +278,10 @@ function Character.graphics_init(self, full, yields)
 end
 
 function Character.graphics_uninit(self)
-  for _, image_name in ipairs(all_images) do
-    self.images[image_name] = nil
+  for imageName, _ in pairs(self.images) do
+    if not table.contains(basic_images, imageName) then
+      self.images[imageName] = nil
+    end
   end
   self.telegraph_garbage_images = {}
 end

--- a/input.lua
+++ b/input.lua
@@ -314,6 +314,7 @@ function love.keypressed(key, scancode, rep)
   local function toggleDebugMode()
     if key == "d" and smashDown() then
       config.debug_mode = not config.debug_mode
+      return true
     end
   end
 
@@ -321,25 +322,29 @@ function love.keypressed(key, scancode, rep)
     if smashDown() then
       if key == "c" then
         characters_reload_graphics()
+        return true
       elseif key == "p" then
         panels_init()
+        return true
       elseif key == "s" then
         stages_reload_graphics()
+        return true
       elseif key == "t" then
         themes[config.theme]:json_init()
         themes[config.theme]:graphics_init()
         themes[config.theme]:final_init()
+        return true
       end
     end
   end
 
   if handleFullscreenToggle() or
      handleScreenshot() or
+     reloadMods() or 
      handleCopy() or
      handleDumpAttackPattern() or
      modifyWinCounts() or
-     toggleDebugMode() or
-     reloadMods() then
+     toggleDebugMode() then
     return
   end
 

--- a/input.lua
+++ b/input.lua
@@ -217,8 +217,25 @@ function joystick_ax()
 end
 
 function love.keypressed(key, scancode, rep)
+
+  local function altDown()
+    return love.keyboard.isDown("lalt") or love.keyboard.isDown("ralt")
+  end
+
+  local function ctrlDown()
+    return love.keyboard.isDown("rctrl") or love.keyboard.isDown("lctrl")
+  end
+
+  local function shiftDown()
+    return love.keyboard.isDown("lshift") or love.keyboard.isDown("rshift")
+  end
+
+  local function smashDown()
+    return ctrlDown() and altDown() and shiftDown()
+  end
+
   local function handleFullscreenToggle()
-    if key == "return" and not rep and (love.keyboard.isDown("lalt") or love.keyboard.isDown("ralt")) then
+    if key == "return" and not rep and altDown() then
       love.window.setFullscreen(not love.window.getFullscreen(), "desktop")
       return true
     end
@@ -235,7 +252,7 @@ function love.keypressed(key, scancode, rep)
   end
 
   local function handleCopy()
-    if key == "c" and not rep and (love.keyboard.isDown("rctrl") or love.keyboard.isDown("lctrl")) then
+    if key == "c" and not rep and ctrlDown() then
       local stacks = {}
       if P1 then
         stacks["P1"] = P1:toPuzzleInfo()
@@ -251,7 +268,7 @@ function love.keypressed(key, scancode, rep)
   end
 
   local function handleDumpAttackPattern()
-    if (key == "1" or key == "2") and not rep and (love.keyboard.isDown("rctrl") or love.keyboard.isDown("lctrl")) then
+    if (key == "1" or key == "2") and not rep and ctrlDown() then
       local stack = P1
 
       if key == "2" then
@@ -274,7 +291,7 @@ function love.keypressed(key, scancode, rep)
   end
 
   local function modifyWinCounts()
-    if GAME.battleRoom and (love.keyboard.isDown("lalt") or love.keyboard.isDown("ralt")) then
+    if GAME.battleRoom and altDown() then
       if key == "1" then -- Add to P1's win count
         GAME.battleRoom.modifiedWinCounts[1] = math.max(0, GAME.battleRoom.modifiedWinCounts[1] + 1)
       end
@@ -295,17 +312,34 @@ function love.keypressed(key, scancode, rep)
   end
 
   local function toggleDebugMode()
-    if key == "d" and (love.keyboard.isDown("rctrl") or love.keyboard.isDown("lctrl")) and (love.keyboard.isDown("lalt") or love.keyboard.isDown("ralt")) and (love.keyboard.isDown("lshift") or love.keyboard.isDown("rshift")) then
+    if key == "d" and smashDown() then
       config.debug_mode = not config.debug_mode
     end
   end
-  
+
+  local function reloadMods()
+    if smashDown() then
+      if key == "c" then
+        characters_reload_graphics()
+      elseif key == "p" then
+        panels_init()
+      elseif key == "s" then
+        stages_reload_graphics()
+      elseif key == "t" then
+        themes[config.theme]:json_init()
+        themes[config.theme]:graphics_init()
+        themes[config.theme]:final_init()
+      end
+    end
+  end
+
   if handleFullscreenToggle() or
      handleScreenshot() or
      handleCopy() or
      handleDumpAttackPattern() or
      modifyWinCounts() or
-     toggleDebugMode() then
+     toggleDebugMode() or
+     reloadMods() then
     return
   end
 

--- a/readme_characters.md
+++ b/readme_characters.md
@@ -308,7 +308,9 @@ You may use .png or .jpg/.jpeg for these.
 .gif files are not supported by the framework Panel Attack uses so please refrain from asking devs to support that.
 
 Assets will get scaled and stretched if they don't match the recommended size or aspect ratio.  
-The per-file recommendations below are given for a resolution of 2560x1440. Using 1.5x/2x the size may look better at higher resolutions while 0.5x the size may look better on lower resolutions.
+The per-file recommendations below are given for a resolution of 2560x1440. Using 1.5x/2x the size may look better at higher resolutions while 0.5x the size may look better on lower resolutions.  
+
+You can use the Ctrl+Shift+Alt+C shortcut to reload character graphics in the game.
 
 ### Garbage assets
 

--- a/readme_panels.txt
+++ b/readme_panels.txt
@@ -38,4 +38,6 @@ File 3: Shape is shifted 4 pixels up
 File 4: Bottom is shifted down 2 pixels, top is squished down 9 pixels, sides are squished out 2 pixels
 File 5: Inverted: Middle color shape is about 20% darker, White is 208, 208, 208, outside is same color as inside
 File 6: Dead: Add a silly / broken / dead version this is shown at the end of popping and at game over.
-File 7: everything is 50% darker
+File 7: everything is 50% darker  
+
+You can use the Ctrl+Shift+Alt+P shortcut to reload all panel graphics in the game.

--- a/readme_stages.md
+++ b/readme_stages.md
@@ -135,7 +135,9 @@ You may use .png or .jpg for these.
 Support for animated backgrounds is on the table but not available yet.  
 
 Assets will get scaled and stretched if they don't match the recommended size or aspect ratio.  
-The per-file recommendations below are given for a resolution of 2560x1440. Using 1.5x/2x the size may look better at higher resolutions while 0.5x the size may look better on lower resolutions.
+The per-file recommendations below are given for a resolution of 2560x1440. Using 1.5x/2x the size may look better at higher resolutions while 0.5x the size may look better on lower resolutions.  
+
+You can use the Ctrl+Shift+Alt+S shortcut to reload stage graphics in the game.
 
 ### thumbnail
 

--- a/readme_themes.md
+++ b/readme_themes.md
@@ -15,7 +15,9 @@ Various files in fact do not have a specific size or aspect ratio but merely a c
 Due to this, it is required for theme assets that you specify in the configuration how a graphic should be scaled.  
 If no configuration is given, standard values from the default theme will be used.  
 You can find the default configuration at  
-https://github.com/panel-attack/panel-attack/blob/beta/themes/Panel%20Attack%20Modern/config.json
+https://github.com/panel-attack/panel-attack/blob/beta/themes/Panel%20Attack%20Modern/config.json  
+
+You can use the Ctrl+Shift+Alt+T shortcut to reload your theme configuration and graphics in the game.
 
 
 -----------------------------------------------------------
@@ -31,7 +33,7 @@ For this reason the "id" of the theme is always the foldername.
 You may use .png or .jpg/.jpeg for these.
 .gif files are not supported by the framework Panel Attack uses so please refrain from asking devs to support that.  
 All file names are case sensitive and the extension *always* has to be lowercase!  
-While an incorrectly cased file may load on Windows, it will not on other operating systems!
+While an incorrectly cased file may load on Windows, it will not on other operating systems!  
 
 ### Default image
 

--- a/stage.lua
+++ b/stage.lua
@@ -253,8 +253,10 @@ end
 
 -- uninits stage graphics
 function Stage.graphics_uninit(self)
-  for _, image_name in ipairs(allImages) do
-    self.images[image_name] = nil
+  for imageName, _ in pairs(self.images) do
+    if not table.contains(basic_images, imageName) then
+      self.images[imageName] = nil
+    end
   end
 end
 

--- a/stage.lua
+++ b/stage.lua
@@ -6,8 +6,7 @@ require("UpdatingImage")
 --  . the data structure that store a stage's data
 
 local basic_images = {"thumbnail"}
-local backgroundImageName = "background"
-local other_images = {backgroundImageName}
+local allImages = {"thumbnail", "background"}
 local defaulted_images = {thumbnail = true, background = true} -- those images will be defaulted if missing
 local basic_musics = {}
 local other_musics = {"normal_music", "danger_music", "normal_music_start", "danger_music_start"}
@@ -216,6 +215,11 @@ function stages_reload_graphics()
   -- reload the current stage graphics immediately
   if stages[current_stage] then
     stages[current_stage]:graphics_init(true, false)
+    if GAME and GAME.match then
+      -- for reasons, this is not drawn directly from the stage but from background image
+      -- so override this while in a match
+      GAME.backgroundImage = UpdatingImage(stages[current_stage].images.background, false, 0, 0, canvas_width, canvas_height)
+    end
   end
   -- lazy load the rest
   for _, stage in pairs(stages) do
@@ -232,7 +236,7 @@ end
 
 -- initalizes stage graphics
 function Stage.graphics_init(self, full, yields)
-  local stage_images = full and other_images or basic_images
+  local stage_images = full and allImages or basic_images
   for _, image_name in ipairs(stage_images) do
     self.images[image_name] = GraphicsUtil.loadImageFromSupportedExtensions(self.path .. "/" .. image_name)
     if not self.images[image_name] and defaulted_images[image_name] and not self:is_bundle() then
@@ -249,7 +253,7 @@ end
 
 -- uninits stage graphics
 function Stage.graphics_uninit(self)
-  for _, image_name in ipairs(other_images) do
+  for _, image_name in ipairs(allImages) do
     self.images[image_name] = nil
   end
 end


### PR DESCRIPTION
Resolves #872 
Reload mods with modifier Ctrl+Alt+Shift and
`c` to reload active characters' graphics
`p` to reload all panels
`s` to reload the active/configured stage's graphics
`t` to reload the theme's config.json and graphics

Additionally I added character's `icon` and stage's `thumbnail` to the full image list so they will get reloaded as well when either rescaling the game or pressing the hotkey. They also get loaded twice as a result in other scenarios (once for partial load and then again for full load) but given the low size, I think that's negligible.
Finally I added a manual background refresh for the stage graphics reload function as the background is drawn separately. 