### PR TITLE
Convert standard puzzles to v2 format

### DIFF
--- a/default_data/puzzles/stock (example).json
+++ b/default_data/puzzles/stock (example).json
@@ -1,320 +1,494 @@
 {
-    "Ridiculous Mode": [
-        [
-            "010000019000199900911900991900",
-            3
-        ],
-        [
-            "111111555555666666333333222222444444111111555555666666333333222222444444",
-            1
-        ],
-        [
-            "032510036520646325641313412143112146325461131516131516416123442315632515",
-            5
-        ]
-    ],
-    "Classic set 2": [
-        [
-            "4000001000001000004000001440",
-            1
-        ],
-        [
-            "60000026000062200",
-            1
-        ],
-        [
-            "3300055350",
-            1
-        ],
-        [
-            "1200001212",
-            2
-        ],
-        [
-            "363636",
-            3
-        ],
-        [
-            "3000332000224000441000115000556000663000332000224000441600116600",
-            1
-        ],
-        [
-            "600002600062200",
-            2
-        ],
-        [
-            "5000005000001000001500005100",
-            2
-        ],
-        [
-            "2200004400004200",
-            2
-        ],
-        [
-            "13000031000013110",
-            2
-        ]
-    ],
-    "Classic set 5": [
-        [
-            "500000200000200000100000100000200000100000200055255",
-            2
-        ],
-        [
-            "550001250001610066220",
-            3
-        ],
-        [
-            "5000004500006400006300003600005344",
-            3
-        ],
-        [
-            "1130001450004550005330004550",
-            3
-        ],
-        [
-            "663366521425512245313343562265",
-            5
-        ],
-        [
-            "606060401040501050402040502020461640",
-            3
-        ],
-        [
-            "600000200010600021200012620",
-            3
-        ],
-        [
-            "400002200001600001400046200026100",
-            3
-        ],
-        [
-            "6000005000053000044000036500043600",
-            3
-        ],
-        [
-            "4340334334455453",
-            3
-        ]
-    ],
-    "Classic set 1": [
-        [
-            "10110",
-            1
-        ],
-        [
-            "3000033030",
-            1
-        ],
-        [
-            "2100001200001200",
-            1
-        ],
-        [
-            "6400006400004600006400006400",
-            1
-        ],
-        [
-            "2000223303",
-            1
-        ],
-        [
-            "115155",
-            1
-        ],
-        [
-            "1000001000003000001000001000003300",
-            1
-        ],
-        [
-            "40000040055450",
-            1
-        ],
-        [
-            "3000002300002230",
-            1
-        ],
-        [
-            "4100001400004100001400004100",
-            3
-        ]
-    ],
-    "Classic set 4": [
-        [
-            "1000004000001000061100044600016100",
-            2
-        ],
-        [
-            "4400006500004600065500",
-            2
-        ],
-        [
-            "4000006000006000002000002240006440",
-            3
-        ],
-        [
-            "1100002330002123",
-            2
-        ],
-        [
-            "300003500002500003200005200332500",
-            3
-        ],
-        [
-            "263000514000445000513000522160616620332120335150226620",
-            1
-        ],
-        [
-            "2000004000004000443000242233",
-            2
-        ],
-        [
-            "4000004600001140006160",
-            3
-        ],
-        [
-            "1000004100001400003300004200032200",
-            3
-        ],
-        [
-            "40000040000010000140001230022440034430",
-            3
-        ]
-    ],
-    "Bagagle mode": [
-        [
-            "4000441101",
-            1
-        ],
-        [
-            "223233",
-            1
-        ],
-        [
-            "400000600000600046400",
-            1
-        ],
-        [
-            "100001300033100",
-            1
-        ],
-        [
-            "4200002400002400",
-            1
-        ],
-        [
-            "2000024400043300211310",
-            1
-        ],
-        [
-            "5000001200014500043420166350226232",
-            1
-        ],
-        [
-            "214365214365662622214365214365",
-            1
-        ],
-        [
-            "5000054550441310513350",
-            2
-        ],
-        [
-            "40000040000030000042000025200051200066500031320556512",
-            3
-        ]
-    ],
-    "Go hard": [
-        [
-            "002000001220019990091990",
-            2
-        ],
-        [
-            "29000092000029000091000019000019",
-            2
-        ]
-    ],
-    "Classic set 3": [
-        [
-            "4000001000001000044000041040",
-            2
-        ],
-        [
-            "3000002000002000003220003230",
-            2
-        ],
-        [
-            "3400004300303404",
-            2
-        ],
-        [
-            "1000006000004000004600006100014100",
-            2
-        ],
-        [
-            "400000650005560054465",
-            3
-        ],
-        [
-            "400000100000544000411000655000366000233000422000144004411",
-            2
-        ],
-        [
-            "100000500000100000100000500005100005155",
-            2
-        ],
-        [
-            "21000012120",
-            3
-        ],
-        [
-            "300000300006500003300005600065600",
-            2
-        ],
-        [
-            "500002500022600066500",
-            2
-        ]
-    ],
-    "Classic set 6": [
-        [
-            "32000036000061000023110026220",
-            3
-        ],
-        [
-            "25000165000636000565000623200611500553500",
-            3
-        ],
-        [
-            "60000610004610002160042610024640",
-            4
-        ],
-        [
-            "50000044000015000014000033000011400035440",
-            4
-        ],
-        [
-            "35000012000011000022000035000013350",
-            4
-        ],
-        [
-            "30000060060040030640034530055360036640",
-            3
-        ],
-        [
-            "40000054000011000044500015110",
-            4
-        ],
-        [
-            "100022600011200031600013361",
-            4
-        ],
-        [
-            "2000005000003000056000046400065200045200053500053500",
-            4
-        ],
-        [
-            "600006400002340001430001310033160021230",
-            4
-        ]
-    ]
+  "Version": 2,
+  "Puzzle Sets": [
+    {
+      "Set Name": "Classic set 1",
+      "Puzzles": [
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "10110"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "3000033030"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "2100001200001200"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "6400006400004600006400006400"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "2000223303"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "115155"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "1000001000003000001000001000003300"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "40000040055450"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "3000002300002230"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "4100001400004100001400004100"
+        }
+      ]
+    },
+    {
+      "Set Name": "Classic set 2",
+      "Puzzles": [
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "4000001000001000004000001440"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "60000026000062200"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "3300055350"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "1200001212"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "363636"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "3000332000224000441000115000556000663000332000224000441600116600"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "600002600062200"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "5000005000001000001500005100"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "2200004400004200"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "13000031000013110"
+        }
+      ]
+    },
+    {
+      "Set Name": "Classic set 3",
+      "Puzzles": [
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "4000001000001000044000041040"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "3000002000002000003220003230"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "3400004300303404"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "1000006000004000004600006100014100"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "400000650005560054465"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "400000100000544000411000655000366000233000422000144004411"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "100000500000100000100000500005100005155"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "21000012120"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "300000300006500003300005600065600"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "500002500022600066500"
+        }
+      ]
+    },
+    {
+      "Set Name": "Classic set 4",
+      "Puzzles": [
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "1000004000001000061100044600016100"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "4400006500004600065500"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "4000006000006000002000002240006440"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "1100002330002123"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "300003500002500003200005200332500"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "263000514000445000513000522160616620332120335150226620"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "2000004000004000443000242233"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "4000004600001140006160"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "1000004100001400003300004200032200"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "40000040000010000140001230022440034430"
+        }
+      ]
+    },
+    {
+      "Set Name": "Classic set 5",
+      "Puzzles": [
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "500000200000200000100000100000200000100000200055255"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "550001250001610066220"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "5000004500006400006300003600005344"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "1130001450004550005330004550"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 5,
+          "Stack": "663366521425512245313343562265"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "606060401040501050402040502020461640"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "600000200010600021200012620"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "400002200001600001400046200026100"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "6000005000053000044000036500043600"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "4340334334455453"
+        }
+      ]
+    },
+    {
+      "Set Name": "Classic set 6",
+      "Puzzles": [
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "32000036000061000023110026220"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "25000165000636000565000623200611500553500"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 4,
+          "Stack": "60000610004610002160042610024640"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 4,
+          "Stack": "50000044000015000014000033000011400035440"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 4,
+          "Stack": "35000012000011000022000035000013350"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "30000060060040030640034530055360036640"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 4,
+          "Stack": "40000054000011000044500015110"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 4,
+          "Stack": "100022600011200031600013361"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 4,
+          "Stack": "2000005000003000056000046400065200045200053500053500"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 4,
+          "Stack": "600006400002340001430001310033160021230"
+        }
+      ]
+    },
+    {
+      "Set Name": "Bagagle Mode",
+      "Puzzles": [
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "4000441101"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "223233"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "400000600000600046400"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "100001300033100"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "4200002400002400"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "2000024400043300211310"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "5000001200014500043420166350226232"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 1,
+          "Stack": "214365214365662622214365214365"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "5000054550441310513350"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "40000040000030000042000025200051200066500031320556512"
+        }
+      ]
+    },
+    {
+      "Set Name": "Go Hard",
+      "Puzzles": [
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "002000001220019990091990"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 2,
+          "Stack": "29000092000029000091000019000019"
+        }
+      ]
+    },
+    {
+      "Set Name": "Ridiculous Mode",
+      "Puzzles": [
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 3,
+          "Stack": "010000019000199900911900991900"
+        },
+        {
+          "Puzzle Type": "moves",
+          "Do Countdown": false,
+          "Moves": 5,
+          "Stack": "032510036520646325641313412143112146325461131516131516416123442315632515"
+        }
+      ]
+    }
+  ]
 }

