### PR TITLE
Implement super select on sceneRefactor branch

### DIFF
--- a/character.lua
+++ b/character.lua
@@ -157,6 +157,10 @@ function Character.is_bundle(self)
   return #self.sub_characters > 1
 end
 
+function Character:canSuperSelect()
+  return (self.panels and panels[self.panels]) or (self.stage and stages[self.stage])
+end
+
 
 -- GRAPHICS
 

--- a/consts.lua
+++ b/consts.lua
@@ -38,8 +38,8 @@ consts.SERVER_SAVE_DIRECTORY = "servers/"
 consts.LEGACY_SERVER_LOCATION = "18.188.43.50"
 consts.SERVER_LOCATION = "panelattack.com"
 
-consts.SUPER_SELECTION_DURATION = 30 -- frames (reminder: 60 frames per sec)
-consts.SUPER_SELECTION_ENABLE_RATIO = 0.3 -- ratio at which super enable is considered started (cancelling it won't validate a character)
+consts.SUPER_SELECTION_DURATION = 0.5 -- seconds
+consts.SUPER_SELECTION_START = 0.1 -- time held at which super enable is considered started
 
 consts.DEFAULT_THEME_DIRECTORY = "Panel Attack Modern"
 

--- a/inputManager.lua
+++ b/inputManager.lua
@@ -250,6 +250,7 @@ function inputManager:mousePressed(x, y, button)
   if not self.mouse.isDown[button] and not self.mouse.isPressed[button] then
     self.mouse.isDown[button] = KEY_CHANGE.DETECTED
   end
+  x, y = GAME:transform_coordinates(x, y)
   self.mouse.x = x
   self.mouse.y = y
 end
@@ -258,11 +259,13 @@ function inputManager:mouseReleased(x, y, button)
   self.mouse.isDown[button] = KEY_CHANGE.NONE
   self.mouse.isPressed[button] = KEY_CHANGE.NONE
   self.mouse.isUp[button] = KEY_CHANGE.DETECTED
+  x, y = GAME:transform_coordinates(x, y)
   self.mouse.x = x
   self.mouse.y = y
 end
 
 function inputManager:mouseMoved(x, y)
+  x, y = GAME:transform_coordinates(x, y)
   self.mouse.x = x
   self.mouse.y = y
 end

--- a/main.lua
+++ b/main.lua
@@ -104,6 +104,7 @@ function love.update(dt)
 
   inputManager:update(dt)
   inputFieldManager.update()
+  touchHandler:update(dt)
 
   local status, err = xpcall(function() GAME:update(dt) end, debug.traceback)
   if not status then

--- a/scenes/CharacterSelect.lua
+++ b/scenes/CharacterSelect.lua
@@ -15,6 +15,7 @@ local Focusable = require("ui.Focusable")
 local ImageContainer = require("ui.ImageContainer")
 local Label = require("ui.Label")
 local BoolSelector = require("ui.BoolSelector")
+local tableUtils = require("tableUtils")
 
 -- @module CharacterSelect
 -- The character select screen scene
@@ -194,8 +195,10 @@ function CharacterSelect:getCharacterButtons()
       local character = characters[self.characterId]
       if inputSource and inputSource.player then
         player = inputSource.player
-      else
+      elseif tableUtils.contains(GAME.battleRoom.players, GAME.localPlayer) then
          player = GAME.localPlayer
+      else
+        return
       end
       play_optional_sfx(themes[config.theme].sounds.menu_validate)
       if character:canSuperSelect() and holdTime > consts.SUPER_SELECTION_START + consts.SUPER_SELECTION_DURATION then

--- a/scenes/CharacterSelect.lua
+++ b/scenes/CharacterSelect.lua
@@ -195,7 +195,7 @@ function CharacterSelect:getCharacterButtons()
       local character = characters[self.characterId]
       if inputSource and inputSource.player then
         player = inputSource.player
-      elseif tableUtils.contains(GAME.battleRoom.players, GAME.localPlayer) then
+      elseif tableUtils.trueForAny(GAME.battleRoom.players, function(p) return p == GAME.localPlayer end) then
          player = GAME.localPlayer
       else
         return

--- a/tableUtils.lua
+++ b/tableUtils.lua
@@ -82,16 +82,17 @@ function tableUtils.insertListAt(list, position, tab)
     table.insert(list, position, tab[i])
   end
 end
- 
--- returns true if the table contains the given element, otherwise false 
-function tableUtils.contains(tab, element) 
-  return tableUtils.trueForAny( 
-    tab, 
-    function(tabElement) 
-      return deep_content_equal(tabElement, element) 
-    end 
-  ) 
-end 
+
+-- returns true if the table contains the given element or an identical copy of it, otherwise false 
+-- may result in a deathloop if there are recursive references
+function tableUtils.contains(tab, element)
+  return tableUtils.trueForAny(
+    tab,
+    function(tabElement)
+      return deep_content_equal(tabElement, element)
+    end
+  )
+end
  
 -- appends an element to a table only if it does not contain the element yet 
 -- 

--- a/ui/Button.lua
+++ b/ui/Button.lua
@@ -33,10 +33,10 @@ function Button:onTouch(x, y)
   self.backgroundColor[4] = 1
 end
 
-function Button:onRelease(x, y)
+function Button:onRelease(x, y, timeHeld)
   self.backgroundColor[4] = 0.7
   if self:inBounds(x, y) then
-    self:onClick()
+    self:onClick(timeHeld)
   end
 end
 

--- a/ui/Button.lua
+++ b/ui/Button.lua
@@ -36,7 +36,8 @@ end
 function Button:onRelease(x, y, timeHeld)
   self.backgroundColor[4] = 0.7
   if self:inBounds(x, y) then
-    self:onClick(timeHeld)
+    -- first argument non-self of onClick is the input source to accomodate inputs via controllers from different players
+    self:onClick(nil, timeHeld)
   end
 end
 

--- a/ui/GridCursor.lua
+++ b/ui/GridCursor.lua
@@ -131,9 +131,9 @@ function GridCursor:drawSelf()
   end
 end
 
-function GridCursor:receiveInputs(inputs)
+function GridCursor:receiveInputs(inputs, dt)
   if self.focused then
-    self.focused:receiveInputs(inputs)
+    self.focused:receiveInputs(inputs, dt, self)
   elseif inputs.isDown["Swap2"] then
     self:escapeCallback()
   elseif inputs:isPressedWithRepeat("Left", consts.KEY_DELAY, consts.KEY_REPEAT_PERIOD) then

--- a/ui/ImageContainer.lua
+++ b/ui/ImageContainer.lua
@@ -34,6 +34,8 @@ end
 
 function ImageContainer:onResize()
   self.scale = math.min(self.width / self.imageWidth, self.height / self.imageHeight)
+  self.width = self.imageWidth * self.scale
+  self.height = self.imageHeight * self.scale
 end
 
 function ImageContainer:drawSelf()

--- a/ui/MultiPlayerSelectionWrapper.lua
+++ b/ui/MultiPlayerSelectionWrapper.lua
@@ -25,8 +25,8 @@ function MultiPlayerSelectionWrapper:addElement(uiElement, player)
 end
 
 -- the parent makes sure this is only called while focused
-function MultiPlayerSelectionWrapper:receiveInputs(inputs)
-  self.wrappedElements[inputs.usedByPlayer]:receiveInputs(inputs)
+function MultiPlayerSelectionWrapper:receiveInputs(inputs, dt)
+  self.wrappedElements[inputs.usedByPlayer]:receiveInputs(inputs, dt)
 end
 
 function MultiPlayerSelectionWrapper:drawSelf()

--- a/ui/Touchable.lua
+++ b/ui/Touchable.lua
@@ -42,7 +42,7 @@ local function canBeTouched(uiElement)
   end
   -- any touchable element is expected to implement at least one touch callback for the touch handler
   assert(uiElement.onTouch
-    --or uiElement.onHold
+    or uiElement.onHold
     or uiElement.onDrag
     or uiElement.onRelease
   )


### PR DESCRIPTION
Closes #1053 

# Hold controls
## Touch
As a requirement this implements an `onHold` function for the touch handler to be able to update the super select shader during the hold process with touch inputs.
The hold time is extended every frame the touched element was held without moving while still being within the bounds of the originally touched element, meaning you can cancel a touch by moving away before releasing.
## Keyboard/Controller
As a requirement it extends all mentions of `receiveInputs` by a `dt` argument to update the super select shader during the hold process with keyboard/controller inputs. (With the exception of end consumers who do not care for the `dt`)

# Functional differences
Other than beta's super select, this one still counts as a click if the super selection was finished, allowing us to show the super select image much sooner without impacting regular click functionality, giving more visibility to the feature. 100ms felt like a fair start (I think before it was 160ms?) but I imagine we could lower it even a bit further given that the hold is an entire half-second.