### PR TITLE
Update licensing information

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,19 +1,181 @@
-Copyright (C) 2011 Robert Burke
+Licensing information
+=====================
 
-This software is provided 'as-is', without any express or implied
-warranty.  In no event will the authors be held liable for any damages
-arising from the use of this software.
+Unless specified otherwise below, all code and assets in this project stand under the license for panel-attack.
 
-Permission is granted to anyone to use this software for any purpose,
-including commercial applications, and to alter it and redistribute it
-freely, subject to the following restrictions:
+panel-attack
+  License: zlib
+  Copyright (C) 2011 Robert Burke
 
-1. The origin of this software must not be misrepresented; you must not
-    claim that you wrote the original software. If you use this software
-    in a product, an acknowledgment in the product documentation would be
-    appreciated but is not required.
-2. Altered source versions must be plainly marked as such, and must not be
-    misrepresented as being the original software.
-3. This notice may not be removed or altered from any source distribution.
+batteries\manual_gc
+  Website: https://github.com/1bardesign/batteries
+  License: zlib
+  Copyright 2021 Max Cahill
 
-Robert Burke sharpobject@gmail.com
+dkjson
+  Website: http://dkolf.de/src/dkjson-lua.fsl/home
+  License: MIT/Expat
+  Copyright (C) 2010-2021 David Heiko Kolf
+
+LuaSQLite3
+  Website: http://lua.sqlite.org/index.cgi/home
+  License: MIT/Expat
+  Copyright (C) 2002-2016 Tiago Dionizio, Doug Currie
+
+LuaSocket
+  Website: https://lunarmodules.github.io/luasocket/index.html
+  License: MIT/Expat
+  Copyright (C) 2004-2013 Diego Nehab
+
+LuaFileSystem
+  Website: https://lunarmodules.github.io/luafilesystem/
+  License: MIT/Expat
+  Copyright © 2003 - 2010 Kepler Project.
+  Copyright © 2010 - 2022 The LuaFileSystem authors.
+
+Apple Computer Osaka-UI (jp.ttf)
+  No formal license, usage according to the embedding permission
+  Copyright © 1990-1999 Apple Computer, Inc.
+
+Noto Sans Thai PA font (th.otf)
+  License: SIL OPEN FONT LICENSE
+  Copyright 2022 The Noto Project Authors (https://github.com/notofonts/thai)
+  This software has been altered to use an ascent of 800 and a descent of -200.
+
+default_data/characters
+default_data/stages
+  No license, graphics used as per the usage agreement on spriters-resource.com
+  Graphics ripped by spriters-resource users JigglypuffGirl, TheWolfBunny, Orion X, Bacon, Angelglory
+  Sounds ripped/recreated by computer and .thatguywiththespoon
+  This is copyrighted material from the games Panel de Pon and Tetris Attack owned by Intelligent Systems / Nintendo, used as a placeholder until original assets have been created.
+
+
+
+License text
+============
+
+zlib license
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+	1. The origin of this software must not be misrepresented you must not
+	claim that you wrote the original software. If you use this software
+	in a product, an acknowledgment in the product documentation would be
+	appreciated but is not required.
+
+	2. Altered source versions must be plainly marked as such, and must not be
+	misrepresented as being the original software.
+
+	3. This notice may not be removed or altered from any source
+	distribution.
+
+MIT/Expat
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in
+	all copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+	THE SOFTWARE.
+
+
+SIL OPEN FONT LICENSE
+    Version 1.1 - 26 February 2007
+    PREAMBLE
+
+    The goals of the Open Font License (OFL) are to stimulate worldwide
+    development of collaborative font projects, to support the font creation
+    efforts of academic and linguistic communities, and to provide a free and
+    open framework in which fonts may be shared and improved in partnership
+    with others.
+
+    The OFL allows the licensed fonts to be used, studied, modified and
+    redistributed freely as long as they are not sold by themselves. The
+    fonts, including any derivative works, can be bundled, embedded,
+    redistributed and/or sold with any software provided that any reserved
+    names are not used by derivative works. The fonts and derivatives,
+    however, cannot be released under any other type of license. The
+    requirement for fonts to remain under this license does not apply
+    to any document created using the fonts or their derivatives.
+    DEFINITIONS
+
+    "Font Software" refers to the set of files released by the Copyright
+    Holder(s) under this license and clearly marked as such. This may
+    include source files, build scripts and documentation.
+
+    "Reserved Font Name" refers to any names specified as such after the
+    copyright statement(s).
+
+    "Original Version" refers to the collection of Font Software components as
+    distributed by the Copyright Holder(s).
+
+    "Modified Version" refers to any derivative made by adding to, deleting,
+    or substituting — in part or in whole — any of the components of the
+    Original Version, by changing formats or by porting the Font Software to a
+    new environment.
+
+    "Author" refers to any designer, engineer, programmer, technical
+    writer or other person who contributed to the Font Software.
+    PERMISSION & CONDITIONS
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of the Font Software, to use, study, copy, merge, embed, modify,
+    redistribute, and sell modified and unmodified copies of the Font
+    Software, subject to the following conditions:
+
+    1) Neither the Font Software nor any of its individual components,
+    in Original or Modified Versions, may be sold by itself.
+
+    2) Original or Modified Versions of the Font Software may be bundled,
+    redistributed and/or sold with any software, provided that each copy
+    contains the above copyright notice and this license. These can be
+    included either as stand-alone text files, human-readable headers or
+    in the appropriate machine-readable metadata fields within text or
+    binary files as long as those fields can be easily viewed by the user.
+
+    3) No Modified Version of the Font Software may use the Reserved Font
+    Name(s) unless explicit written permission is granted by the corresponding
+    Copyright Holder. This restriction only applies to the primary font name as
+    presented to the users.
+
+    4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+    Software shall not be used to promote, endorse or advertise any
+    Modified Version, except to acknowledge the contribution(s) of the
+    Copyright Holder(s) and the Author(s) or with their explicit written
+    permission.
+
+    5) The Font Software, modified or unmodified, in part or in whole,
+    must be distributed entirely under this license, and must not be
+    distributed under any other license. The requirement for fonts to
+    remain under this license does not apply to any document created
+    using the Font Software.
+    TERMINATION
+
+    This license becomes null and void if any of the above conditions are
+    not met.
+    DISCLAIMER
+
+    THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+    OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+    DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+    OTHER DEALINGS IN THE FONT SOFTWARE.


### PR DESCRIPTION
Added a (hopefully complete) reference for all third party software and assets in COPYING that are part of this repository.
I used the license notice that comes with löve distributions as inspiration for the format.

@sharpobject I would like to change the copyright notice for the project to `Copyright (C) 2011-2023 The Panel Attack Contributors`. This requires your permission because it alters the notice (which in turn violates the license).