### PR TITLE
Fix shortcuts and challenge mode replays

### DIFF
--- a/AttackEngine.lua
+++ b/AttackEngine.lua
@@ -32,6 +32,7 @@ AttackEngine =
     -- The table of AttackPattern objects this engine will run through.
     self.attackPatterns = {}
     self:addAttackPatternsFromTable(attackSettings.attackPatterns)
+    self.attackSettings = attackSettings
 
     -- the clock to control the continuity of the sending process
     self.clock = 0

--- a/ChallengeMode.lua
+++ b/ChallengeMode.lua
@@ -208,8 +208,6 @@ function ChallengeMode:setStage(index)
   local stageSettings = self.stages[self.stageIndex]
   self.player.settings.attackEngineSettings = stageSettings.attackSettings
   self.player.settings.healthSettings = stageSettings.healthSettings
-  -- for replay display
-  self.player.settings.stageIndex = self.stageIndex
   if stageSettings.characterId then
     self.player:setCharacter(stageSettings.characterId)
   else

--- a/ChallengeMode.lua
+++ b/ChallengeMode.lua
@@ -13,12 +13,14 @@ local ChallengeMode =
   function(self, difficulty, stageIndex)
     self.mode = GameModes.getPreset("ONE_PLAYER_CHALLENGE")
     self.stages = self:createStages(difficulty)
