### PR TITLE
Dynamically lock player inputs on sceneRefactor branch

### DIFF
--- a/BattleRoom.lua
+++ b/BattleRoom.lua
@@ -217,15 +217,17 @@ end
 
 function BattleRoom:refreshReadyStates()
   -- ready should probably be a battleRoom prop, not a player prop? at least for local player(s)?
-  for playerNumber = 1, #self.players do
-    self.players[playerNumber].ready = tableUtils.trueForAll(self.players, function(p)
-      -- everyone finished loaded or isLocal (in which case BattleRoom.allAssetsLoaded covers that)
-      return (p.hasLoaded or p.isLocal)
+  for _, player in ipairs(self.players) do
+    player.ready = tableUtils.trueForAll(self.players, function(p)
+      -- everyone finished loading or isLocal (in which case BattleRoom.allAssetsLoaded covers that)
+      return (p.settings.hasLoaded or p.isLocal)
       -- everyone actually wants to start
       and p.settings.wantsReady
-      -- every local player has an input configuration assigned
-      and (p.isLocal and p.human and p.inputConfiguration.usedByPlayer)
-    end) and self.allAssetsLoaded
+    end)
+    -- all needed assets for players are loaded
+    and self.allAssetsLoaded
+    -- every local human player has an input configuration assigned
+    and ((player.isLocal and player.human and player.inputConfiguration.usedByPlayer ~= nil) or (player.isLocal and not player.human))
   end
 end
 

--- a/BattleRoom.lua
+++ b/BattleRoom.lua
@@ -354,6 +354,21 @@ function BattleRoom:assignInputConfigurations()
     localPlayers[1]:subscribe(localPlayers[1], "wantsReady", self.updateInputConfigurationForPlayer)
   elseif #localPlayers > 1 then
     self.tryLockInputs = true
+    local validInputConfigurationCount = 0
+    -- assert that there are enough valid input configurations actually configured
+    for _, inputConfiguration in ipairs(GAME.input.inputConfigurations) do
+      if inputConfiguration["Swap1"] then
+        validInputConfigurationCount = validInputConfigurationCount + 1
+      end
+    end
+    if validInputConfigurationCount < #localPlayers then
+      local messageText = "There are more local players than input configurations configured." ..
+      "\nPlease configure enough input configurations and try again"
+      local nextScene = sceneManager:createScene("MainMenu")
+      local transition = MessageTransition(GAME.timer, 5, sceneManager.activeScene, nextScene, messageText)
+      sceneManager:switchToScene(nextScene, transition)
+      self:shutdown()
+    end
   end
 end
 
@@ -426,6 +441,7 @@ function BattleRoom:shutdown()
   end
   stop_the_music()
   self:shutdownNetwork()
+  self.shutdown = true
   GAME:initializeLocalPlayer()
   GAME.battleRoom = nil
   self = nil

--- a/BattleRoom.lua
+++ b/BattleRoom.lua
@@ -327,7 +327,8 @@ function BattleRoom:startLoadingNewAssets()
 end
 
 -- updates a player's input configuration
--- only has a result when it is either meant to unlock or any unclaimed inputConfiguration is in use on that frame
+-- if lock is true it tries to claim the first unclaim inputConfiguration for which a key is down (may not claim any)
+-- if lock is false it unclaims the player's current inputConfiguration
 function BattleRoom.updateInputConfigurationForPlayer(player, lock)
   if lock then
     for _, inputConfiguration in ipairs(GAME.input.inputConfigurations) do
@@ -342,6 +343,7 @@ function BattleRoom.updateInputConfigurationForPlayer(player, lock)
   end
 end
 
+-- sets up the process to get an input configuration assigned for every local player
 function BattleRoom:assignInputConfigurations()
   local localPlayers = {}
   for i = 1, #self.players do
@@ -367,7 +369,7 @@ function BattleRoom:assignInputConfigurations()
     self:shutdown()
   else
     if #localPlayers == 1 then
-      -- lock the inputConfiguration whenever the player readies up
+      -- lock the inputConfiguration whenever the player readies up (and release it when they unready)
       -- the ready up press guarantees that at least 1 input config has a key down
       localPlayers[1]:subscribe(localPlayers[1], "wantsReady", self.updateInputConfigurationForPlayer)
     elseif #localPlayers > 1 then
@@ -378,7 +380,7 @@ function BattleRoom:assignInputConfigurations()
   end
 end
 
--- tries to assign input configurations for all local players based on currently used inputs
+-- tries to assign unclaimed input configurations for all local players based on currently used inputs
 function BattleRoom:tryAssignInputConfigurations()
   if self.tryLockInputs then
     for _, player in ipairs(self.players) do

--- a/BattleRoom.lua
+++ b/BattleRoom.lua
@@ -451,7 +451,7 @@ function BattleRoom:shutdown()
   end
   stop_the_music()
   self:shutdownNetwork()
