### PR TITLE
No danger music start on dynamic stages

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -1643,7 +1643,11 @@ function Stack.simulate(self)
           end
 
           local fadePercentage = self.fade_music_clock / fadeLength
-          if wantsDangerMusic then
+          -- Don't play danger music at the start of the match.
+          if self.game_stopwatch < fadeLength then
+            setFadePercentageForGivenTracks(1, normalMusic)
+            setFadePercentageForGivenTracks(0, dangerMusic)
+          elseif wantsDangerMusic then
             setFadePercentageForGivenTracks(1 - fadePercentage, normalMusic)
             setFadePercentageForGivenTracks(fadePercentage, dangerMusic)
           else


### PR DESCRIPTION
Dynamic music's structure starts a match by fading out danger music and fading in normal music. This new code forces the game to play normal music at the start of the match.