### PR TITLE
Scene refactor: Save inputs properly

### DIFF
--- a/FileUtils.lua
+++ b/FileUtils.lua
@@ -1,4 +1,3 @@
-local class = require("class")
 local logger = require("logger")
 
 local PREFIX_OF_IGNORED_DIRECTORIES = "__"

--- a/inputManager.lua
+++ b/inputManager.lua
@@ -379,4 +379,26 @@ function inputManager:importConfigurations(configurations)
   end
 end
 
+function inputManager:getKeyMapTable()
+  local keyMaps = {}
+  for i, inputConfig in ipairs(self.inputConfigurations) do
+    local keyMap = {}
+    keyMap["up"] = inputConfig["Up"]
+    keyMap["down"] = inputConfig["Down"]
+    keyMap["left"] = inputConfig["Left"]
+    keyMap["right"] = inputConfig["Right"]
+    keyMap["swap1"] = inputConfig["Swap1"]
+    keyMap["swap2"] = inputConfig["Swap2"]
+    keyMap["taunt_up"] = inputConfig["TauntUp"]
+    keyMap["taunt_down"] = inputConfig["TauntDown"]
+    keyMap["raise1"] = inputConfig["Raise1"]
+    keyMap["raise2"] = inputConfig["Raise2"]
+    keyMap["pause"] = inputConfig["Start"]
+
+    keyMaps[i] = keyMap
+  end
+
+  return keyMaps
+end
+
 return inputManager

--- a/inputManager.lua
+++ b/inputManager.lua
@@ -333,7 +333,7 @@ local function convertKey(key)
   return key
 end
 
-function inputManager:migrateInputConfigs(inputConfigs)
+function inputManager:mapInputConfigs(inputConfigs)
   local oldToNewKeyMap = {
     up = "Up",
     down = "Down",

--- a/save.lua
+++ b/save.lua
@@ -13,7 +13,7 @@ local save = {}
 function write_key_file()
   pcall(
     function()
-      local file = love.filesystem.newFile("keysV3.txt")
+      local file = love.filesystem.newFile("keysV2.txt")
       file:open("w")
       file:write(json.encode(inputManager.inputConfigurations))
       file:close()
@@ -23,30 +23,10 @@ end
 
 -- reads the "keys.txt" file
 function save.read_key_file()
-  local file = love.filesystem.newFile("keysV3.txt")
-  local ok, err = file:open("r")
-  local migrateInputs = false
-  
-  if not ok then
-    file = love.filesystem.newFile("keysV2.txt")
-    ok, err = file:open("r")
-    migrateInputs = true
-  end
-  
-  if not ok then
-    return inputManager.inputConfigurations
-  end
-  
-  local jsonInputConfig = file:read(file:getSize())
-  file:close()
-  
-  local inputConfigs = json.decode(jsonInputConfig)
-  
-  if migrateInputs then
-    -- migrate old input configs
-    inputConfigs = inputManager:migrateInputConfigs(inputConfigs)
-  end
-  
+  local inputConfigs = fileUtils.readJsonFile("keysV2.txt")
+
+  inputConfigs = inputManager:mapInputConfigs(inputConfigs)
+
   return inputConfigs
 end
 

--- a/save.lua
+++ b/save.lua
@@ -10,12 +10,12 @@ local logger = require("logger")
 local save = {}
 
 -- writes to the "keys.txt" file
-function write_key_file()
+function write_key_file(keymaps)
   pcall(
     function()
       local file = love.filesystem.newFile("keysV2.txt")
       file:open("w")
-      file:write(json.encode(inputManager.inputConfigurations))
+      file:write(json.encode(keymaps))
       file:close()
     end
   )

--- a/scenes/InputConfigMenu.lua
+++ b/scenes/InputConfigMenu.lua
@@ -76,7 +76,7 @@ function InputConfigMenu:updateKey(key, pressedKey, index)
   GAME.input.inputConfigurations[configIndex][key] = pressedKey
   local keyDisplayName = self:getKeyDisplayName(pressedKey)
   self.menu.menuItems[index + 1].children[2]:setText(keyDisplayName)
-  write_key_file()
+  write_key_file(GAME.input:getKeyMapTable())
 end
 
 function InputConfigMenu:setKey(key, index)
@@ -132,7 +132,7 @@ local function clearAllInputs(menuOptions)
     local keyName = loc("op_none")
     menuOptions[i + 1][2]:setText(keyName)
   end
-  write_key_file()
+  write_key_file(GAME.input:getKeyMapTable())
 end
 
 function InputConfigMenu:resetToDefault(menuOptions) 
@@ -149,7 +149,7 @@ function InputConfigMenu:resetToDefault(menuOptions)
     end
   end
   self:updateInputConfigMenuLabels(1)
-  write_key_file() 
+  write_key_file(GAME.input:getKeyMapTable())
 end
 
 local function exitMenu()


### PR DESCRIPTION
Implements #1070 
Since the inputConfigurations on GAME.input had too much bloat data to persist cleanly with just a json.encode (even before I added more), reading and writing key config required mapping for saving a sane config.
So I got rid of keysV3 and we're now performing a mapping on read and write respectively instead, allowing us to keep the same file format as before.