+    self.difficulty = difficulty
     self.difficultyName = loc("challenge_difficulty_" .. difficulty)
     self.continues = 0
     self.expendedTime = 0
 
     self:addPlayer(GAME.localPlayer)
     self.player = ChallengeModePlayer(#self.players + 1)
+    self.player.settings.difficulty = difficulty
     self:addPlayer(self.player)
     self:assignInputConfigurations()
     self:setStage(stageIndex or 1)
@@ -140,16 +142,8 @@ function ChallengeMode:recordStageResult(winners, gameLength)
     if winners[1] == self.player then
       self.continues = self.continues + 1
     else
-      self.stageIndex = self.stageIndex + 1
-      if self.stages[self.stageIndex] then
-        local stageSettings = self.stages[self.stageIndex]
-        self.player.settings.attackEngineSettings = stageSettings.attackSettings
-        self.player.settings.healthSettings = stageSettings.healthSettings
-        if stageSettings.characterId then
-          self.player:setCharacter(stageSettings.characterId)
-        else
-          self.player:setCharacterForStage(self.stageIndex)
-        end
+      if self.stages[self.stageIndex + 1] then
+        self:setStage(self.stageIndex + 1)
       else
         -- completed!
         local scene = sceneManager:createScene("MainMenu")
@@ -211,10 +205,17 @@ function ChallengeMode:setStage(index)
   self.stageIndex = index
   GAME.localPlayer:setLevel(self.stages[index].playerLevel)
 
-  self.player:setCharacterForStage(index)
+  local stageSettings = self.stages[self.stageIndex]
+  self.player.settings.attackEngineSettings = stageSettings.attackSettings
+  self.player.settings.healthSettings = stageSettings.healthSettings
+  -- for replay display
+  self.player.settings.stageIndex = self.stageIndex
+  if stageSettings.characterId then
+    self.player:setCharacter(stageSettings.characterId)
+  else
+    self.player:setCharacterForStage(self.stageIndex)
+  end
   self.player:setStage("")
-  self.player.settings.healthSettings = self.stages[index].healthSettings
-  self.player.settings.attackEngineSettings = self.stages[index].attackSettings
 end
 
 return ChallengeMode

--- a/ChallengeModePlayer.lua
+++ b/ChallengeModePlayer.lua
@@ -3,6 +3,7 @@ local class = require("class")
 local SimulatedStack = require("SimulatedStack")
 
 local ChallengeModePlayer = class(function(self, playerNumber)
+  self.name = "Challenger"
   self.playerNumber = playerNumber
   self.isLocal = true
   self.settings.attackEngineSettings = nil
@@ -44,6 +45,7 @@ function ChallengeModePlayer:createStackFromSettings(match, which)
   simulatedStack:addAttackEngine(self.settings.attackEngineSettings, true)
   simulatedStack:addHealth(self.settings.healthSettings)
   self.stack = simulatedStack
+  simulatedStack.player = self
 
   return simulatedStack
 end
@@ -63,6 +65,8 @@ function ChallengeModePlayer.createFromReplayPlayer(replayPlayer, playerNumber)
   player.settings.attackEngineSettings = replayPlayer.settings.attackEngineSettings
   player.settings.healthSettings = replayPlayer.settings.healthSettings
   player.settings.characterId = CharacterLoader.resolveCharacterSelection(replayPlayer.settings.characterId)
+  player.settings.stageIndex = replayPlayer.settings.stageIndex
+  player.settings.difficulty = replayPlayer.settings.difficulty
   player.isLocal = false
   return player
 end

--- a/ChallengeModePlayer.lua
+++ b/ChallengeModePlayer.lua
@@ -65,7 +65,6 @@ function ChallengeModePlayer.createFromReplayPlayer(replayPlayer, playerNumber)
   player.settings.attackEngineSettings = replayPlayer.settings.attackEngineSettings
   player.settings.healthSettings = replayPlayer.settings.healthSettings
   player.settings.characterId = CharacterLoader.resolveCharacterSelection(replayPlayer.settings.characterId)
-  player.settings.stageIndex = replayPlayer.settings.stageIndex
   player.settings.difficulty = replayPlayer.settings.difficulty
   player.isLocal = false
   return player

--- a/Health.lua
+++ b/Health.lua
@@ -17,10 +17,6 @@ Health =
   end
 )
 
-function Health:deinit()
-
-end
-
 function Health:run()
   -- Increment rise speed if needed
   if self.clock > 0 and self.clock % (15 * 60) == 0 then

--- a/Shortcuts.lua
+++ b/Shortcuts.lua
@@ -41,14 +41,16 @@ local function refreshDesignHelper()
 end
 
 local function handleCopy()
-  local stacks = {}
-  if GAME.battleRoom and GAME.battleRoom.match and GAME.battleRoom.match.P1 then
-    local match = GAME.battleRoom.match
+  if sceneManager.activeScene and sceneManager.activeScene.match and sceneManager.activeScene.match.P1 then
+    local stacks = {}
+    local match = sceneManager.activeScene.match
 
     for i = 1, #match.players do
       local player = match.players[i]
-      stacks["P" .. i] = player.stack:toPuzzleInfo()
-      stacks["P" .. i]["Player"] = player.name
+      if player.stack.toPuzzleInfo then
+        stacks["P" .. i] = player.stack:toPuzzleInfo()
+        stacks["P" .. i]["Player"] = player.name
+      end
     end
 
     if tableUtils.length(stacks) > 0 then
@@ -59,36 +61,40 @@ local function handleCopy()
 end
 
 local function handleDumpAttackPattern(playerNumber)
-  if GAME.battleRoom and GAME.battleRoom.match and GAME.battleRoom.match.players[playerNumber] then
-    local player = GAME.battleRoom.match.players[playerNumber]
+  if sceneManager.activeScene and sceneManager.activeScene.match then
+    local player = sceneManager.activeScene.match.players[playerNumber]
 
-    if player.stack then
+    if player and player.stack then
       local data, state = player.stack:getAttackPatternData()
-      data.extraInfo.playerName = player.name
       saveJSONToPath(data, state, "dumpAttackPattern.json")
       return true
     end
   end
-
 end
 
 local function modifyWinCounts(functionIndex)
   if GAME.battleRoom then
-    if functionIndex == 1 then -- Add to P1's win count
-      GAME.battleRoom.modifiedWinCounts[1] = math.max(0, GAME.battleRoom.modifiedWinCounts[1] + 1)
+    local players = GAME.battleRoom.players
+    if players[1] then
+      if functionIndex == 1 then -- Add to P1's win count
+        players[1].modifiedWins = math.max(0, players[1].modifiedWins + 1)
+      end
+      if functionIndex == 2 then -- Subtract from P1's win count
+        players[1].modifiedWins = math.max(0, players[1].modifiedWins - 1)
+      end
     end
-    if functionIndex == 2 then -- Subtract from P1's win count
-      GAME.battleRoom.modifiedWinCounts[1] = math.max(0, GAME.battleRoom.modifiedWinCounts[1] - 1)
-    end
-    if functionIndex == 3 then -- Add to P2's win count
-      GAME.battleRoom.modifiedWinCounts[2] = math.max(0, GAME.battleRoom.modifiedWinCounts[2] + 1)
-    end
-    if functionIndex == 4 then -- Subtract from P2's win count
-      GAME.battleRoom.modifiedWinCounts[2] = math.max(0, GAME.battleRoom.modifiedWinCounts[2] - 1)
+    if players[2] then
+      if functionIndex == 3 then -- Add to P2's win count
+        players[2].modifiedWins = math.max(0, players[2].modifiedWins + 1)
+      end
+      if functionIndex == 4 then -- Subtract from P2's win count
+        players[2].modifiedWins = math.max(0, players[2].modifiedWins - 1)
+      end
     end
     if functionIndex == 5 then -- Reset key
-      GAME.battleRoom.modifiedWinCounts[1] = 0
-      GAME.battleRoom.modifiedWinCounts[2] = 0
+      for i = 1, #players do
+        players[i].modifiedWins = 0
+      end
     end
   end
 end

--- a/SimulatedStack.lua
+++ b/SimulatedStack.lua
@@ -254,12 +254,23 @@ function SimulatedStack:drawMultibar()
   self:drawAbsoluteMultibar(0, 0)
 end
 
+-- in the long run we should have all quads organized in a Stack.quads table
+-- with access then being self.quads.speed to access the current self.speedQuads
+-- that way deinit could be implemented generically in StackBase
 function SimulatedStack:deinit()
   self.healthQuad:release()
   self.stackHeightQuad:release()
-  if self.healthEngine then
-    -- need to merge beta to get Health:deinit()
-    -- self.healthEngine:deinit()
+  for _, quad in ipairs(self.speedQuads) do
+    GraphicsUtil:releaseQuad(quad)
+  end
+  for _, quad in ipairs(self.wins_quads) do
+    GraphicsUtil:releaseQuad(quad)
+  end
+  for _, quad in ipairs(self.difficultyQuads) do
+    GraphicsUtil:releaseQuad(quad)
+  end
+  for _, quad in ipairs(self.stageQuads) do
+    GraphicsUtil:releaseQuad(quad)
   end
 end
 

--- a/SimulatedStack.lua
+++ b/SimulatedStack.lua
@@ -245,7 +245,9 @@ end
 
 function SimulatedStack:drawLevel()
   -- no level
-  -- drawing stageIndex would be a) redundant with human player win count and b) not offset nicely because level is an image, not a number
+  -- thought about drawing stage number here but it would be
+  -- a) redundant with human player win count
+  -- b) not offset nicely because level is an image, not a number
 end
 
 function SimulatedStack:drawMultibar()

