### PR TITLE
Fixed user ID not writing to file

### DIFF
--- a/save.lua
+++ b/save.lua
@@ -56,7 +56,7 @@ end
 function write_user_id_file(userID, serverIP)
   pcall(
     function()
-      love.filesystem.createDirectory("servers/")
+      love.filesystem.createDirectory("servers/" .. serverIP)
       local file = love.filesystem.newFile("servers/" .. serverIP .. "/user_id.txt")
       file:open("w")
       file:write(tostring(userID))


### PR DESCRIPTION
First-time run of panel attack creates servers folder, but does not create serverIP folder. Therefore, writing to user_idtxt inside the serverIP folder will not work.  This commit adds the serverIP folder, and user_id.txt now works again.