### PR TITLE
Fix 2 crashes

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -317,7 +317,7 @@ function Stack:calculateMultibarFrameCount()
   -- this is a first idea going from 2s prestop on 10 to nearly 4s prestop on 1
   --local preStopFrameCount = 30 + (10 - self.level) * 5
 
-  local minFrameCount = maxStop + level_to_hang_time[self.level] --+ preStopFrameCount
+  local minFrameCount = maxStop + (level_to_hang_time[self.level] or 1) --+ preStopFrameCount
 
   --return minFrameCount + preStopFrameCount
   return math.max(240, minFrameCount)

--- a/replay.lua
+++ b/replay.lua
@@ -104,7 +104,7 @@ function Replay.loadFromFile(replay, wantsCanvas)
     assert(replayDetails.P1_level, "invalid replay: player 1 level missing from vs replay")
     local inputType1 = (replayDetails.P1_inputMethod) or "controller"
     P1 = Stack{which=1, match=GAME.match, wantsCanvas=wantsCanvas, is_local=false, level=replayDetails.P1_level, character=replayDetails.P1_char, inputMethod=inputType1}
-
+    GAME.match:addPlayer(P1)
     if replayDetails.I and utf8.len(replayDetails.I)> 0 then
       assert(replayDetails.P2_level, "invalid replay: player 1 level missing from vs replay")
       local inputType2 = (replayDetails.P2_inputMethod) or "controller"
@@ -143,7 +143,6 @@ function Replay.loadFromFile(replay, wantsCanvas)
   end
 
   P1:receiveConfirmedInput(uncompress_input_string(replayDetails.in_buf))
-  GAME.match:addPlayer(P1)
   P1.do_countdown = replayDetails.do_countdown or false
   P1.max_runs_per_frame = 1
   P1.cur_wait_time = replayDetails.cur_wait_time or default_input_repeat_delay


### PR DESCRIPTION
Game would crash in classic mode upon calculating multibar height.
Game would crash when loading classic mode replays due to trying to add the same stack to the match twice.