### PR TITLE
clear shake time on garbage puzzles since its always on screen

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -862,6 +862,7 @@ function Stack.setPanelsForPuzzleString(self, puzzleString)
   for row = 1, self.height do
     for col = 1, self.width do
       panels[row][col].stateChanged = true
+      panels[row][col].shake_time = nil
     end
   end
 end


### PR DESCRIPTION
Right now puzzle garbage is always on screen and already spawned, so it shouldn't have shake time

Fixes #1019 