### PR TITLE
Reimplement modify user ID for sceneRefactor

### DIFF
--- a/Game.lua
+++ b/Game.lua
@@ -202,7 +202,8 @@ function Game:createScenes()
     require("scenes.OptionsMenu"),
     require("scenes.SoundTest"),
     require("scenes.DesignHelper"),
-    require("scenes.VsSelfGame")
+    require("scenes.VsSelfGame"),
+    require("scenes.SetUserIdMenu")
   }
 end
 

--- a/Shortcuts.lua
+++ b/Shortcuts.lua
@@ -1,6 +1,7 @@
 local input = require("inputManager")
 local sceneManager = require("scenes.sceneManager")
 local tableUtils = require("tableUtils")
+local inputFieldManager = require("ui.inputFieldManager")
 
 local function runSystemCommands()
   -- toggle debug mode
@@ -102,6 +103,11 @@ function handleShortcuts()
       handleDumpAttackPattern(1)
     elseif input.allKeys.isDown["2"] then
       handleDumpAttackPattern(2)
+    elseif input.allKeys.isDown["v"] then
+      local clipboard = love.system.getClipboardText()
+      if clipboard then
+        inputFieldManager.textInput(clipboard)
+      end
     end
   elseif input.isPressed["Alt"] then
     if input.isDown["return"] then

--- a/scenes/Lobby.lua
+++ b/scenes/Lobby.lua
@@ -195,7 +195,7 @@ print("lobby2")
   match_type = ""
   match_type_message = ""
   --attempt login
-  read_user_id_file()
+  read_user_id_file(GAME.connected_server_ip)
   if not my_user_id then
     my_user_id = "need a new user id"
   end
@@ -226,7 +226,7 @@ function Lobby:processServerMessages()
         if msg.new_user_id then
           my_user_id = msg.new_user_id
           logger.trace("about to write user id file")
-          write_user_id_file()
+          write_user_id_file(my_user_id, GAME.connected_server_ip)
           self.login_status_message = loc("lb_user_new", config.name)
         elseif msg.name_changed then
           self.login_status_message = loc("lb_user_update", msg.old_name, msg.new_name)

--- a/scenes/OptionsMenu.lua
+++ b/scenes/OptionsMenu.lua
@@ -55,6 +55,7 @@ local menus = {
   audioMenu = nil,
   debugMenu = nil,
   aboutMenu = nil,
+  modifyUserIdMenu = nil
 }
 
 local foundThemes = {}
@@ -223,6 +224,8 @@ function OptionsMenu:repositionMenus()
   menus["debugMenu"].y = y
   menus["aboutMenu"].x = x
   menus["aboutMenu"].y = y
+  menus["modifyUserIdMenu"].x = x
+  menus["modifyUserIdMenu"].y = y
 end
 
 function OptionsMenu:load()
@@ -265,6 +268,7 @@ function OptionsMenu:load()
     {Button({width = LABEL_WIDTH, label = "op_audio", onClick = function() switchMenu("audioMenu") end})},
     {Button({width = LABEL_WIDTH, label = "op_debug", onClick = function() switchMenu("debugMenu") end})},
     {Button({width = LABEL_WIDTH, label = "op_about", onClick = function() switchMenu("aboutMenu") end})},
+    {Button({width = LABEL_WIDTH, label = "Modify User ID", onClick = function() switchMenu("modifyUserIdMenu") end})},
     {Button({width = LABEL_WIDTH, label = "back", onClick = exitMenu})},
   }
 
@@ -479,7 +483,14 @@ function OptionsMenu:load()
     {Button({width = LABEL_WIDTH, label = "System Info", translate = false, onClick = setupSystemInfo})},
     {Button({width = LABEL_WIDTH, label = "back", onClick = function() switchMenu("baseMenu") end})},
   }