--- a/SimulatedStack.lua
+++ b/SimulatedStack.lua
@@ -8,19 +8,21 @@ local GFX_SCALE = consts.GFX_SCALE
 require("queue")
 
 -- A simulated stack sends attacks and takes damage from a player, it "loses" if it takes too many attacks.
-SimulatedStack =
-  class(
-  function(self, arguments)
-    self.panels_dir = config.panels
-    self.max_runs_per_frame = 1
-    self.multiBarFrameCount = 240
+SimulatedStack = class(function(self, arguments)
+  self.panels_dir = config.panels
+  self.max_runs_per_frame = 1
+  self.multiBarFrameCount = 240
 
-    self.stackHeightQuad = GraphicsUtil:newRecycledQuad(0, 0, themes[config.theme].images.IMG_multibar_shake_bar:getWidth(), themes[config.theme].images.IMG_multibar_shake_bar:getHeight(), themes[config.theme].images.IMG_multibar_shake_bar:getWidth(), themes[config.theme].images.IMG_multibar_shake_bar:getHeight())
-    -- somehow bad things happen if this is called in the base class constructor instead
-    self:moveForRenderIndex(self.which)
-  end,
-  StackBase
-)
+  self.stackHeightQuad = GraphicsUtil:newRecycledQuad(0, 0, themes[config.theme].images.IMG_multibar_shake_bar:getWidth(),
+                                                      themes[config.theme].images.IMG_multibar_shake_bar:getHeight(),
+                                                      themes[config.theme].images.IMG_multibar_shake_bar:getWidth(),
+                                                      themes[config.theme].images.IMG_multibar_shake_bar:getHeight())
+  self.speedQuads = {}
+  self.stageQuads = {}
+  self.difficultyQuads = {}
+  -- somehow bad things happen if this is called in the base class constructor instead
+  self:moveForRenderIndex(self.which)
+end, StackBase)
 
 -- adds an attack engine to the simulated opponent
 function SimulatedStack:addAttackEngine(attackSettings, shouldPlayAttackSfx)
