### PR TITLE
Fix bundle portrait crash

### DIFF
--- a/character_loader.lua
+++ b/character_loader.lua
@@ -196,12 +196,11 @@ function CharacterLoader.initCharacters()
 end
 
 function CharacterLoader.resolveCharacterSelection(characterId)
-  if characterId and characters[characterId] then
-    characterId = CharacterLoader.resolveBundle(characterId)
-  else
+  if not characterId or not characters[characterId] then
     -- resolve via random selection
     characterId = tableUtils.getRandomElement(characters_ids_for_current_theme)
   end
+  characterId = CharacterLoader.resolveBundle(characterId)
 
   return characterId
 end

--- a/select_screen/select_screen.lua
+++ b/select_screen/select_screen.lua
@@ -204,7 +204,7 @@ function select_screen.on_select(self, player, super)
     player.selectedCharacter = player.cursor.positionId
     local character = characters[player.selectedCharacter]
     if character then
-      player.character = character.id
+      player.character = CharacterLoader.resolveCharacterSelection(character.id)
       CharacterLoader.load(player.character)
       characterSelectionSoundHasBeenPlayed = character:play_selection_sfx()
       if super then
@@ -505,8 +505,8 @@ end
 function select_screen.initializeFromPlayerConfig(self, playerNumber)
   self.players[playerNumber].stage = config.stage
   self.players[playerNumber].selectedStage = config.stage
-  self.players[playerNumber].character = config.character
   self.players[playerNumber].selectedCharacter = config.character
+  self.players[playerNumber].character = config.character
   self.players[playerNumber].level = config.level
   self.players[playerNumber].inputMethod = config.inputMethod or "controller"
   self.players[playerNumber].panels_dir = config.panels

--- a/stage_loader.lua
+++ b/stage_loader.lua
@@ -67,12 +67,11 @@ function StageLoader.clear()
 end
 
 function StageLoader.resolveStageSelection(stageId)
-  if stageId and stages[stageId] then
-    stageId = StageLoader.resolveBundle(stageId)
-  else
+  if not stageId or not stages[stageId] then
     -- resolve via random selection
     stageId = tableUtils.getRandomElement(stages_ids_for_current_theme)
   end
+  stageId = StageLoader.resolveBundle(stageId)
 
   return stageId
 end


### PR DESCRIPTION
Bundle characters would crash if the game was started with random character config and Time Attack / Endless rolled a bundle characters.
Bundle characters would crash if a 1p mode with select screen was chosen as first thing on startup and a bundle character different than the configured startup character was picked.