### PR TITLE
Reduce globals for asset loading

### DIFF
--- a/AttackEngine.lua
+++ b/AttackEngine.lua
@@ -29,7 +29,9 @@ AttackEngine =
     -- The table of AttackPattern objects this engine will run through.
     self.attackPatterns = {}
     self.clock = 0
-    self.character = wait_for_random_character(character)
+    self.character = CharacterLoader.resolveCharacterSelection(character)
+    CharacterLoader.load(self.character)
+    CharacterLoader.wait()
     self.telegraph = Telegraph(sender)
     self:setGarbageTarget(garbageTarget)
     self.shouldPlayAttackSfx = shouldPlayAttackSfx

--- a/character_loader.lua
+++ b/character_loader.lua
@@ -2,7 +2,6 @@ require("queue")
 require("globals")
 require("character")
 local logger = require("logger")
-local tableUtils = require("table_util")
 
 CharacterLoader = {}
 
@@ -200,7 +199,7 @@ function CharacterLoader.resolveCharacterSelection(characterId)
     characterId = CharacterLoader.resolveBundle(characterId)
   else
     -- resolve via random selection
-    characterId = tableUtils.getRandomElement(characters_ids_for_current_theme)
+    characterId = table.getRandomElement(characters_ids_for_current_theme)
   end
 
   return characterId
@@ -208,7 +207,7 @@ end
 
 function CharacterLoader.resolveBundle(characterId)
   while characters[characterId]:is_bundle() do
-    characterId = tableUtils.getRandomElement(characters[characterId].sub_characters)
+    characterId = table.getRandomElement(characters[characterId].sub_characters)
   end
 
   return characterId

--- a/character_loader.lua
+++ b/character_loader.lua
@@ -2,6 +2,7 @@ require("queue")
 require("globals")
 require("character")
 local logger = require("logger")
+local tableUtils = require("table_util")
 
 CharacterLoader = {}
 
@@ -65,18 +66,6 @@ function CharacterLoader.clear()
       character:unload()
     end
   end
-end
-
-function wait_for_random_character(character)
-  local resolvedCharacter = character
-  if character == random_character_special_value then
-    resolvedCharacter = table.getRandomElement(characters_ids_for_current_theme)
-  elseif characters[character]:is_bundle() then -- may have picked a bundle
-    resolvedCharacter = table.getRandomElement(characters[character].sub_characters)
-  end
-  CharacterLoader.load(resolvedCharacter)
-  CharacterLoader.wait()
-  return resolvedCharacter
 end
 
 -- Adds all the characters recursively in a folder to the global characters variable
@@ -204,4 +193,23 @@ function CharacterLoader.initCharacters()
     CharacterLoader.load(config.character)
     CharacterLoader.wait()
   end
+end
+
+function CharacterLoader.resolveCharacterSelection(characterId)
+  if characterId and characters[characterId] then
+    characterId = CharacterLoader.resolveBundle(characterId)
+  else
+    -- resolve via random selection
+    characterId = tableUtils.getRandomElement(characters_ids_for_current_theme)
+  end
+
+  return characterId
+end
+
+function CharacterLoader.resolveBundle(characterId)
+  while characters[characterId]:is_bundle() do
+    characterId = tableUtils.getRandomElement(characters[characterId].sub_characters)
+  end
+
+  return characterId
 end

--- a/character_loader.lua
+++ b/character_loader.lua
@@ -3,17 +3,14 @@ require("globals")
 require("character")
 local logger = require("logger")
 
+CharacterLoader = {}
+
 local loading_queue = Queue()
 
 local loading_character = nil
 
-characters = {} -- holds all characters, most of them will not be fully loaded
-characters_ids = {} -- holds all characters ids
-characters_ids_for_current_theme = {} -- holds characters ids for the current theme, those characters will appear in the lobby
-characters_ids_by_display_names = {} -- holds keys to array of character ids holding that name
-
 -- queues a character to be loaded
-function character_loader_load(character_id)
+function CharacterLoader.load(character_id)
   if characters[character_id] and not characters[character_id].fully_loaded then
     loading_queue:push(character_id)
   end
@@ -22,7 +19,7 @@ end
 local instant_load_enabled = false
 
 -- return true if there is still data to load
