### PR TITLE
Added input test

### DIFF
--- a/CustomRun.lua
+++ b/CustomRun.lua
@@ -69,12 +69,7 @@ function CustomRun.sleep()
   CustomRun.runMetrics.sleepDuration = currentTime - originalTime
 end
 
--- This is our custom version of run that uses a custom sleep and records metrics.
-local dt = 0
-local mem = 0
-local prevMem = 0
-function CustomRun.innerRun()
-  -- Process events.
+function CustomRun.processEvents()
   if love.event then
     love.event.pump()
     for name, a, b, c, d, e, f in love.event.poll() do
@@ -86,7 +81,14 @@ function CustomRun.innerRun()
       love.handlers[name](a, b, c, d, e, f)
     end
   end
+end
 
+-- This is our custom version of run that uses a custom sleep and records metrics.
+local dt = 0
+local mem = 0
+local prevMem = 0
+function CustomRun.innerRun()
+  CustomRun.processEvents()
   mem = collectgarbage("count")
 
   -- Update dt, as we'll be passing it to update

--- a/tests/InputTests.lua
+++ b/tests/InputTests.lua
@@ -1,0 +1,34 @@
+local StackReplayTestingUtils = require("tests.StackReplayTestingUtils")
+local CustomRun = require("CustomRun")
+
+local function testSameFrameKeyPressRelease()
+  local match = StackReplayTestingUtils.createEndlessMatch(nil, nil, 10)
+  GAME.input:requestSingleInputConfigurationForPlayerCount(1)
+  -- we need to lock in the used keyconfig with a single input before inputs can be detected
+  local swapKey = GAME.input.availableInputConfigurationsToAssign[1]["swap1"]
+  love.event.push("keypressed", swapKey, swapKey, false)
+  CustomRun.processEvents()
+  love.event.push("keyreleased", swapKey, swapKey, false)
+  CustomRun.processEvents()
+  -- need to overwrite these to pretend that a frame passed (part of variable_step)
+  this_frame_keys = {}
+  this_frame_released_keys = {}
+  this_frame_unicodes = {}
+
+  -- need this to be true to process input locally
+  match.P1.is_local = true
+  match.P1:receiveConfirmedInput(string.rep(match.P1:idleInput(), 200))
+  while match.P1.clock < 200 do
+    assert(match:matchOutcome() == nil, "Game isn't expected to end yet")
+    assert(#match.P1.input_buffer > 0)
+    match:run()
+  end
+  local raiseKey = GAME.input.playerInputConfigurationsMap[1][1]["raise1"]
+  love.event.push("keypressed", raiseKey, raiseKey, false)
+  love.event.push("keyreleased", raiseKey, raiseKey, false)
+  CustomRun.processEvents()
+  match:run()
+  assert(match.P1.confirmedInput[#match.P1.confirmedInput] == "g")
+end
+
+testSameFrameKeyPressRelease()

--- a/tests/Tests.lua
+++ b/tests/Tests.lua
@@ -1,5 +1,5 @@
 -- In Development, so you don't have to wait for all other tests to debug (move to correct location later)
-
+require("tests.InputTests")
 -- Small tests (unit tests)
 require("PuzzleTests")
 require("ServerQueueTests")


### PR DESCRIPTION
Added a test that confirms that inputs released on the same frame they were first pressed are still applied to the game.
Mostly relevant for #1014, although I couldn't do a generic implementation as inputs are mostly frame aware and tests are performed within one frame so some implementation-specific hacking was necessary.
Needs to be adjusted when merged to sceneRefactor
a) assigning the config for the player (not sure if that is even a feature already)
b) pretending a frame has passed (should just be calling `inputManager:update()` once I think)