### PR TITLE
Extend menuState check to table fields

### DIFF
--- a/select_screen/select_screen.lua
+++ b/select_screen/select_screen.lua
@@ -581,7 +581,7 @@ function select_screen.sendMenuState(self)
   menuState.level = self.players[self.my_player_number].level
   menuState.inputMethod = self.players[self.my_player_number].inputMethod
   for k, v in pairs(menuState) do
-    if type(k) == "function" or type(v) == "function" then
+    if type(k) == "function" or type(v) == "function" or type(k) == "table" or type(v) == "table" then
       error("Trying to send an illegal object to the server\n" .. table_to_string(menuState))
     end
   end


### PR DESCRIPTION
Got the menustate crash the other day even with the check.
Looks like the function is part of a table (and neither should any of the menu state values be a table value).