### PR TITLE
Correctly detect game win for winning stack in vs

### DIFF
--- a/engine.lua
+++ b/engine.lua
@@ -1637,11 +1637,7 @@ function Stack:game_ended()
   if self.game_over_clock > 0 then
     return self.clock >= self.game_over_clock
   else
-    if #self.gameWinConditions > 0 then
-      return self:checkGameWin()
-    else
-      return false
-    end
+    return self:checkGameWin()
   end
 end
 
@@ -2270,5 +2266,11 @@ function Stack:checkGameWin()
       end
     end
   end
+
+  -- match is over and we didn't die so clearly we won
+  if self.match.ended and self.game_over_clock <= 0 then
+    return true
+  end
+
   return false
 end

--- a/graphics.lua
+++ b/graphics.lua
@@ -459,7 +459,7 @@ function Stack.render(self)
 
   -- Draw the cursor
   if self:game_ended() == false then
-    self:render_cursor()
+    self:render_cursor(shake)
   end
 
   self:drawCountdown()
@@ -487,7 +487,7 @@ function Stack:drawRating()
 end
 
 -- Draw the stacks cursor
-function Stack.render_cursor(self)
+function Stack:render_cursor(shake)
   if self.inputMethod == "touch" then
     if self.cur_row == 0 and self.cur_col == 0 then
       --no panel is touched, let's not draw the cursor
@@ -496,8 +496,6 @@ function Stack.render_cursor(self)
   end
 
   local cursorImage = self.theme.images.IMG_cursor[(floor(self.clock / 16) % 2) + 1]
-  local shake_idx = #shake_arr - self.shake_time
-  local shake = ceil((shake_arr[shake_idx] or 0) * 13)
   local desiredCursorWidth = 40
   local panelWidth = 16
   local scale_x = desiredCursorWidth / cursorImage:getWidth()


### PR DESCRIPTION
Fixes #1096 
I would have preferred solving this without a reference to `match` but the alternative would be to add a flag that is set by match on vs win. But for that to work seamlessly with rewind from death it would be necessary to add the flag to rollback and that doesn't seem worth it atm.