### PR TITLE
Fixed training mode spamming combo sounds

### DIFF
--- a/AttackEngine.lua
+++ b/AttackEngine.lua
@@ -15,7 +15,7 @@ AttackPattern =
 -- An attack engine sends attacks based on a set of rules.
 AttackEngine =
   class(
-  function(self, delayBeforeStart, delayBeforeRepeat, disableQueueLimit, garbageTarget, sender, character)
+  function(self, delayBeforeStart, delayBeforeRepeat, disableQueueLimit, garbageTarget, sender, character, shouldPlayAttackSfx)
     -- The number of frames before the first attack starts. Note if this is changed after attack patterns are added their times won't be updated.
     self.delayBeforeStart = delayBeforeStart 
 
@@ -32,14 +32,15 @@ AttackEngine =
     self.character = wait_for_random_character(character)
     self.telegraph = Telegraph(sender)
     self:setGarbageTarget(garbageTarget)
+    self.shouldPlayAttackSfx = shouldPlayAttackSfx
   end
 )
 
-function AttackEngine.createEngineForTrainingModeSettings(trainingModeSettings, garbageTarget, opponent, character)
+function AttackEngine.createEngineForTrainingModeSettings(trainingModeSettings, garbageTarget, opponent, character, shouldPlayAttackSfx)
   local delayBeforeStart = trainingModeSettings.delayBeforeStart or 0
   local delayBeforeRepeat = trainingModeSettings.delayBeforeRepeat or 0
   local disableQueueLimit = trainingModeSettings.disableQueueLimit or false
-  local attackEngine = AttackEngine(delayBeforeStart, delayBeforeRepeat, disableQueueLimit, garbageTarget, opponent, character)
+  local attackEngine = AttackEngine(delayBeforeStart, delayBeforeRepeat, disableQueueLimit, garbageTarget, opponent, character, shouldPlayAttackSfx)
   attackEngine:addAttackPatternsFromTable(trainingModeSettings.attackPatterns)
   return attackEngine
 end
@@ -143,7 +144,7 @@ function AttackEngine.run(self)
     metalCount = 3
   end
   local newComboChainInfo = Stack.attackSoundInfoForMatch(maxChain > 0, maxChain, maxCombo, metalCount)    
-  if newComboChainInfo then
+  if newComboChainInfo and self.shouldPlayAttackSfx then
     characters[self.character]:playAttackSfx(newComboChainInfo)
   end
 

--- a/ChallengeStage.lua
+++ b/ChallengeStage.lua
@@ -24,7 +24,7 @@ function ChallengeStage:createHealth()
 end
 
 function ChallengeStage:createAttackEngine(garbageTarget, opponent, character)
-  local attackEngine = AttackEngine.createEngineForTrainingModeSettings(self.attackSettings, garbageTarget, opponent, character)
+  local attackEngine = AttackEngine.createEngineForTrainingModeSettings(self.attackSettings, garbageTarget, opponent, character, true)
   return attackEngine
 end
 

--- a/select_screen/select_screen.lua
+++ b/select_screen/select_screen.lua
@@ -906,9 +906,9 @@ function select_screen.start1pLocalMatch(self)
     local mirror = -1
     local simulatedOpponent = SimulatedOpponent(health, character, xPosition, yPosition, mirror)
     if challengeStage then
-      attackEngine = challengeStage:createAttackEngine(P1, simulatedOpponent, character)
+      attackEngine = challengeStage:createAttackEngine(P1, simulatedOpponent, character, true)
     else
-      attackEngine = AttackEngine.createEngineForTrainingModeSettings(GAME.battleRoom.trainingModeSettings.attackSettings, P1, simulatedOpponent, character)
+      attackEngine = AttackEngine.createEngineForTrainingModeSettings(GAME.battleRoom.trainingModeSettings.attackSettings, P1, simulatedOpponent, character, false)
     end
     simulatedOpponent:setAttackEngine(attackEngine)
 


### PR DESCRIPTION
Added an additional parameter to the AttackEngine to determine whether or not to play attack sounds from the opponent.  This allows the new challenge mode to keep opponent attack sound effects while making training modes silent.