@@ -36,12 +38,8 @@ function SimulatedStack:addAttackEngine(attackSettings, shouldPlayAttackSfx)
 end
 
 function SimulatedStack:addHealth(healthSettings)
-  self.healthEngine = Health(
-    healthSettings.framesToppedOutToLose,
-    healthSettings.lineClearGPM,
-    healthSettings.lineHeightToKill,
-    healthSettings.riseSpeed
-  )
+  self.healthEngine = Health(healthSettings.framesToppedOutToLose, healthSettings.lineClearGPM, healthSettings.lineHeightToKill,
+                             healthSettings.riseSpeed)
   self.health = healthSettings.framesToppedOutToLose
 end
 
@@ -100,7 +98,7 @@ function SimulatedStack:drawDebug()
     gprintf("Clock " .. self.clock, drawX, drawY)
 
     drawY = drawY + padding
-    gprintf("P" .. self.which .." Ended?: " .. tostring(self:game_ended()), drawX, drawY)
+    gprintf("P" .. self.which .. " Ended?: " .. tostring(self:game_ended()), drawX, drawY)
   end
 end
 
@@ -126,7 +124,8 @@ function SimulatedStack:renderStackHeight()
   local yScale = (self.canvas:getHeight() - 4) / themes[config.theme].images.IMG_multibar_shake_bar:getHeight() * percentage
 
   love.graphics.setColor(1, 1, 1, 0.6)
-  love.graphics.draw(themes[config.theme].images.IMG_multibar_shake_bar, self.stackHeightQuad, 4, self.canvas:getHeight(), 0, xScale, - yScale)
+  love.graphics.draw(themes[config.theme].images.IMG_multibar_shake_bar, self.stackHeightQuad, 4, self.canvas:getHeight(), 0, xScale,
+                     -yScale)
   love.graphics.setColor(1, 1, 1, 1)
 end
 
@@ -215,12 +214,50 @@ function SimulatedStack:setGarbageTarget(garbageTarget)
   end
 end
 
