### PR TITLE
Pop FX updates

### DIFF
--- a/SimulatedOpponent.lua
+++ b/SimulatedOpponent.lua
@@ -8,6 +8,8 @@ SimulatedOpponent =
     self.character = character
     self.frameOriginX = positionX / GFX_SCALE
     self.frameOriginY = positionY / GFX_SCALE
+    self.panelOriginX = self.frameOriginX
+    self.panelOriginY = self.frameOriginY
     self.mirror_x = mirror
     self.clock = 0
   end

--- a/character.lua
+++ b/character.lua
@@ -78,7 +78,7 @@ function Character.json_init(self)
 
     --popfx_burstRotate
     if read_data.popfx_burstRotate and type(read_data.popfx_burstRotate) == "boolean" then
-      self.popfx_burstRrotate = read_data.popfx_burstRotate
+      self.popfx_burstRotate = read_data.popfx_burstRotate
     end
 
     --popfx_type

--- a/consts.lua
+++ b/consts.lua
@@ -96,7 +96,7 @@ score_chain_TA = {  0,   50,   80,  150,  300,
 
 GFX_SCALE = 3
 
--- frames to use for the card animation
+-- frames of the card animation and corresponding y offset
 card_animation = {false,
    -1, 0, 1, 2, 3, 4, 4, 5, 5, 6,
    6, 7, 7, 8, 8, 8, 9, 9, 9, 9,

--- a/engine.lua
+++ b/engine.lua
@@ -1170,9 +1170,11 @@ function Stack.enqueue_card(self, chain, x, y, n)
   local card_burstAtlas = nil
   local card_burstParticle = nil
   if config.popfx == true then
-    card_burstAtlas = characters[self.character].images["burst"]
-    local card_burstFrameDimension = card_burstAtlas:getWidth() / 9
-    card_burstParticle = GraphicsUtil:newRecycledQuad(card_burstFrameDimension, 0, card_burstFrameDimension, card_burstFrameDimension, card_burstAtlas:getDimensions())
+    if characters[self.character].popfx_style == "burst" or characters[self.character].popfx_style == "fadeburst" then
+      card_burstAtlas = characters[self.character].images["burst"]
+      local card_burstFrameDimension = card_burstAtlas:getWidth() / 9
+      card_burstParticle = GraphicsUtil:newRecycledQuad(card_burstFrameDimension, 0, card_burstFrameDimension, card_burstFrameDimension, card_burstAtlas:getDimensions())
+    end
   end
   self.card_q:push({frame = 1, chain = chain, x = x, y = y, n = n, burstAtlas = card_burstAtlas, burstParticle = card_burstParticle})
 end
@@ -1217,7 +1219,6 @@ function Stack.enqueue_popfx(self, x, y, popsize)
       fadeFrameDimension = fadeFrameDimension,
       fadeParticle = fadeParticle,
       bigParticle = bigParticle,
-      bigTimer = 0,
       popsize = popsize,
       x = x,
       y = y

--- a/engine/checkMatches.lua
+++ b/engine/checkMatches.lua
@@ -399,13 +399,8 @@ function Stack:pushGarbage(coordinate, isChain, comboSize, metalCount)
   local combo_pieces = combo_garbage[comboSize]
   for i = 1, #combo_pieces do
     if self.garbageTarget and self.telegraph then
-      local rowOffset = 0
-      if isChain then
-        -- If we did a chain also, we need to enqueue the attack graphic one row lower cause thats where the combo card will be.
-        rowOffset = 1
-      end
       -- Give out combo garbage based on the lookup table, even if we already made shock garbage,
-      self.telegraph:push({width = combo_pieces[i], height = 1, isMetal = false, isChain = false}, coordinate.column, coordinate.row + rowOffset,
+      self.telegraph:push({width = combo_pieces[i], height = 1, isMetal = false, isChain = false}, coordinate.column, coordinate.row,
                           self.clock)
     end
     self:recordComboHistory(self.clock, combo_pieces[i], 1, false)
@@ -413,7 +408,12 @@ function Stack:pushGarbage(coordinate, isChain, comboSize, metalCount)
 
   if isChain then
     if self.garbageTarget and self.telegraph then
-      self.telegraph:push({width = 6, height = self.chain_counter - 1, isMetal = false, isChain = true}, coordinate.column, coordinate.row,
+      local rowOffset = 0
+      if #combo_pieces > 0 then
+        -- If we did a combo also, we need to enqueue the attack graphic one row higher cause thats where the chain card will be.
+        rowOffset = 1
+      end
+      self.telegraph:push({width = 6, height = self.chain_counter - 1, isMetal = false, isChain = true}, coordinate.column, coordinate.row +  rowOffset,
                           self.clock)
     end
     self:recordChainHistory()
@@ -502,7 +502,7 @@ end
 
 function Stack:enqueueCards(attackGfxOrigin, isChainLink, comboSize)
   if comboSize > 3 and isChainLink then
-    -- we did a combo AND a chain; cards should not overlap so offset the attack origin to one row above for the chain
+    -- we did a combo AND a chain; cards should not overlap so offset the chain card to one row above the combo card
     self:enqueue_card(false, attackGfxOrigin.column, attackGfxOrigin.row, comboSize)
     self:enqueue_card(true, attackGfxOrigin.column, attackGfxOrigin.row + 1, self.chain_counter)
   elseif comboSize > 3 then

--- a/engine/checkMatches.lua
+++ b/engine/checkMatches.lua
@@ -399,8 +399,13 @@ function Stack:pushGarbage(coordinate, isChain, comboSize, metalCount)
   local combo_pieces = combo_garbage[comboSize]
   for i = 1, #combo_pieces do
     if self.garbageTarget and self.telegraph then
+      local rowOffset = 0
+      if isChain then
+        -- If we did a chain also, we need to enqueue the attack graphic one row lower cause thats where the combo card will be.
+        rowOffset = 1
+      end
       -- Give out combo garbage based on the lookup table, even if we already made shock garbage,
-      self.telegraph:push({width = combo_pieces[i], height = 1, isMetal = false, isChain = false}, coordinate.column, coordinate.row,
+      self.telegraph:push({width = combo_pieces[i], height = 1, isMetal = false, isChain = false}, coordinate.column, coordinate.row + rowOffset,
                           self.clock)
     end
     self:recordComboHistory(self.clock, combo_pieces[i], 1, false)

--- a/engine/telegraph.lua
+++ b/engine/telegraph.lua
@@ -13,6 +13,8 @@ Telegraph = class(function(self, sender)
   assert(sender.clock ~= nil, "telegraph sender invalid")
   assert(sender.frameOriginX ~= nil, "telegraph sender invalid")
   assert(sender.frameOriginY ~= nil, "telegraph sender invalid")
+  assert(sender.panelOriginX ~= nil, "telegraph sender invalid")
+  assert(sender.panelOriginY ~= nil, "telegraph sender invalid")
   assert(sender.character ~= nil, "telegraph sender invalid")
 
   -- Stores the actual queue of garbages in the telegraph but not queued long enough to exceed the "stoppers"
@@ -309,23 +311,32 @@ function Telegraph:telegraphRenderXPosition(index)
   return result
 end
 
-function Telegraph:attackStartFrame()
+function Telegraph:attackAnimationStartFrame()
+  -- Traditionally this would be right after #card_animation
+  -- but PA doesn't keep attacks in the telegraph quite as long.
+  -- This is so they can go over the network sooner for rollback.
+  -- As a result we need to start the attack animation sooner so it has time
+  -- to get to and stay in the telegraph
   return 1
 end
 
-function Telegraph:telegraphLoopAttackPosition(garbage_block, frames_since_earned)
+function Telegraph:attackAnimationEndFrame()
+  return GARBAGE_TRANSIT_TIME
+end
 
-  local resultX, resultY = garbage_block.origin_x, garbage_block.origin_y
+function Telegraph:telegraphLoopAttackPosition(attack, garbage_block, frames_since_earned)
 
-  if frames_since_earned > self:attackStartFrame() + #telegraph_attack_animation_speed then
-    frames_since_earned = self:attackStartFrame() + #telegraph_attack_animation_speed
+  local resultX, resultY = attack.origin_x, attack.origin_y
+
+  if frames_since_earned > self:attackAnimationStartFrame() + #telegraph_attack_animation_speed then
+    frames_since_earned = self:attackAnimationStartFrame() + #telegraph_attack_animation_speed
   end
 
   -- We can't gaurantee every frame was rendered, so we must calculate the exact location regardless of how many frames happened.
   -- TODO make this more performant?
-  for frame=1, frames_since_earned - self:attackStartFrame() do
-    resultX = resultX + telegraph_attack_animation[garbage_block.direction][frame].dx
-    resultY = resultY + telegraph_attack_animation[garbage_block.direction][frame].dy
+  for frame=1, frames_since_earned - self:attackAnimationStartFrame() do
+    resultX = resultX + telegraph_attack_animation[attack.direction][frame].dx
+    resultY = resultY + telegraph_attack_animation[attack.direction][frame].dy
   end
 
   return resultX, resultY
@@ -343,9 +354,9 @@ function Telegraph:render()
 
     for timeAttackInteracts, attacks_this_frame in pairs(telegraph_to_render.attacks) do
       local frames_since_earned = telegraph_to_render.sender.clock - timeAttackInteracts
-      if frames_since_earned <= self:attackStartFrame() then
+      if frames_since_earned < self:attackAnimationStartFrame() then
         --don't draw anything yet, card animation is still in progress.
-      elseif frames_since_earned >= GARBAGE_TRANSIT_TIME then
+      elseif frames_since_earned >= self:attackAnimationEndFrame() then
         --Attack is done, remove.
         telegraph_to_render.attacks[timeAttackInteracts] = nil
       else
@@ -354,35 +365,39 @@ function Telegraph:render()
             garbage_block.destination_x = self:telegraphRenderXPosition(telegraph_to_render.garbage_queue:get_idx_of_garbage(unpack(garbage_block))) + (TELEGRAPH_BLOCK_WIDTH / 2) - ((TELEGRAPH_BLOCK_WIDTH / orig_atk_w) / 2)
             garbage_block.destination_y = garbage_block.destination_y or (telegraph_to_render.originY - TELEGRAPH_PADDING)
             
-            if not garbage_block.origin_x or not garbage_block.origin_y then
-              garbage_block.origin_x = (attack.origin_col-1) * 16 + telegraph_to_render.sender.frameOriginX
-              garbage_block.origin_y = (11-attack.origin_row) * 16 + telegraph_to_render.sender.frameOriginY + (telegraph_to_render.sender.displacement or 0) - card_animation[#card_animation]
-              garbage_block.x = garbage_block.origin_x
-              garbage_block.y = garbage_block.origin_y
-              garbage_block.direction = garbage_block.direction or math.sign(garbage_block.destination_x - garbage_block.origin_x) --should give -1 for left, or 1 for right
+            if not attack.origin_x or not attack.origin_y then
+              attack.origin_x = (attack.origin_col-1) * 16 + telegraph_to_render.sender.panelOriginX
+              attack.origin_y = (11-attack.origin_row) * 16 + telegraph_to_render.sender.panelOriginY + (telegraph_to_render.sender.displacement or 0) - (card_animation[frames_since_earned] or 0)
+              attack.direction = math.sign(garbage_block.destination_x - attack.origin_x) --should give -1 for left, or 1 for right
             end
 
-            if frames_since_earned <= self:attackStartFrame() + #telegraph_attack_animation_speed then
+            if self.sender.opacityForFrame then
+              set_color(1, 1, 1, self.sender:opacityForFrame(frames_since_earned, 1, 8))
+            end
+
+            if frames_since_earned <= self:attackAnimationStartFrame() + #telegraph_attack_animation_speed then
               --draw telegraph attack animation, little loop down and to the side of origin.
       
               -- We can't gaurantee every frame was rendered, so we must calculate the exact location regardless of how many frames happened.
               -- TODO make this more performant?
-              garbage_block.x, garbage_block.y = telegraph_to_render:telegraphLoopAttackPosition(garbage_block, frames_since_earned)
+              local garbageBlockX, garbageBlockY = telegraph_to_render:telegraphLoopAttackPosition(attack, garbage_block, frames_since_earned)
 
-              draw(characters[senderCharacter].telegraph_garbage_images["attack"], garbage_block.x, garbage_block.y, 0, atk_scale, atk_scale)
+              draw(characters[senderCharacter].telegraph_garbage_images["attack"], garbageBlockX, garbageBlockY, 0, atk_scale, atk_scale)
             else
               --move toward destination
 
-              local loopX, loopY = telegraph_to_render:telegraphLoopAttackPosition(garbage_block, frames_since_earned)
-              local framesHappened = frames_since_earned - (self:attackStartFrame() + #telegraph_attack_animation_speed)
-              local totalFrames = GARBAGE_TRANSIT_TIME - (self:attackStartFrame() + #telegraph_attack_animation_speed)
+              local loopX, loopY = telegraph_to_render:telegraphLoopAttackPosition(attack, garbage_block, frames_since_earned)
+              local framesHappened = frames_since_earned - (self:attackAnimationStartFrame() + #telegraph_attack_animation_speed)
+              local totalFrames = self:attackAnimationEndFrame() - (self:attackAnimationStartFrame() + #telegraph_attack_animation_speed)
               local percent =  framesHappened / totalFrames
 
-              garbage_block.x = loopX + percent * (garbage_block.destination_x - loopX)
-              garbage_block.y = loopY + percent * (garbage_block.destination_y - loopY)
+              local garbageBlockX = loopX + percent * (garbage_block.destination_x - loopX)
+              local garbageBlockY = loopY + percent * (garbage_block.destination_y - loopY)
 
-              draw(characters[senderCharacter].telegraph_garbage_images["attack"], garbage_block.x, garbage_block.y, 0, atk_scale, atk_scale)
+              draw(characters[senderCharacter].telegraph_garbage_images["attack"], garbageBlockX, garbageBlockY, 0, atk_scale, atk_scale)
             end
+
+            set_color(1, 1, 1, 1)
           end
         end
       end
@@ -398,12 +413,12 @@ function Telegraph:render()
       draw(characters[senderCharacter].telegraph_garbage_images["attack"], telegraph_to_render:telegraphRenderXPosition(-1), telegraph_to_render.originY, 0, atk_scale, atk_scale)
     end
 
-    --then draw the telegraph's garbage queue, leaving an empty space until such a time as the attack arrives (earned_frame-GARBAGE_TRANSIT_TIME)
+    --then draw the telegraph's garbage queue, leaving an empty space until such a time as the attack arrives
     local g_queue_to_draw = telegraph_to_render.garbage_queue:makeCopy()
     local current_block = g_queue_to_draw:pop()
     local draw_y = telegraph_to_render.originY
     local drewChain = false
-    local attackAnimationLength = GARBAGE_TRANSIT_TIME
+    local attackAnimationLength = self:attackAnimationEndFrame()
     if not config.renderAttacks then
       attackAnimationLength = 0
     end

--- a/globals.lua
+++ b/globals.lua
@@ -13,12 +13,12 @@ server_queue = ServerQueue()
 
 score_mode = SCOREMODE_TA
  
-GARBAGE_TELEGRAPH_TIME = 45 -- the amount of time the garbage stays in the telegraph after getting there from the attack animation
 GARBAGE_DELAY_LAND_TIME = 60 -- this is the amount of time after garbage leaves the telegraph before it can land on the opponent
 						  -- a higher value allows less rollback to happen and makes lag have less of an impact on the game
 						  -- technically this was 0 in classic games, but we are using this value to make rollback less noticable and match PA history
+GARBAGE_TELEGRAPH_TIME = 45 -- the amount of time the garbage stays in the telegraph after getting there from the attack animation
 GARBAGE_TRANSIT_TIME = 45 -- the amount of time the garbage attack animation plays before getting to the telegraph
-MAX_LAG = 200 + GARBAGE_TELEGRAPH_TIME -- maximum amount of lag before net games abort
+MAX_LAG = 155 + GARBAGE_TELEGRAPH_TIME + GARBAGE_TRANSIT_TIME -- maximum amount of lag before net games abort
 NAME_LENGTH_LIMIT = 16
 
 gfx_q = Queue()

--- a/match.lua
+++ b/match.lua
@@ -549,13 +549,11 @@ function Match.render(self)
         challengeMode:render()
       end
 
-      if self.battleRoom then
-        if P1 and P1.telegraph then
-          P1.telegraph:render()
-        end
-        if P2 and P2.telegraph then
-          P2.telegraph:render()
-        end
+      if P1 then
+        P1:drawTopLayers()
+      end
+      if P2 then
+        P2:drawTopLayers()
       end
 
       -- Draw VS HUD

--- a/readme_characters.md
+++ b/readme_characters.md
@@ -287,12 +287,10 @@ An icon will be display next to the character's name in character select if a fi
 
 ### PopFX configuration
 
-I vaguely remember there was something wrong with this documentation, so I'm leaving this out for now.
-
 #### popfx_style
 The style of popfx to use, options:
- "burst" (default) - Shows the burst image of the character coming out of panels and circling attack cards
- "fade" - Shows the fade image of the character as the matched panels disappear
+ "burst" (default) - Shows the burst image of the character coming out of panels and circling attack cards  
+ "fade" - Shows the fade image of the character as the matched panels disappear  
  "fadeburst" - Shows both the burst and fade animations
 
 #### popfx_burstRotate

--- a/readme_characters.md
+++ b/readme_characters.md
@@ -290,18 +290,20 @@ An icon will be display next to the character's name in character select if a fi
 I vaguely remember there was something wrong with this documentation, so I'm leaving this out for now.
 
 #### popfx_style
+The style of popfx to use, options:
+ "burst" (default) - Shows the burst image of the character coming out of panels and circling attack cards
+ "fade" - Shows the fade image of the character as the matched panels disappear
+ "fadeburst" - Shows both the burst and fade animations
 
-#### popfx_rotation
+#### popfx_burstRotate
+If this option set to true, the burst popfx up, down, left, and right particles rotate to point to the direction they are moving in.
+Default is false.
 
-#### burst_scale
+#### popfx_burstScale
+The scale of the burst popfx, default is 1, 2 means twice the size, 0.5 half the size, etc.
 
-#### fade_scale
-	PopFX options:
-	- (popfx_style): The style of popfx to use, options: "burst" (default), "fade", "fadeburst"
-	- (popfx_rotation): If this option set to true, the burst popfx up, down, left, and right particles rotate to point to the direction they are moving in. Default is false.
-	- (burst_scale): The scale of the burst popfx, default is 1, 2 means twice the size, 0.5 half the size, etc.
-	- (fade_scale): The scale of the fade popfx, default is 1, 2 means twice the size, 0.5 half the size, etc.
-
+#### popfx_fadeScale
+The scale of the fade popfx, default is 1, 2 means twice the size, 0.5 half the size, etc.
 
 -----------------------------------------------------------
 

--- a/readme_characters.md
+++ b/readme_characters.md
@@ -288,7 +288,7 @@ An icon will be display next to the character's name in character select if a fi
 ### PopFX configuration
 
 #### popfx_style
-The style of popfx to use, options:
+The style of popfx to use, options:  
  "burst" (default) - Shows the burst image of the character coming out of panels and circling attack cards  
  "fade" - Shows the fade image of the character as the matched panels disappear  
  "fadeburst" - Shows both the burst and fade animations


### PR DESCRIPTION
Not sure if we want to retarget this to scene refactor or not. I'm open to either.

This fixes a bunch of bugs with pop FX, and attack cards and also universally applies the same transparency algorithm we were using for cards to make popfx not get in the way of playing the game.

- Fixed a typo in popfx_burstRotate
- Fixed burst animation not circling card when "fadeburst" was used 
- Deleted bigTimer, randomMax, big_position  and popSize variables as they did nothing / unused 
- Updated the popfx radius calculation to closer match the inspirational games and be smoother 
- Updated the popfx to draw behind the cards and the attack animations behind the cards so you can always see the cards 
- Fixed a bug where the attack animation wouldn't come from the right spot if you did a combo chain on the same frame
- Fixed a bug where the attack animation would use the original chain spot when you grew a chain instead of the new spot 
- Fixed a bug where the attack animation was offset by the frame offset 
- Fixed a bunch of logic to allow the attack animation to start at a different offset, but ended up keeping it the same due to the short time needed to get it to the telegraph 
- Updated consts order and max lag now better documents the source of the number 
- Updated character documentation