### PR TITLE
Added checks for HTTP response

### DIFF
--- a/auto_updater/game_updater_thread.lua
+++ b/auto_updater/game_updater_thread.lua
@@ -24,7 +24,7 @@ function download_available_versions(server_url, timeout, max_size, timestamp_fi
     end
   }
 
-  if body and body ~= "" then
+  if body ~= "" then
     for w in body:gmatch('<a href="([/%w_-]+)%.love">') do
       all_versions[#all_versions+1] = w:gsub("^/[/%w_-]+/", "")
     end

--- a/auto_updater/main.lua
+++ b/auto_updater/main.lua
@@ -214,8 +214,11 @@ local function run()
 
   if GAME_UPDATER.config.force_version ~= "" then
     if containsForcedVersion(all_versions) then
-      awaitGameDownload(GAME_UPDATER.config.force_version)
-      setGameStartVersion(GAME_UPDATER.config.force_version)
+      if awaitGameDownload(GAME_UPDATER.config.force_version) then
+        setGameStartVersion(GAME_UPDATER.config.force_version)
+      else
+        error("Failed to download forced version " .. GAME_UPDATER.config.force_version)
+      end
     else
       local err = 'Could not find online version: "'..GAME_UPDATER.config.force_version..'" (force_version)\nAvailable versions are:\n'
         for _, v in pairs(all_versions) do err = err..v.."\n" end
@@ -235,8 +238,12 @@ local function run()
         setEmbeddedAsGameStartVersion()
       else
         logMessage("A new version of the game has been found!")
-        awaitGameDownload(all_versions[1])
-        setGameStartVersion(all_versions[1])
+        if awaitGameDownload(all_versions[1]) then
+          logMessage("New version downloaded successfully!")
+          setGameStartVersion(all_versions[1])
+        else
+          logMessage("Download of new version failed!")
+        end
       end
     else
       logMessage("No online version found for " .. UPDATER_NAME)


### PR DESCRIPTION
Fixes #905 
The updater was trying to write the body of the server answer without checking the result of the HTTP request.
Now it confirms that there is a response body and that it indeed contains what was requested via checking the status code.

This probably happens once in a blue moon so we could wait with releasing this until there's a more pressing issue for updating the auto updater.