### PR TITLE
Fix more startup crashes

### DIFF
--- a/Game.lua
+++ b/Game.lua
@@ -28,7 +28,7 @@ end
 local Game = class(
   function(self)
     self.scores = require("scores")
-    self.input = { maxConfigurations = 8, inputConfigurations = {}}
+    self.input = { maxConfigurations = 8, inputConfigurations = {{}, {}, {}, {}, {}, {}, {}, {}}}
     self.match = nil -- Match - the current match going on or nil if inbetween games
     self.battleRoom = nil -- BattleRoom - the current room being used for battles
     self.focused = true -- if the window is focused

--- a/Game.lua
+++ b/Game.lua
@@ -56,6 +56,7 @@ local Game = class(
     self.global_canvas = love.graphics.newCanvas(consts.CANVAS_WIDTH, consts.CANVAS_HEIGHT, {dpiscale=newCanvasSnappedScale(self)})
     
     self.availableScales = {1, 1.5, 2, 2.5, 3}
+    -- specifies a time that is compared against self.timer to determine if GameScale should be shown
     self.showGameScaleUntil = 0
     self.needsAssetReload = false
     self.previousWindowWidth = 0
@@ -76,6 +77,7 @@ local Game = class(
 
     -- misc
     self.rich_presence = RichPresence()
+    -- time in seconds, can be used by other elements to track the passing of time beyond dt
     self.timer = love.timer.getTime()
   end
 )

--- a/Game.lua
+++ b/Game.lua
@@ -56,7 +56,7 @@ local Game = class(
     self.global_canvas = love.graphics.newCanvas(consts.CANVAS_WIDTH, consts.CANVAS_HEIGHT, {dpiscale=newCanvasSnappedScale(self)})
     
     self.availableScales = {1, 1.5, 2, 2.5, 3}
-    self.showGameScale = false
+    self.showGameScaleUntil = 0
     self.needsAssetReload = false
     self.previousWindowWidth = 0
     self.previousWindowHeight = 0
@@ -76,6 +76,7 @@ local Game = class(
 
     -- misc
     self.rich_presence = RichPresence()
+    self.timer = love.timer.getTime()
   end
 )
 
@@ -265,14 +266,15 @@ function Game:handleResize(newWidth, newHeight)
     else
       self:refreshCanvasAndImagesForNewScale()
     end
-    self.showGameScale = true
+    self.showGameScaleUntil = self.timer + 5
   end
 end
 
 -- Called every few fractions of a second to update the game
 -- dt is the amount of time in seconds that has passed.
 function Game:update(dt)
-    if sceneManager.activeScene == nil then
+  self.timer = love.timer.getTime()
+  if sceneManager.activeScene == nil then
     leftover_time = leftover_time + dt
   else
     leftover_time = 0
@@ -350,7 +352,7 @@ function Game:draw()
     love.graphics.print("FPS: " .. love.timer.getFPS(), 1, 1)
   end
   
-  if self.showGameScale or config.debug_mode then
+  if self.showGameScaleUntil > self.timer or config.debug_mode then
     local scaleString = "Scale: " .. self.canvasXScale .. " (" .. canvas_width * self.canvasXScale .. " x " .. canvas_height * self.canvasYScale .. ")"
     local newPixelWidth = love.graphics.getWidth()
 

--- a/scenes/OptionsMenu.lua
+++ b/scenes/OptionsMenu.lua
@@ -326,7 +326,7 @@ function OptionsMenu:load()
   )
 
   local function scaleSettingsChanged()
-    GAME.showGameScale = true
+    GAME.showGameScaleUntil = GAME.timer + 1000
     local newPixelWidth, newPixelHeight = love.graphics.getWidth(), love.graphics.getHeight()
     local previousXScale = GAME.canvasXScale
     GAME:updateCanvasPositionAndScale(newPixelWidth, newPixelHeight)
@@ -421,7 +421,7 @@ function OptionsMenu:load()
     {Label({width = LABEL_WIDTH, label = "op_renderTelegraph"}), createToggleButtonGroup("renderTelegraph")},
     {Label({width = LABEL_WIDTH, label = "op_renderAttacks"}), createToggleButtonGroup("renderAttacks")},
     {Button({width = LABEL_WIDTH, label = "back", onClick = function()
-      GAME.showGameScale = false
+      GAME.showGameScaleUntil = GAME.timer
       switchMenu("baseMenu")
     end})},
   }

--- a/scenes/OptionsMenu.lua
+++ b/scenes/OptionsMenu.lua
@@ -420,7 +420,10 @@ function OptionsMenu:load()
     {Label({width = LABEL_WIDTH, label = "op_popfx"}), createToggleButtonGroup("popfx")},
     {Label({width = LABEL_WIDTH, label = "op_renderTelegraph"}), createToggleButtonGroup("renderTelegraph")},
     {Label({width = LABEL_WIDTH, label = "op_renderAttacks"}), createToggleButtonGroup("renderAttacks")},
-    {Button({width = LABEL_WIDTH, label = "back", onClick = function() switchMenu("baseMenu") end})},
+    {Button({width = LABEL_WIDTH, label = "back", onClick = function()
+      GAME.showGameScale = false
+      switchMenu("baseMenu")
+    end})},
   }
 
   local soundTestMenuOptions = {


### PR DESCRIPTION
This fixes 2 small issues:
`Game.input.inputConfigurations` had no empty configurations inside so when entering input config the game just crashed on accessing a nil index.

On first startup it is almost guaranteed that `love.resize` would be called, causing the Scale display in the top left corner to be displayed until game restart.
I solved this by giving `Game` its own `timer` prop that gets updated with the current time (in seconds). `showGameScale` was recoined as `showGameScaleUntil` and now is being assigned a time relative to that `timer` prop in seconds.
Seemed like a good idea to have a general game timer to compare against, also for future display thingies (notifications etc.)