+function SimulatedStack:getAttackPatternData()
+  if self.attackEngine then
+    return self.attackEngine.attackSettings
+  end
+end
+
+function SimulatedStack:drawScore()
+  -- no fake score for simulated stacks yet
+  -- could be fun for fake 1p time attack vs later on, lol
+end
+
+function SimulatedStack:drawSpeed()
+  if self.healthEngine then
+    self:drawLabel(themes[config.theme].images["IMG_speed_" .. self.which .. "P"], themes[config.theme].speedLabel_Pos,
+                   themes[config.theme].speedLabel_Scale)
+    self:drawNumber(self.healthEngine.currentRiseSpeed, self.speedQuads, themes[config.theme].speed_Pos, themes[config.theme].speed_Scale)
+  end
+end
+
+-- rating is substituted for challenge mode difficulty here
+function SimulatedStack:drawRating()
+  if self.player.settings.difficulty then
+    self:drawLabel(themes[config.theme].images["IMG_rating_" .. self.which .. "P"], themes[config.theme].ratingLabel_Pos,
+                   themes[config.theme].ratingLabel_Scale, true)
+    self:drawNumber(self.player.settings.difficulty, self.difficultyQuads, themes[config.theme].rating_Pos,
+                    themes[config.theme].rating_Scale)
+  end
+end
+
+function SimulatedStack:drawLevel()
+  -- no level
+  -- drawing stageIndex would be a) redundant with human player win count and b) not offset nicely because level is an image, not a number
+end
+
+function SimulatedStack:drawMultibar()
+  self:drawAbsoluteMultibar(0, 0)
+end
+
 function SimulatedStack:deinit()
   self.healthQuad:release()
   self.stackHeightQuad:release()
   if self.healthEngine then
     -- need to merge beta to get Health:deinit()
-    --self.healthEngine:deinit()
+    -- self.healthEngine:deinit()
   end
 end
 

--- a/StackBase.lua
+++ b/StackBase.lua
@@ -29,6 +29,7 @@ local StackBase = class(function(self, args)
   -- graphics
   self.canvas = love.graphics.newCanvas(104 * GFX_SCALE, 204 * GFX_SCALE, {dpiscale = GAME:newCanvasSnappedScale()})
   self.healthQuad = GraphicsUtil:newRecycledQuad(0, 0, themes[config.theme].images.IMG_healthbar:getWidth(), themes[config.theme].images.IMG_healthbar:getHeight(), themes[config.theme].images.IMG_healthbar:getWidth(), themes[config.theme].images.IMG_healthbar:getHeight())
+  self.wins_quads = {}
 end)
 
 -- Provides the X origin to draw an element of the stack