-function character_loader_update()
+function CharacterLoader.update()
   if not loading_character and loading_queue:len() > 0 then
     local character_name = loading_queue:pop()
     loading_character = {
@@ -49,11 +46,11 @@ function character_loader_update()
   return false
 end
 
--- Waits for all characters to be loaded
-function character_loader_wait()
+-- Waits for all queued characters to be loaded
+function CharacterLoader.wait()
   instant_load_enabled = true
   while true do
-    if not character_loader_update() then
+    if not CharacterLoader.update() then
       break
     end
   end
@@ -61,7 +58,7 @@ function character_loader_wait()
 end
 
 -- Unloads all characters not in use by config or player 2
-function character_loader_clear()
+function CharacterLoader.clear()
   local p2_local_character = global_op_state and global_op_state.character or nil
   for character_id, character in pairs(characters) do
     if character.fully_loaded and character_id ~= config.character and character_id ~= p2_local_character then
@@ -77,13 +74,13 @@ function wait_for_random_character(character)
   elseif characters[character]:is_bundle() then -- may have picked a bundle
     resolvedCharacter = table.getRandomElement(characters[character].sub_characters)
   end
-  character_loader_load(resolvedCharacter)
-  character_loader_wait()
+  CharacterLoader.load(resolvedCharacter)
+  CharacterLoader.wait()
   return resolvedCharacter
 end
 
 -- Adds all the characters recursively in a folder to the global characters variable
-local function add_characters_from_dir_rec(path)
+function CharacterLoader.addCharactersFromDirectoryRecursively(path)
   local lfs = love.filesystem
   local raw_dir_list = FileUtil.getFilteredDirectoryItems(path)
   for i, v in ipairs(raw_dir_list) do
@@ -92,7 +89,7 @@ local function add_characters_from_dir_rec(path)
       local current_path = path .. "/" .. v
       if lfs.getInfo(current_path) and lfs.getInfo(current_path).type == "directory" then
         -- call recursively: facade folder
-        add_characters_from_dir_rec(current_path)
+        CharacterLoader.addCharactersFromDirectoryRecursively(current_path)
 
         -- init stage: 'real' folder
         local character = Character(current_path, v)
@@ -113,7 +110,7 @@ local function add_characters_from_dir_rec(path)
 end
 
 -- Loads all character IDs into the characters_ids global
-local function fill_characters_ids()
+function CharacterLoader.fillCharactersIds()
   -- check validity of bundle characters
   local invalid = {}
   local copy_of_characters_ids = shallowcpy(characters_ids)
@@ -149,19 +146,19 @@ local function fill_characters_ids()
   end
 end
 
--- Initializes the characters globals with data
-function characters_init()
+-- (re)Initializes the characters globals with data
+function CharacterLoader.initCharacters()
   characters = {} -- holds all characters, most of them will not be fully loaded
   characters_ids = {} -- holds all characters ids
   characters_ids_for_current_theme = {} -- holds characters ids for the current theme, those characters will appear in the lobby
   characters_ids_by_display_names = {} -- holds keys to array of character ids holding that name
-  add_characters_from_dir_rec("characters")
-  fill_characters_ids()
+  CharacterLoader.addCharactersFromDirectoryRecursively("characters")
+  CharacterLoader.fillCharactersIds()
 
   if #characters_ids == 0 then
     recursive_copy("default_data/characters", "characters")
-    add_characters_from_dir_rec("characters")
-    fill_characters_ids()
+    CharacterLoader.addCharactersFromDirectoryRecursively("characters")
+    CharacterLoader.fillCharactersIds()
   end
 
   if love.filesystem.getInfo(Theme.themeDirectoryPath .. config.theme .. "/characters.txt") then
@@ -204,7 +201,7 @@ function characters_init()
   end
 
   if config.character ~= random_character_special_value and not characters[config.character]:is_bundle() then
-    character_loader_load(config.character)
-    character_loader_wait()
+    CharacterLoader.load(config.character)
+    CharacterLoader.wait()
   end
 end

--- a/engine.lua
+++ b/engine.lua
@@ -1144,7 +1144,9 @@ function Stack.enqueue_card(self, chain, x, y, n)
 end
 
 function Stack:wait_for_random_character()
-  self.character = wait_for_random_character(self.character)
+  self.character = CharacterLoader.resolveCharacterSelection(self.character)
+  CharacterLoader.load(self.character)
+  CharacterLoader.wait()
 end
 
 -- Enqueue a pop animation

--- a/mainloop.lua
+++ b/mainloop.lua
@@ -43,7 +43,7 @@ function fmainloop()
   panels_init()
   GAME:drawLoadingString(loc("ld_characters"))
   wait()
-  characters_init()
+  CharacterLoader.initCharacters()
   GAME:drawLoadingString(loc("ld_analytics"))
   wait()
   analytics.init()
@@ -190,8 +190,8 @@ do
         find_and_add_music(themes[config.theme].musics, "main")
       end
     end
-    character_loader_clear()
-    stage_loader_clear()
+    CharacterLoader.clear()
+    StageLoader.clear()
     resetNetwork()
     undo_stonermode()
     GAME.backgroundImage = themes[config.theme].images.bg_main
@@ -305,8 +305,8 @@ local function use_current_stage()
   if current_stage == nil then
     pick_random_stage()
   else
-    stage_loader_load(current_stage)
-    stage_loader_wait()
+    StageLoader.load(current_stage)
+    StageLoader.wait()
     GAME.backgroundImage = UpdatingImage(stages[current_stage].images.background, false, 0, 0, canvas_width, canvas_height)
     GAME.background_overlay = themes[config.theme].images.bg_overlay
     GAME.foreground_overlay = themes[config.theme].images.fg_overlay
@@ -917,8 +917,8 @@ function main_net_vs_lobby()
   GAME.battleRoom = nil
   undo_stonermode()
   reset_filters()
-  character_loader_clear()
-  stage_loader_clear()
+  CharacterLoader.clear()
+  StageLoader.clear()
   local items
   local unpaired_players = {} -- list
   local willing_players = {} -- set

--- a/replay.lua
+++ b/replay.lua
@@ -159,7 +159,7 @@ function Replay.loadFromFile(replay, wantsCanvas)
     P2.cur_wait_time = replayDetails.P2_cur_wait_time or default_input_repeat_delay
     refreshBasedOnOwnMods(P2)
   end
-  character_loader_wait()
+  CharacterLoader.wait()
 
   P1:starting_state()
 

--- a/select_screen/select_screen.lua
+++ b/select_screen/select_screen.lua
@@ -89,7 +89,7 @@ function refreshBasedOnOwnMods(player)
 
       resolveRandomStage()
       player.stage_display_name = stages[player.stage].stage_display_name
-      stage_loader_load(player.stage)
+      StageLoader.load(player.stage)
     end
 
     -- character
@@ -118,7 +118,7 @@ function refreshBasedOnOwnMods(player)
 
       resolveRandomCharacter()
       player.character_display_name = characters[player.character].character_display_name
-      character_loader_load(player.character)
+      CharacterLoader.load(player.character)
     end
   end
 end
@@ -182,7 +182,7 @@ function select_screen.on_select(self, player, super)
   if selectable[player.cursor.positionId] then
     if player.cursor.selected and player.cursor.positionId == "__Stage" then
       -- load stage even if hidden!
-      stage_loader_load(player.stage)
+      StageLoader.load(player.stage)
     end
     -- Don't let the player stop ready if both players have already told the server to start the game
     if player.cursor.positionId ~= "__Ready" or player.ready == false then 
@@ -803,8 +803,8 @@ function select_screen.startNetPlayMatch(self, msg)
   refreshBasedOnOwnMods(msg) -- for stage only, other data are meaningless to us
   -- mainly for spectator mode, those characters have already been loaded otherwise
   current_stage = msg.stage
-  character_loader_wait()
-  stage_loader_wait()
+  CharacterLoader.wait()
+  StageLoader.wait()
   GAME.match = Match("vs", GAME.battleRoom)
 
   GAME.match.seed = self:getSeed(msg)
@@ -869,8 +869,8 @@ function select_screen.start2pLocalMatch(self)
   P2:setOpponent(P1)
   P2:setGarbageTarget(P1)
   current_stage = self.players[math.random(1, #self.players)].stage
-  stage_loader_load(current_stage)
-  stage_loader_wait()
+  StageLoader.load(current_stage)
+  StageLoader.wait()
   P2:moveForPlayerNumber(2)
 
   P1:starting_state()
@@ -898,8 +898,8 @@ function select_screen.start1pLocalMatch(self)
     if challengeMode then
       health = challengeStage:createHealth()
       character = challengeStage:characterForStageNumber(P1.character)
-      character_loader_load(character)
-      character_loader_wait()
+      CharacterLoader.load(character)
+      CharacterLoader.wait()
     end
 
     local xPosition = 796
@@ -924,8 +924,8 @@ function select_screen.start1pLocalMatch(self)
   end
   P2 = nil
   current_stage = self.players[self.my_player_number].stage
-  stage_loader_load(current_stage)
-  stage_loader_wait()
+  StageLoader.load(current_stage)
+  StageLoader.wait()
 
   GAME.input:requestSingleInputConfigurationForPlayerCount(1)
 
@@ -945,8 +945,8 @@ function select_screen.start1pCpuMatch(self)
   P1.garbageTarget = P2
   P2.garbageTarget = P1
   current_stage = self.players[self.my_player_number].stage
-  stage_loader_load(current_stage)
-  stage_loader_wait()
+  StageLoader.load(current_stage)
+  StageLoader.wait()
   P2:moveForPlayerNumber(2)
 
   GAME.input:requestSingleInputConfigurationForPlayerCount(1)
@@ -1031,8 +1031,8 @@ function select_screen.main(self, character_select_mode, roomInitializationMessa
       function()
         self.menu_clock = self.menu_clock + 1
 
-        character_loader_update()
-        stage_loader_update()
+        CharacterLoader.update()
+        StageLoader.update()
         self:refreshLoadingState(self.my_player_number)
         if self:isMultiplayer() then
           self:refreshLoadingState(self.op_player_number)

--- a/stage_loader.lua
+++ b/stage_loader.lua
@@ -1,6 +1,5 @@
 require("queue")
 require("globals")
-local tableUtils = require("table_util")
 
 StageLoader = {}
 
@@ -71,7 +70,7 @@ function StageLoader.resolveStageSelection(stageId)
     stageId = StageLoader.resolveBundle(stageId)
   else
     -- resolve via random selection
-    stageId = tableUtils.getRandomElement(stages_ids_for_current_theme)
+    stageId = table.getRandomElement(stages_ids_for_current_theme)
   end
 
   return stageId
@@ -79,7 +78,7 @@ end
 
 function StageLoader.resolveBundle(stageId)
   while stages[stageId]:is_bundle() do
-    stageId = tableUtils.getRandomElement(stages[stageId].sub_stages)
+    stageId = table.getRandomElement(stages[stageId].sub_stages)
   end
 
   return stageId

--- a/stage_loader.lua
+++ b/stage_loader.lua
@@ -1,12 +1,14 @@
 require("queue")
 require("globals")
 
+StageLoader = {}
+
 local loading_queue = Queue() -- stages to load
 
 local loading_stage = nil -- currently loading stage
 
 -- loads the stages of the specified id
-function stage_loader_load(stage_id)
+function StageLoader.load(stage_id)
   if stages[stage_id] and not stages[stage_id].fully_loaded then
     loading_queue:push(stage_id)
   end
@@ -15,7 +17,7 @@ end
 local instant_load_enabled = false
 
 -- return true if there is still data to load
-function stage_loader_update()
+function StageLoader.update()
   if not loading_stage and loading_queue:len() > 0 then
     local stage_id = loading_queue:pop()
     loading_stage = {
@@ -43,10 +45,10 @@ function stage_loader_update()
 end
 
 -- waits on loading stages
-function stage_loader_wait()
+function StageLoader.wait()
   instant_load_enabled = true
   while true do
-    if not stage_loader_update() then
+    if not StageLoader.update() then
       break
     end
   end
@@ -54,7 +56,7 @@ function stage_loader_wait()
 end
 
 -- unloads stages
-function stage_loader_clear()
+function StageLoader.clear()
   local p2_local_stage = global_op_state and global_op_state.stage or nil
   for stage_id, stage in pairs(stages) do
     if stage.fully_loaded and stage_id ~= config.stage and stage_id ~= p2_local_stage then

--- a/stage_loader.lua
+++ b/stage_loader.lua
@@ -1,5 +1,6 @@
 require("queue")
 require("globals")
+local tableUtils = require("table_util")
 
 StageLoader = {}
 
@@ -63,4 +64,23 @@ function StageLoader.clear()
       stage:unload()
     end
   end
+end
+
+function StageLoader.resolveStageSelection(stageId)
+  if stageId and stages[stageId] then
+    stageId = StageLoader.resolveBundle(stageId)
+  else
+    -- resolve via random selection
+    stageId = tableUtils.getRandomElement(stages_ids_for_current_theme)
+  end
+
+  return stageId
+end
+
+function StageLoader.resolveBundle(stageId)
+  while stages[stageId]:is_bundle() do
+    stageId = tableUtils.getRandomElement(stages[stageId].sub_stages)
+  end
+
+  return stageId
 end


### PR DESCRIPTION
I'm currently working on reimplementing selectScreen in all of its forms on Sankyr's UI rework.
I'll do parallel PRs to both beta and scenes for non-UI changes so we'll have less troubles porting changes later on.

This change in particular is a preparation to move away from the global `refreshBasedOnOwnMods` which is rather verbose and a bit complicated and mixes rather different use-cases (online vs local) and I want to get rid of it in the select screen of the new UI. I already replaced it in places where it didn't bloat code too much.
Additionally we had different functions doing similar things like the former `wait_for_random_character` which has been removed in favor of an explicit implementation using the new functions.
The implementation in this PR in particular makes sure that there cannot be a crash when bundles are nested further than 1 level and bundles.
Additionally the globals in character_loader had already been declared in globals.lua so this takes care of it.

Future PRs of this type will go against sceneRefactor instead but I'll first need to merge beta against that which will take a while because I still need to get into Sankyr's codebase to resolve some of the conflicts.