### PR TITLE
Let players know that rollback is in effect

### DIFF
--- a/match.lua
+++ b/match.lua
@@ -367,7 +367,7 @@ function Match.render(self)
     if P2Behind > 0 then
       gprint("P2 Average Latency: " .. P2Behind, 1, 34)
     end
-    
+
     if GAME.battleRoom.spectating and behind > MAX_LAG * 0.75 then
       local iconSize = 20
       local icon_width, icon_height = themes[config.theme].images.IMG_bug:getDimensions()
@@ -376,7 +376,7 @@ function Match.render(self)
       draw(themes[config.theme].images.IMG_bug, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height)
     end
   end
-  
+
   self:drawCommunityMessage()
 
   if config.debug_mode then
@@ -574,6 +574,13 @@ function Match.render(self)
     local y = 5
     draw(themes[config.theme].images.IMG_bug, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height)
     gprint("A warning has occurred, please post your warnings.txt file and this replay to #panel-attack-bugs in the discord.", x + iconSize, y)
+  elseif P1.clock >= P2.clock + GARBAGE_DELAY_LAND_TIME then
+    -- let the player know that rollback is active
+    local iconSize = 20
+    local icon_width, icon_height = themes[config.theme].images.IMG_bug:getDimensions()
+    local x = 5
+    local y = 30
+    draw(themes[config.theme].images.IMG_bug, x / GFX_SCALE, y / GFX_SCALE, 0, iconSize / icon_width, iconSize / icon_height)
   end
 end
 


### PR DESCRIPTION
Done by displaying the bug image below the FPS counter if stacks are sufficiently desynced for rollback to be in effect.
This should give us a better orientation if any performance related issues are simultaneously rollback-related or not.

This may or may not help us in better troubleshooting bricking setups like ZaUa's but in any case it should be a nice touch.