### PR TITLE
Add *.otf to build.sh to capture thai font

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ echo "Building... Results can be found at ${build_dir}"
 echo "Generating panel attack love file"
 
 # We are explicitly specifying which files are included. Make sure to add specific files in alphabetical order.
-zip -r --quiet "${build_dir}panel-attack.love" *.lua *.ttf readme*.txt *.md *.ogg characters computerPlayers default_data engine libraries localization.csv panels rich_presence select_screen stages themes -x ".*" \*__MACOSX* \*\.DS_Store
+zip -r --quiet "${build_dir}panel-attack.love" *.lua *.ttf *.otf readme*.txt *.md *.ogg characters computerPlayers default_data engine libraries localization.csv panels rich_presence select_screen stages themes -x ".*" \*__MACOSX* \*\.DS_Store
 
 if [ -n "$1" ] && [ $1 == "auto-updater" ]
 then


### PR DESCRIPTION
Turns out the thai font didn't get included with the recent stable/beta thanks to that and PA crashes when trying to switch language to thai as a result.