### PR TITLE
Scene refactor: Fix input fields

### DIFF
--- a/ui/inputFieldManager.lua
+++ b/ui/inputFieldManager.lua
@@ -13,15 +13,15 @@ function inputFieldManager.update()
     return
   end
 
-  if input:isPressedWithRepeat("backspace", consts.KEY_DELAY, consts.KEY_REPEAT_PERIOD)then
+  if input.allKeys:isPressedWithRepeat("backspace", consts.KEY_DELAY, consts.KEY_REPEAT_PERIOD)then
     inputFieldManager.selectedInputField:onBackspace()
   end
   
-  if input:isPressedWithRepeat("left", consts.KEY_DELAY, consts.KEY_REPEAT_PERIOD) then
+  if input.allKeys:isPressedWithRepeat("left", consts.KEY_DELAY, consts.KEY_REPEAT_PERIOD) then
     inputFieldManager.selectedInputField:onMoveCursor(-1)
   end
   
-  if input:isPressedWithRepeat("right", consts.KEY_DELAY, consts.KEY_REPEAT_PERIOD) then
+  if input.allKeys:isPressedWithRepeat("right", consts.KEY_DELAY, consts.KEY_REPEAT_PERIOD) then
     inputFieldManager.selectedInputField:onMoveCursor(1)
   end
 end


### PR DESCRIPTION
I noticed that I broke the backspace interaction on input fields when I changed the standard input set of `isPressedWithRepeat`.
So this fixes it by explicitly refering to `inputs.allKeys`.