### PR TITLE
Fix chaining in puzzles with color 9 panels

### DIFF
--- a/engine/checkMatches.lua
+++ b/engine/checkMatches.lua
@@ -51,6 +51,24 @@ local function getOnScreenCount(stackHeight, panels)
   return count
 end
 
+-- returns true if this panel can be matched
+-- false if it cannot be matched
+local function canMatch(panel)
+  -- panels without colors can't match
+  if panel.color == 0 or panel.color == 9 then
+    return false
+  else
+    if panel.state == "normal"
+      or panel.state == "landing"
+      or (panel.matchAnyway and panel.state == "hovering")  then
+      return true
+    else
+      -- swapping, matched, popping, popped, hover, falling, dimmed, dead
+      return false
+    end
+  end
+end
+
 function Stack:checkMatches()
   if self.do_countdown then
     return
@@ -102,7 +120,7 @@ function Stack:getMatchingPanels()
   for row = 1, self.height do
     for col = 1, self.width do
       local panel = panels[row][col]
-      if panel.stateChanged and panel:canMatch() then
+      if panel.stateChanged and canMatch(panel) then
         candidatePanels[#candidatePanels + 1] = panel
       end
     end
@@ -119,7 +137,7 @@ function Stack:getMatchingPanels()
     -- below
     for row = candidatePanels[i].row - 1, 1, -1 do
       panel = panels[row][candidatePanels[i].column]
-      if panel.color == candidatePanels[i].color and panel:canMatch() then
+      if panel.color == candidatePanels[i].color  and canMatch(panel) then
         verticallyConnected[#verticallyConnected + 1] = panel
       else
         break
@@ -128,7 +146,7 @@ function Stack:getMatchingPanels()
     -- above
     for row = candidatePanels[i].row + 1, self.height do
       panel = panels[row][candidatePanels[i].column]
-      if panel.color == candidatePanels[i].color and panel:canMatch() then
+      if panel.color == candidatePanels[i].color  and canMatch(panel) then
         verticallyConnected[#verticallyConnected + 1] = panel
       else
         break
@@ -137,7 +155,7 @@ function Stack:getMatchingPanels()
     -- to the left
     for column = candidatePanels[i].column - 1, 1, -1 do
       panel = panels[candidatePanels[i].row][column]
-      if panel.color == candidatePanels[i].color and panel:canMatch() then
+      if panel.color == candidatePanels[i].color  and canMatch(panel) then
         horizontallyConnected[#horizontallyConnected + 1] = panel
       else
         break
@@ -146,7 +164,7 @@ function Stack:getMatchingPanels()
     -- to the right
     for column = candidatePanels[i].column + 1, self.width do
       panel = panels[candidatePanels[i].row][column]
-      if panel.color == candidatePanels[i].color and panel:canMatch() then
+      if panel.color == candidatePanels[i].color and canMatch(panel) then
         horizontallyConnected[#horizontallyConnected + 1] = panel
       else
         break
@@ -530,7 +548,7 @@ function Stack:clearChainingFlags()
     for column = 1, self.width do
       local panel = self.panels[row][column]
       -- if a chaining panel wasn't matched but was eligible, we have to remove its chain flag
-      if not panel.matching and panel.chaining and not panel.matchAnyway and panel:canMatch() then
+      if not panel.matching and panel.chaining and not panel.matchAnyway and (canMatch(panel) or panel.color == 9) then
         if row > 1 then
           -- no swapping panel below so this panel loses its chain flag
           if self.panels[row - 1][column].state ~= "swapping" then

--- a/engine/panel.lua
+++ b/engine/panel.lua
@@ -573,24 +573,6 @@ deadState.update = function(panel, panels)
   -- dead is dead
 end
 
--- returns false if this panel can be matched
--- true if it cannot be matched
-function Panel.canMatch(self)
-  -- panels without colors can't match
-  if self.color == 0 or self.color == 9 then
-    return false
-  else
-    if self.state == "normal"
-      or self.state == "landing"
-      or (self.matchAnyway and self.state == "hovering")  then
-      return true
-    else
-      -- swapping, matched, popping, popped, hover, falling, dimmed, dead
-      return false
-    end
-  end
-end
-
 -- returns false if this panel can be swapped
 -- true if it can not be swapped
 function Panel.canSwap(self)


### PR DESCRIPTION
I rechecked with the old implementation and it looks like color 9 panels never even got the chaining flag there.
The port to the panel class missed this and they do get the chaining flag now.
As they're considered not matchable, color 9 panels were not part of the cleanup routine for the chaining flag.
I included them in there now as it would be much more invasive to try and prevent color 9 panels to get the flag rather than just slightly adjust the behaviour of the matching routine and clear it.

The bug was reported by mato when making an insert-catch puzzle for someone in #strategy-coaching on the 27th November:
[insert_catch.txt](https://github.com/panel-attack/panel-attack/files/13531049/insert_catch.txt)

I also noticed that `canMatch` is only used in `checkMatches.lua`, so I moved it over and made it a local there instead of a function on the panel itself which should be enough to counteract any impact the color check might have (although technically caching that value on state changes would be even better).