-  self.shutdown = true
+  self.hasShutdown = true
   GAME:initializeLocalPlayer()
   GAME.battleRoom = nil
   self = nil

--- a/ChallengeMode.lua
+++ b/ChallengeMode.lua
@@ -185,6 +185,12 @@ function ChallengeMode:onMatchEnded(match)
     self:reportLocalGameResult(winners)
   end
 
+  for _, player in ipairs(self.players) do
+    if player.human then
+      player:setWantsReady(false)
+    end
+  end
+
   if match.aborted then
   -- match:deinit is the responsibility of the one switching out of the game scene
     match:deinit()

--- a/ChallengeMode.lua
+++ b/ChallengeMode.lua
@@ -20,6 +20,7 @@ local ChallengeMode =
     self:addPlayer(GAME.localPlayer)
     self.player = ChallengeModePlayer(#self.players + 1)
     self:addPlayer(self.player)
+    self:assignInputConfigurations()
     self:setStage(stageIndex or 1)
   end,
   BattleRoom

--- a/Player.lua
+++ b/Player.lua
@@ -37,8 +37,8 @@ local Player = class(function(self, name, publicId, isLocal)
   self.playerNumber = nil
   self.isLocal = isLocal or false
   -- a player has only one configuration at a time
-  -- this is either keys or a single input configuration
-  self.inputConfiguration = input.allKeys
+  -- this is either everything or a single input configuration
+  self.inputConfiguration = input
   self.subscriptionList = util.getWeaklyKeyedTable()
   self.human = true
 end,
@@ -198,7 +198,7 @@ end
 
 function Player:unrestrictInputs()
   self.inputConfiguration.usedByPlayer = nil
-  self.inputConfiguration = input.allKeys
+  self.inputConfiguration = input
 end
 
 function Player.getLocalPlayer()

--- a/inputManager.lua
+++ b/inputManager.lua
@@ -290,7 +290,7 @@ end
 
 function inputManager:isPressedWithRepeat(key, delay, repeatPeriod, inputs)
   if not inputs then
-    inputs = self.allKeys
+    inputs = self
   end
 
   return isPressedWithRepeat(inputs, key, delay, repeatPeriod)

--- a/scenes/MainMenu.lua
+++ b/scenes/MainMenu.lua
@@ -82,8 +82,11 @@ local menuItems = {
     end, {""})
   }, {
     createMainMenuButton("mm_2_vs_local", function()
-      GAME.battleRoom = BattleRoom.createLocalFromGameMode(GameModes.getPreset("TWO_PLAYER_VS"))
-      switchToScene(CharacterSelect2p())
+      local battleRoom = BattleRoom.createLocalFromGameMode(GameModes.getPreset("TWO_PLAYER_VS"))
+      if not battleRoom.shutdown then
+        GAME.battleRoom = battleRoom
+        switchToScene(CharacterSelect2p())
+      end
     end)
   }, {
     createMainMenuButton("mm_replay_browser", function()

--- a/scenes/MainMenu.lua
+++ b/scenes/MainMenu.lua
@@ -83,7 +83,7 @@ local menuItems = {
   }, {
     createMainMenuButton("mm_2_vs_local", function()
       local battleRoom = BattleRoom.createLocalFromGameMode(GameModes.getPreset("TWO_PLAYER_VS"))
-      if not battleRoom.shutdown then
+      if not battleRoom.hasShutdown then
         GAME.battleRoom = battleRoom
         switchToScene(CharacterSelect2p())
       end

--- a/scenes/Transitions/MessageTransition.lua
+++ b/scenes/Transitions/MessageTransition.lua
@@ -5,7 +5,7 @@ local input = require("inputManager")
 
 local MessageTransition = class(function(transition, startTime, duration, oldScene, newScene, message)
   transition.message = message
-  transition.label = Label({text = message, hAlign = "center"})
+  transition.label = Label({text = message, hAlign = "center", vAlign = "center"})
   transition.uiRoot:addChild(transition.label)
 end, Transition)
 
@@ -19,15 +19,7 @@ function MessageTransition:updateScenes(dt)
 end
 
 function MessageTransition:draw()
-  local alpha = 1
-  if self.progress > 0.9 then
-    alpha = 1 - (self.progress - 0.9) * 10
-  elseif self.progress < 0.1 then
-    alpha = self.progress * 10
-  end
-  love.graphics.setColor(1, 1, 1, alpha)
-  self.label:draw()
-  love.graphics.setColor(1, 1, 1, 1)
+  self.uiRoot:draw()
 end
 
 return MessageTransition


### PR DESCRIPTION
Implements #1054 according to the description.
Additionally there is a check for input assignment where the client is redirected to the main menu if there aren't enough inputConfigurations for all players.