@@ -152,7 +153,7 @@ function StackBase:drawNumber(number, quads, themePositionOffset, scale, cameFro
   end
   local x = self:elementOriginXWithOffset(themePositionOffset, cameFromLegacyScoreOffset)
   local y = self:elementOriginYWithOffset(themePositionOffset, cameFromLegacyScoreOffset)
-  GraphicsUtil.draw_number(number, self.theme.images["IMG_number_atlas_" .. self.which .. "P"], quads, x, y, scale, "center")
+  GraphicsUtil.draw_number(number, themes[config.theme].images["IMG_number_atlas_" .. self.which .. "P"], quads, x, y, scale, "center")
 end
 
 function StackBase:drawString(string, themePositionOffset, cameFromLegacyScoreOffset, fontSize)
@@ -164,7 +165,7 @@ function StackBase:drawString(string, themePositionOffset, cameFromLegacyScoreOf
   
   local limit = consts.CANVAS_WIDTH - x
   local alignment = "left"
-  if self.theme:offsetsAreFixed() then
+  if themes[config.theme]:offsetsAreFixed() then
     if self.which == 1 then
       limit = x
       x = 0
@@ -361,6 +362,16 @@ function StackBase:drawAbsoluteMultibar(stop_time, shake_time)
       end
     end
   end
+end
+
+function StackBase:drawPlayerName()
+  local username = (self.player.name or "")
+  self:drawString(username, themes[config.theme].name_Pos, true, themes[config.theme].name_Font_Size)
+end
+
+function StackBase:drawWinCount()
+  self:drawLabel(themes[config.theme].images.IMG_wins, themes[config.theme].winLabel_Pos, themes[config.theme].winLabel_Scale, true)
+  self:drawNumber(self.player:getWinCountForDisplay(), self.wins_quads, themes[config.theme].win_Pos, themes[config.theme].win_Scale, true)
 end
 
 --------------------------------

--- a/engine.lua
+++ b/engine.lua
@@ -272,7 +272,6 @@ Stack =
     s.move_quads = {}
     s.score_quads = {}
     s.speed_quads = {}
-    s.wins_quads = {}
     s.rating_quads = {}
     s.level_quad = GraphicsUtil:newRecycledQuad(0, 0, s.theme.images.levelNumberAtlas[s.which].charWidth, s.theme.images.levelNumberAtlas[s.which].charHeight, s.theme.images.levelNumberAtlas[s.which].image:getDimensions())
     s.multi_prestopQuad = GraphicsUtil:newRecycledQuad(0, 0, s.theme.images.IMG_multibar_prestop_bar:getWidth(), s.theme.images.IMG_multibar_prestop_bar:getHeight(), s.theme.images.IMG_multibar_prestop_bar:getWidth(), s.theme.images.IMG_multibar_prestop_bar:getHeight())
@@ -1971,7 +1970,7 @@ function Stack:getAttackPatternData()
 
   local data = {}
   data.extraInfo = {}
-  data.extraInfo.playerName = "Player"
+  data.extraInfo.playerName = self.player.name
   data.extraInfo.gpm = self.analytic:getRoundedGPM(self.clock) or 0
   data.extraInfo.matchLength = " "
   if self.game_stopwatch and tonumber(self.game_stopwatch) then

--- a/graphics.lua
+++ b/graphics.lua
@@ -468,20 +468,6 @@ function Stack.render(self)
   self:drawDebug()
 end
 
-function Stack:drawPlayerName()
-  local username = (self.match.players[self.which].name or "")
-  self:drawString(username, self.theme.name_Pos, true, self.theme.name_Font_Size)
-end
-
-function Stack:drawWinCount()
-  if self.match.P2 == nil then 
-    return -- need multiple players for showing wins to make sense
-  end
-
-  self:drawLabel(self.theme.images.IMG_wins, self.theme.winLabel_Pos, self.theme.winLabel_Scale, true)
-  self:drawNumber(self.player:getWinCountForDisplay(), self.wins_quads, self.theme.win_Pos, self.theme.win_Scale, true)
-end
-
 function Stack:drawRating()
   local match = self.match
   local roomRatings = match.room_ratings

--- a/replay.lua
+++ b/replay.lua
@@ -44,7 +44,9 @@ function Replay.createNewReplay(match)
         inputMethod = player.settings.inputMethod,
         allowAdjacentColors = player.stack.allowAdjacentColors,
         attackEngineSettings = player.settings.attackEngineSettings,
-        healthSettings = player.settings.healthSettings
+        healthSettings = player.settings.healthSettings,
+        -- challenge mode stage
+        stageIndex = player.settings.stageIndex
       },
       human = player.human
     }

--- a/replay.lua
+++ b/replay.lua
@@ -45,8 +45,6 @@ function Replay.createNewReplay(match)
         allowAdjacentColors = player.stack.allowAdjacentColors,
         attackEngineSettings = player.settings.attackEngineSettings,
         healthSettings = player.settings.healthSettings,
-        -- challenge mode stage
-        stageIndex = player.settings.stageIndex
       },
       human = player.human
     }

--- a/scenes/Game1pChallenge.lua
+++ b/scenes/Game1pChallenge.lua
@@ -24,7 +24,7 @@ sceneManager:addScene(Game1pChallenge)
 
 function Game1pChallenge:onMatchEnded(match)
   Replay.finalizeAndWriteReplay("Challenge Mode",
-                                "diff-" .. GAME.battleRoom.difficulty .. "-stage-" .. match.players[2].settings.stageIndex, match.replay)
+                                "diff-" .. GAME.battleRoom.difficulty .. "-stage-" .. GAME.battleRoom.stageIndex, match.replay)
 end
 
 function Game1pChallenge:drawHUD()

