### PR TITLE
Prevent mirror matches from random

### DIFF
--- a/replay.lua
+++ b/replay.lua
@@ -148,7 +148,7 @@ function Replay.loadFromFile(replay, wantsCanvas)
   P1.max_runs_per_frame = 1
   P1.cur_wait_time = replayDetails.cur_wait_time or default_input_repeat_delay
 
-  refreshBasedOnOwnMods(P1)
+  refreshBasedOnOwnMods(P1, GAME.match.players)
 
   if P2 then
     P2:receiveConfirmedInput(uncompress_input_string(replayDetails.I))
@@ -157,7 +157,7 @@ function Replay.loadFromFile(replay, wantsCanvas)
     P2.do_countdown = replayDetails.do_countdown or false
     P2.max_runs_per_frame = 1
     P2.cur_wait_time = replayDetails.P2_cur_wait_time or default_input_repeat_delay
-    refreshBasedOnOwnMods(P2)
+    refreshBasedOnOwnMods(P2, GAME.match.players)
   end
   CharacterLoader.wait()
 

--- a/tableUtils.lua
+++ b/tableUtils.lua
@@ -38,6 +38,12 @@ function tableUtils.filter(tab, filter)
   return filteredTable 
 end 
  
+-- returns all elements in a new table that fulfill the filter condition 
+function tableUtils.subtractTable(tab, otherTable) 
+  local result = tableUtils.filter(tab, function (value) return tableUtils.contains(otherTable, value) == false end)
+  return result
+end 
+ 
 -- returns true if the table contains at least one value that fulfills the condition, otherwise false 
 function tableUtils.trueForAny(tab, condition) 
   for _, value in pairs(tab) do 
@@ -106,6 +112,12 @@ function tableUtils.getRandomElement(tab)
       end
     end
   end
+end
+
+-- Randomly grabs a value from the table skipping the given values
+function tableUtils.getRandomElementExcludingValues(tab, values) 
+  local pairedTable = tableUtils.subtractTable(tab, values)
+  return tableUtils.getRandomElement(pairedTable)
 end
  
 -- returns all keys of a table, sorted using the standard comparator to account for sequence based tables 

--- a/tableUtilsTest.lua
+++ b/tableUtilsTest.lua
@@ -108,6 +108,42 @@ local function testTableFilterDict()
   logger.trace("passed test testTableFilterDict")
 end
 
+
+local function testTableSubtractTable()
+  local testData = getTestDataList()
+  local excludes = {{row = 2, column = 1, color = 3},{row = 2, column = 2, color = 3}}
+  local expected = {
+    {row = 1, column = 1, color = 2},
+    {row = 1, column = 2, color = 1},
+    {row = 3, column = 1, color = 4}
+  }
+
+  local filteredTable = tableUtils.subtractTable(testData, excludes)
+  assert(#filteredTable == 3)
+  for i = 1, #expected do
+    assert(deep_content_equal(filteredTable[i], expected[i]))
+  end
+
+  logger.trace("passed test testTableSubtractTable")
+end
+
+local function testTableDictSubtractTable()
+  local testData = getTestDataDict()
+  local excludes = { "330000" }
+  local expected = {}
+  expected["row1"] = "210000"
+  expected["row3"] = "400000"
+
+  local filteredTable = tableUtils.subtractTable(testData, excludes)
+  
+  assert(tableUtils.length(filteredTable) == 2)
+  for key, _ in pairs(expected) do
+    assert(deep_content_equal(filteredTable[key], expected[key]))
+  end
+
+  logger.trace("passed test testTableDictSubtractTable")
+end
+
 local function testTableTrueForAnyList()
   local testData = getTestDataList()
   assert(
@@ -371,6 +407,8 @@ end
 testTableGetKeys()
 testTableTrueForAllList()
 testTableTrueForAllDict()
+testTableSubtractTable()
+testTableDictSubtractTable()
 testTableTrueForAnyList()
 testTableTrueForAnyDict()
 testTableContainsList()
@@ -388,3 +426,34 @@ testTableMapDict()
 testRandomElementEmpty()
 testRandomElementList()
 testRandomElementDict()
+
+-- Proves that getRandomElementExcludingValues evenly distributes
+-- local testData = {key1 = "bob", key2 = "jerry", key3 = "tim"}
+
+-- local results = {}
+-- for _, value in pairs(testData) do
+--   results[value] = 0
+-- end
+-- for _ = 1, 1000 do
+--   local result = tableUtils.getRandomElementExcludingValues(testData, {"jerry"})
+--   results[result] = results[result] + 1
+-- end
+
+-- for index, value in pairs(results) do
+--   print(index .. " - " .. value)
+-- end
+
+-- testData = {1, 2, 3, 4}
+
+-- local results = {}
+-- for _, value in pairs(testData) do
+--   results[value] = 0
+-- end
+-- for _ = 1, 1000 do
+--   local result = tableUtils.getRandomElementExcludingValues(testData, {1})
+--   results[result] = results[result] + 1
+-- end
+
+-- for index, value in ipairs(results) do
+--   print(index .. " - " .. value)
+-- end


### PR DESCRIPTION
This is just a proof of concept
I know its gonna need to be redone on scene refactor if we decide it will conflict too much.
Gets the underlying functions for random with exclusion.

@Endaris refreshBasedOnOwnMods(msg.opponent_settings} is weird... it's modifying the message, not the player settings, I think thats a bug?