### PR TITLE
Save inputs in tables instead of string concat

### DIFF
--- a/server/Connection.lua
+++ b/server/Connection.lua
@@ -218,10 +218,10 @@ function Connection:I(message)
     if self.player_number == 1 and self.room then
       local uMessage = NetworkProtocol.markedMessageForTypeAndBody(NetworkProtocol.serverMessageTypes.secondOpponentInput.prefix, message)
       self.room:send_to_spectators(uMessage)
-      self.room.replay.vs.in_buf = self.room.replay.vs.in_buf .. message
+      self.room.inputs[self.player_number][#self.room.inputs[self.player_number] + 1] = message
     elseif self.player_number == 2 and self.room then
       self.room:send_to_spectators(iMessage)
-      self.room.replay.vs.I = self.room.replay.vs.I .. message
+      self.room.inputs[self.player_number][#self.room.inputs[self.player_number] + 1] = message
     end
   end
 end
@@ -374,6 +374,7 @@ function Connection:handleMenuStateMessage(message)
   end
 
   if self.ready and self.opponent.ready then
+    self.room.inputs = {{},{}}
     self.room.replay = {}
     self.room.replay.vs = {
       P = "",

--- a/server/Room.lua
+++ b/server/Room.lua
@@ -114,6 +114,8 @@ function Room.add_spectator(self, new_spectator_connection)
     player_settings = {character = self.a.character, character_display_name = self.a.character_display_name, level = self.a.level, player_number = self.a.player_number, inputMethod = self.a.inputMethod},
     opponent_settings = {character = self.b.character, character_display_name = self.b.character_display_name, level = self.b.level, player_number = self.b.player_number, inputMethod = self.b.inputMethod}
   }
+  msg.replay_of_match_so_far.vs.I = table.concat(self.inputs[1])
+  msg.replay_of_match_so_far.vs.in_buf = table.concat(self.inputs[2])
   if COMPRESS_SPECTATOR_REPLAYS_ENABLED then
     msg.replay_of_match_so_far.vs.in_buf = compress_input_string(msg.replay_of_match_so_far.vs.in_buf)
     msg.replay_of_match_so_far.vs.I = compress_input_string(msg.replay_of_match_so_far.vs.I)
@@ -244,14 +246,18 @@ function Room.resolve_game_outcome(self)
       elseif outcome == 0 then
         filename = filename .. "-draw"
       end
-      filename = filename .. ".txt"
-      if self.replay.vs and COMPRESS_REPLAYS_ENABLED then
-        self.replay.vs.I = compress_input_string(self.replay.vs.I)
-        self.replay.vs.in_buf = compress_input_string(self.replay.vs.in_buf)
-        logger.debug("Compressed vs I/in_buf")
-        logger.debug("saving compressed replay as " .. path .. sep .. filename)
-      else
-        logger.debug("saving replay as " .. path .. sep .. filename)
+      filename = filename .. ".json"
+      if self.replay.vs then
+        self.replay.vs.I = table.concat(self.inputs[1])
+        self.replay.vs.in_buf = table.concat(self.inputs[2])
+        if COMPRESS_REPLAYS_ENABLED then
+          self.replay.vs.I = compress_input_string(self.replay.vs.I)
+          self.replay.vs.in_buf = compress_input_string(self.replay.vs.in_buf)
+          logger.debug("Compressed vs I/in_buf")
+          logger.debug("saving compressed replay as " .. path .. sep .. filename)
+        else
+          logger.debug("saving replay as " .. path .. sep .. filename)
+        end
       end
       write_replay_file(self.replay, path, filename)
     else


### PR DESCRIPTION
Fixes #999 

Using `I` and `in_buf` fields for the table didn't prove feasible because they would get overwritten when concatenating for a joining spectator due to the message table holding a reference to the whole replay. Unless I wanted to mess with serialization which I didn't.
I opted to save the inputs on the room in an array numbered by playerNumber instead of on `replay` to avoid it getting serialized in replays / spectator join messages on top of the string representation of the replay. Not sure if that's the best idea, let me know if you have a better one.

And I changed the file extension to json. Cause it's a json. Which should also vastly improve readability when you click on a public replay on our website cause browsers actually have some general ideas for displaying json.