-  
+
+  local modifyUserIdOptions = {}
+  local userIDDirectories = fileUtils.getFilteredDirectoryItems("servers")
+  for i = 1, #userIDDirectories do
+    modifyUserIdOptions[#modifyUserIdOptions+1] = {Button({width = LABEL_WIDTH, label = userIDDirectories[i], onClick = function() sceneManager:switchToScene("SetUserIdMenu", {serverIp = userIDDirectories[i]}) end})}
+  end
+  modifyUserIdOptions[#modifyUserIdOptions + 1] = {Button({width = LABEL_WIDTH, label = "back", onClick = function() switchMenu("baseMenu") end})}
+
   menus["baseMenu"] = Menu({menuItems = baseMenuOptions, maxHeight = themes[config.theme].main_menu_max_height})
   menus["generalMenu"] = Menu({menuItems = generalMenuOptions, maxHeight = themes[config.theme].main_menu_max_height})
   menus["graphicsMenu"] = Menu({menuItems = graphicsMenuOptions, maxHeight = themes[config.theme].main_menu_max_height})
@@ -487,6 +498,7 @@ function OptionsMenu:load()
   menus["audioMenu"] = Menu({menuItems = audioMenuOptions, maxHeight = themes[config.theme].main_menu_max_height})
   menus["debugMenu"] = Menu({menuItems = debugMenuOptions, maxHeight = themes[config.theme].main_menu_max_height})
   menus["aboutMenu"] = Menu({menuItems = aboutMenuOptions, maxHeight = themes[config.theme].main_menu_max_height})
+  menus["modifyUserIdMenu"] = Menu({menuItems = modifyUserIdOptions, maxHeight = themes[config.theme].main_menu_max_height})
 
   for _, menu in pairs(menus) do
     menu:setVisibility(false)

--- a/scenes/OptionsMenu.lua
+++ b/scenes/OptionsMenu.lua
@@ -15,6 +15,7 @@ local fileUtils = require("FileUtils")
 local analytics = require("analytics")
 local class = require("class")
 local tableUtils = require("tableUtils")
+local utf8 = require("utf8")
 
 --@module optionsMenu
 -- Scene for the options menu

--- a/scenes/SetNameMenu.lua
+++ b/scenes/SetNameMenu.lua
@@ -55,10 +55,9 @@ function SetNameMenu:update(dt)
   if not input.allKeys.isDown["return"] and tableUtils.trueForAny(input.allKeys.isDown, function(val) return val end) then
     warningText = ""
   end
-
-  local toPrint = loc("op_enter_name") .. " (" .. nameField.value:len() .. "/" .. NAME_LENGTH_LIMIT .. ")" .. "\n" .. warningText
-  gprint(toPrint, unpack(themes[config.theme].main_menu_screen_pos))
   
+  GAME.gfx_q:push({self.draw, {self}})
+
   if input.allKeys.isDown["return"] then
     if nameField.value == "" then
       warningText = loc("op_username_blank_warning")
@@ -74,7 +73,13 @@ function SetNameMenu:update(dt)
     sceneManager:switchToScene("MainMenu")
   end
   
+end
+
+function SetNameMenu:draw()
+  local toPrint = loc("op_enter_name") .. " (" .. nameField.value:len() .. "/" .. NAME_LENGTH_LIMIT .. ")" .. "\n" .. warningText
+  gprint(toPrint, unpack(themes[config.theme].main_menu_screen_pos))
   nameField:draw()
+
 end
 
 function SetNameMenu:unload()  

--- a/scenes/SetUserIdMenu.lua
+++ b/scenes/SetUserIdMenu.lua
@@ -1,0 +1,67 @@
+local Scene = require("scenes.Scene")
+local InputField = require("ui.InputField")
+local sceneManager = require("scenes.sceneManager")
+local Menu = require("ui.Menu")
+local input = require("inputManager")
+local save = require("save")
+local utf8 = require("utf8")
+local class = require("class")
+
+-- @module setNameMenu
+-- Scene for setting the username
+local SetUserIdMenu = class(function(self, sceneParams)
+  self:load(sceneParams)
+end, Scene)
+
+SetUserIdMenu.name = "SetUserIdMenu"
+sceneManager:addScene(SetUserIdMenu)
+
+local menuX, menuY = unpack(themes[config.theme].main_menu_screen_pos)
+
+function SetUserIdMenu:load(sceneParams)
+  backgroundImg = themes[config.theme].images.bg_main
+  self.serverIp = sceneParams.serverIp
+
+  self.idInputField = InputField({
+    x = menuX,
+    y = menuY + 50,
+    width = 200,
+    height = 25,
+    value =  read_user_id_file(self.serverIp),
+    isVisible = false
+  })
+
+  self.idInputField:setVisibility(true)
+  self.idInputField:setFocus(0, 0)
+  self.idInputField.offset = utf8.len(self.idInputField.value)
+end
+
+function SetUserIdMenu:update(dt)
+  if input.allKeys.isDown["return"] then
+    local hasNonDigits = string.match(self.idInputField.value, "[^%d]")
+    if not hasNonDigits and self.idInputField.value:len() > 0 then
+      -- not much point in doing validation but let's stay numeric and non-empty at least
+      Menu.playValidationSfx()
+      write_user_id_file(self.idInputField.value, self.serverIp)
+      -- this is dirty but with how stupid nested OptionsMenu is, there is no way to get back right to where we came from
+      sceneManager:switchToScene("MainMenu")
+    else
+      Menu.playCancelSfx()
+    end
+  elseif input.allKeys.isDown["escape"] then
+    sceneManager:switchToScene("MainMenu")
+  elseif input.allKeys.isDown["a"] then
+    local phi = 5
+  end
+
+  GAME.gfx_q:push({self.draw, {self}})
+end
+
+function SetUserIdMenu:drawBackground()
+  backgroundImg:draw()
+end
+
+function SetUserIdMenu:draw()
+  gprintf("Enter User ID (or paste from clipboard)", menuX, menuY)
+  self.idInputField:draw()
+end

--- a/ui/InputField.lua
+++ b/ui/InputField.lua
@@ -85,7 +85,7 @@ end
 
 function InputField:onBackspace()
   if self.offset == 0 then
-    return 
+    return
   end
 
   -- get the byte offset to the last UTF-8 character in the string.
@@ -100,7 +100,7 @@ function InputField:onBackspace()
   else
     self.value = string.sub(self.value, 1, byteoffset) .. string.sub(self.value, byteoffset2 + 1, strByteLength)
   end
-  self.text = love.graphics.newText(love.graphics.getFont(), self.value)
+  self.text:set(self.value)
   self.offset = self.offset - 1
 end
 
@@ -112,7 +112,7 @@ function InputField:textInput(t)
   if self.filterAlphanumeric and string.find(t, "[^%w]+") then
     return
   end
-  if utf8.len(self.value) < self.charLimit then
+  if utf8.len(self.value) + utf8.len(t) <= self.charLimit then
     local strByteLength = utf8.offset(self.value, -1) or 0
     local byteoffset = utf8.offset(self.value, self.offset) or 0
     if self.offset == 0 then
@@ -122,25 +122,27 @@ function InputField:textInput(t)
     else
       self.value = string.sub(self.value, 1, byteoffset) .. t .. string.sub(self.value, byteoffset + 1, strByteLength)
     end
-    self.text = love.graphics.newText(love.graphics.getFont(), self.value)
-    self.offset = self.offset + 1
+    self.text:set(self.value)
+    self.offset = self.offset + utf8.len(t)
   end
 end
 
+local valueColor = {1, 1, 1, 1}
+local placeholderColor = {.5, .5, .5, 1}
 function InputField:draw()
   if not self.isVisible then
     return
   end
 
-  GAME.gfx_q:push({love.graphics.setColor, self.outlineColor})
-  GAME.gfx_q:push({love.graphics.rectangle, {"line", self.x, self.y, self.width, self.height}})
-  GAME.gfx_q:push({love.graphics.setColor, self.backgroundColor})
-  GAME.gfx_q:push({love.graphics.rectangle, {"fill", self.x, self.y, self.width, self.height}})
+  love.graphics.setColor(self.outlineColor)
+  love.graphics.rectangle("line", self.x, self.y, self.width, self.height)
+  love.graphics.setColor(self.backgroundColor)
+  love.graphics.rectangle("fill", self.x, self.y, self.width, self.height)
   
   local text = self.value ~= "" and self.text or self.placeholderText
-  local textColor = self.value ~= "" and {1, 1, 1, 1} or {.5, .5, .5, 1}
+  local textColor = self.value ~= "" and valueColor or placeholderColor
   
-  GAME.gfx_q:push({love.graphics.setColor, textColor})
+  love.graphics.setColor(textColor)
   
   local textWidth = self.text:getWidth()
   local textHeight = text:getHeight()
@@ -157,16 +159,16 @@ function InputField:draw()
   local xPosAlign, xOffset = unpack(xAlignments[self.halign])
   local yPosAlign, yOffset = unpack(yAlignments[self.valign])
   
-  GAME.gfx_q:push({love.graphics.draw, {text, self.x + xPosAlign + textOffset, self.y + yPosAlign + 0, 0, 1, 1, xOffset, yOffset}})
+  love.graphics.draw(text, self.x + xPosAlign + textOffset, self.y + yPosAlign + 0, 0, 1, 1, xOffset, yOffset)
   
   if self.hasFocus then
     local cursorFlashPeriod = .5
     if (math.floor(love.timer.getTime() / cursorFlashPeriod)) % 2 == 0 then
-      GAME.gfx_q:push({love.graphics.setColor, {1, 1, 1, 1}})
-      GAME.gfx_q:push({love.graphics.draw, {textCursor, self:getCursorPos(), self.y + yPosAlign + 0, 0, 1, 1, xOffset, yOffset}})
+      love.graphics.setColor(1, 1, 1, 1)
+      love.graphics.draw(textCursor, self:getCursorPos(), self.y + yPosAlign + 0, 0, 1, 1, xOffset, yOffset)
     end
   end
-  GAME.gfx_q:push({love.graphics.setColor, {1, 1, 1, 1}})
+  love.graphics.setColor(1, 1, 1, 1)
   
   -- draw children
   UIElement.draw(self)


### PR DESCRIPTION
Also implements copy paste functionality for input fields for parity with beta.
I implemented this as a scene for now as I wasn't keen on adding to the somewhat messy setup that OptionsMenu already is.
Due to this, it's not possible to return to the same depth of the OptionsMenu and as changing user id should be an extraordinarily rare event anyway, I think it's fine to just return to main menu.