--- a/readme_puzzles.txt
+++ b/readme_puzzles.txt
@@ -75,10 +75,11 @@ Note: carriage returns and spaces in your file are very helpful for readability,
  but are not necessary.
  
 Be sure to use the correct delimiters in the right places, i.e: 
-curly braces {} to start and end the file,
-square brackets [] around individual puzzles and around puzzle sets,
+curly braces {} to start and end the file and around individual puzzles and puzzle sets,
+square brackets [] around the list of puzzle sets and each list of puzzles,
 quotes "" around set names and panel maps
 commas between elements
+Try and use a JSON validator if Panel Attack cannot read your puzzle file!
 
 About the numbers mapping out each puzzle now:
 

--- a/readme_puzzles.txt
+++ b/readme_puzzles.txt
@@ -12,18 +12,18 @@ The contents of each puzzle file should be formatted something like this:
 {
   "Version": 2,
   "Puzzle Sets": [
-    [
+    {
       "Set Name": "Name of Puzzle Set",
       "Puzzles": [
-        [
+        {
           "Puzzle Type": "chain",
           "Do Countdown": true,
           "Moves": 0,
           "Stack": 
             "040000
              111440",
-        ],
-        [
+        },
+        {
           "Puzzle Type": "clear",
           "Do Countdown": false,
           "Moves": 0,
@@ -43,9 +43,9 @@ The contents of each puzzle file should be formatted something like this:
 		   325363",
 		   "Stop": 60,
            "Shake": 0
-        ],
+        },
       ]
-    ],
+    },
   ]
 }
 

--- a/readme_puzzles.txt
+++ b/readme_puzzles.txt
@@ -89,7 +89,8 @@ Additionally there exists a special notation for representing connected garbage 
 
 This allows us to lay out our text representation of the puzzle how it would look in the game, like this:
 
-[====]
+[=====
+=====]
 001200
 002100
 002100


### PR DESCRIPTION
This is to ensure that people don't take v1 puzzles as an example. Additionally I fixed bracket usage.
While our library accepts either `{` or `[` for dictionary type lists, formal json only accepts `{` and uses `[` exclusively for arrays without a key (implicit numbered index). This made it so that our puzzles would fail against any json validator so I corrected that.

I also removed the self-solving +72 combo puzzle from ridiculous mode because it literally served no purpose.

Implements #909 