### PR TITLE
Dont allow movement on last countdown move frame

### DIFF
--- a/consts.lua
+++ b/consts.lua
@@ -14,6 +14,8 @@ consts.ENGINE_VERSIONS.TOUCH_COMPATIBLE = "047"
 VERSION = consts.ENGINE_VERSIONS.TOUCH_COMPATIBLE -- The current engine version
 VERSION_MIN_VIEW = consts.ENGINE_VERSIONS.TELEGRAPH_COMPATIBLE -- The lowest version number that can be watched
 
+consts.COUNTDOWN_CURSOR_SPEED = 4 --one move every this many frames
+consts.COUNTDOWN_LENGTH = 180 --3 seconds at 60 fps
 canvas_width = 1280
 canvas_height = 720
 

--- a/engine.lua
+++ b/engine.lua
@@ -17,7 +17,6 @@ local min, pairs, deepcpy = math.min, pairs, deepcpy
 local max = math.max
 
 local DT_SPEED_INCREASE = 15 * 60 -- frames it takes to increase the speed level by 1
-local COUNTDOWN_CURSOR_SPEED = 4 --one move every this many frames
 
 -- Represents the full panel stack for one player
 Stack =
@@ -1773,27 +1772,28 @@ function Stack:runCountDownIfNeeded()
         self.cur_col = self.width
       end
     end
-    local COUNTDOWN_LENGTH = 180 --3 seconds at 60 fps
     if self.countdown_clock == 8 then
-      self.countdown_timer = COUNTDOWN_LENGTH
+      self.countdown_timer = consts.COUNTDOWN_LENGTH
     end
     if self.countdown_timer then
-      local countDownFrame = COUNTDOWN_LENGTH - self.countdown_timer
-      if countDownFrame > 0 and countDownFrame % COUNTDOWN_CURSOR_SPEED == 0 then
-        local moveIndex = math.floor(countDownFrame / COUNTDOWN_CURSOR_SPEED)
+      local countDownFrame = consts.COUNTDOWN_LENGTH - self.countdown_timer
+      if countDownFrame > 0 and countDownFrame % consts.COUNTDOWN_CURSOR_SPEED == 0 then
+        local moveIndex = math.floor(countDownFrame / consts.COUNTDOWN_CURSOR_SPEED)
         if moveIndex <= 4 then
           self:moveCursorInDirection("down")
         elseif moveIndex <= 6 then
           self:moveCursorInDirection("left")
-          if self.match.engineVersion == consts.ENGINE_VERSIONS.TELEGRAPH_COMPATIBLE and moveIndex == 6 then
-            self.cursorLock = nil
-          end
+
         elseif moveIndex == 10 then
-          self.animatingCursorDuringCountdown = false
+          self.animatingCursorDuringCountdown = nil
           if self.inputMethod == "touch" then
             self.cur_row = 0
             self.cur_col = 0
           end
+        end
+      elseif countDownFrame == 6 * consts.COUNTDOWN_CURSOR_SPEED + 1 then
+        if self.match.engineVersion == consts.ENGINE_VERSIONS.TELEGRAPH_COMPATIBLE then
+          self.cursorLock = nil
         end
       end
       if self.countdown_timer == 0 then
@@ -1801,7 +1801,6 @@ function Stack:runCountDownIfNeeded()
         self.do_countdown = false
         self.countdown_timer = nil
         self.countdown_clock = nil
-        self.animatingCursorDuringCountdown = nil
         self.game_stopwatch_running = true
         if self.which == 1 and self:shouldChangeSoundEffects() then
           SFX_Go_Play = 1

--- a/match.lua
+++ b/match.lua
@@ -78,12 +78,14 @@ function Match.matchOutcome(self)
     results["winSFX"] = self.P2:pick_win_sfx()
     results["end_text"] =  loc("ss_p_wins", GAME.battleRoom.playerNames[2])
     -- win_counts will get overwritten by the server in net games
-    results["outcome_claim"] = P2.player_number
-  elseif P2.game_over_clock == self.gameEndedClock then -- client wins
+    GAME.battleRoom.playerWinCounts[self.P2.player_number] = GAME.battleRoom.playerWinCounts[self.P2.player_number] + 1
+    results["outcome_claim"] = self.P2.player_number
+  elseif self.P2.game_over_clock == self:gameEndedClockTime() then -- client wins
     results["winSFX"] = self.P1:pick_win_sfx()
     results["end_text"] =  loc("ss_p_wins", GAME.battleRoom.playerNames[1])
     -- win_counts will get overwritten by the server in net games
-    results["outcome_claim"] = P1.player_number
+    GAME.battleRoom.playerWinCounts[self.P1.player_number] = GAME.battleRoom.playerWinCounts[self.P1.player_number] + 1
+    results["outcome_claim"] = self.P1.player_number
   else
     error("No win result")
   end

--- a/tests/ReplayTests.lua
+++ b/tests/ReplayTests.lua
@@ -6,6 +6,7 @@ local Replay = require("replay")
 
 local function endlessSaveTest()
   local match = StackReplayTestingUtils.createEndlessMatch(nil, nil, 10)
+  match.P1:receiveConfirmedInput(string.rep(match.P1:idleInput(), 909))
   local replay = Replay.createNewReplay(match)
   StackReplayTestingUtils:fullySimulateMatch(match)
 

--- a/tests/StackReplayTestingUtils.lua
+++ b/tests/StackReplayTestingUtils.lua
@@ -8,8 +8,8 @@ end
 function StackReplayTestingUtils.createEndlessMatch(speed, difficulty, level)
   local match = Match("endless")
   match.seed = 1
-  local P1 = Stack{which=1, match=match, wantsCanvas=false, is_local=true, panels_dir=config.panels, speed=speed, difficulty=difficulty, level=level, character=config.character, inputMethod="controller"}
-
+  local P1 = Stack{which=1, match=match, wantsCanvas=false, is_local=false, panels_dir=config.panels, speed=speed, difficulty=difficulty, level=level, character=config.character, inputMethod="controller"}
+  P1.max_runs_per_frame = 1
   match.P1 = P1
   P1:wait_for_random_character()
   P1:starting_state()
@@ -41,7 +41,9 @@ function StackReplayTestingUtils:simulateStack(stack, clockGoal)
 end
 
 function StackReplayTestingUtils:simulateMatchUntil(match, clockGoal)
+  assert(match.P1.is_local == false, "Don't use 'local' for tests, we might simulate the clock time too much if local")
   while match.P1.clock < clockGoal do
+      assert(#match.P1.input_buffer > 0)
       match:run()
   end
   assert(match.P1.clock == clockGoal)


### PR DESCRIPTION
We were allowing movement on the last movement of the cursor animation, which broke old v46 replays sometimes Add a unit test
Fixed some other unit test problems
moved some constants into constants file