--- a/scenes/Game1pChallenge.lua
+++ b/scenes/Game1pChallenge.lua
@@ -23,7 +23,8 @@ Game1pChallenge.name = "Game1pChallenge"
 sceneManager:addScene(Game1pChallenge)
 
 function Game1pChallenge:onMatchEnded(match)
-  Replay.finalizeAndWriteReplay("Challenge Mode", "stage-" .. match.players[1].wins + 1, match.replay)
+  Replay.finalizeAndWriteReplay("Challenge Mode",
+                                "diff-" .. GAME.battleRoom.difficulty .. "-stage-" .. match.players[2].settings.stageIndex, match.replay)
 end
 
 function Game1pChallenge:drawHUD()

--- a/scenes/Game1pChallenge.lua
+++ b/scenes/Game1pChallenge.lua
@@ -92,7 +92,7 @@ function Game1pChallenge:drawTimeSplits(xPosition, yPosition)
     local time = self.stages[i].expendedTime
     local currentStageTime = time
     local isCurrentStage = i == self.stageIndex
-    if isCurrentStage and self.match.P1:game_ended() == false then
+    if isCurrentStage and self.match:hasEnded() == false then
       currentStageTime = currentStageTime + (self.match.P1.game_stopwatch or 0)
     end
     totalTime = totalTime + currentStageTime

--- a/scenes/GameBase.lua
+++ b/scenes/GameBase.lua
@@ -243,7 +243,9 @@ end
 
 function GameBase:drawHUD()
   for i, stack in ipairs(self.match.stacks) do
-    stack:drawMoveCount()
+    if stack.puzzle then
+      stack:drawMoveCount()
+    end
     if config.show_ingame_infos then
       if not self.puzzle then
         stack:drawScore()
@@ -260,7 +262,9 @@ function GameBase:drawHUD()
     end
 
     stack:drawLevel()
-    stack:drawAnalyticData()
+    if stack.analytic then
+      stack:drawAnalyticData()
+    end
   end
 end
 


### PR DESCRIPTION
Originally intended to just fix #1056 
For the puzzle string it achieves that by checking whether the stack implements that function.
For attack patterns it achieves that by saving the attackSettings on the AttackEngine and have the SimulatedStack return them if it has an attackEngine.
In both cases the copy now checks the active scene for a match rather than the active battleRoom to guarantee that it works with replays (which don't have a battleRoom).
Win count modifications only work with battleRooms as there is no reasonable use case for modifying them in replays, no fun allowed.

So this is going a bit overboard (sorry!) because in the process I realised that I broke challenge mode replays when I abstracted the HUD to be different due to `GameBase:drawHUD` calling on graphics functions that `SimulatedStack` didn't have and I needed this to work for testing.
So I did a bunch of changes in ChallengeMode, ChallengeModePlayer, SimulatedStack and StackBase to give `SimulatedStack` a reasonable default drawing behaviour for replays with the regular HUD:
- the difficulty of the challenge mode is now saved on the ChallengeMode, ChallengeModePlayer and replays
- the difficulty is displayed in place of the rating as a number rather than the full name because it is impossible to fit the localized text with theme offsets
- drawWinCount and drawPlayerName have been moved from `Stack` to `StackBase` because every MatchParticipant is expected to have name/wins fields
- I ran a format document on StackBase/SimulatedStack, not many changes from that but a few
- I noticed that `ChallengeMode.setStage` was mostly redundant with the branch of `ChallengeMode.recordStageResult` that dealt with the human player winning. So I consolidated them into setStage and call it instead.
- This also fixes a bug in challenge mode where the stage time in the HUD would display double its actual value once the match ended with a human player win.