### PR TITLE
SceneRefactor: Fix Saving of v3 Input Configs

### DIFF
--- a/inputManager.lua
+++ b/inputManager.lua
@@ -334,6 +334,20 @@ local function convertKey(key)
 end
 
 function inputManager:migrateInputConfigs(inputConfigs)
+  local oldToNewKeyMap = self:getOldToNewKeyMap()
+  if tableUtils.trueForAll(inputConfigs, function(inputConfig)
+    return not inputConfig["Start"]
+  end) then
+    for i, inputConfig in ipairs(inputConfigs) do
+      for oldKey, newKey in pairs(oldToNewKeyMap) do
+        inputConfigs[i][newKey] = convertKey(inputConfig[oldKey])
+      end
+    end
+  end
+  return inputConfigs
+end
+
+function inputManager:getOldToNewKeyMap()
   local oldToNewKeyMap = {
     up = "Up",
     down = "Down",
@@ -347,16 +361,20 @@ function inputManager:migrateInputConfigs(inputConfigs)
     raise2 = "Raise2",
     pause = "Start"
   }
-  if tableUtils.trueForAll(inputConfigs, function(inputConfig)
-    return not inputConfig["Start"]
-  end) then
-    for i, inputConfig in ipairs(inputConfigs) do
-      for oldKey, newKey in pairs(oldToNewKeyMap) do
-        inputConfigs[i][newKey] = convertKey(inputConfig[oldKey])
-      end
+
+  return oldToNewKeyMap
+end
+
+-- Gets only the saved keymaps from each input config
+function inputManager:getSaveKeyMap()
+  local result = {}
+  for i, inputConfig in ipairs(inputManager.inputConfigurations) do
+    result[i] = {}
+    for _, keyName in ipairs(consts.KEY_NAMES) do
+      result[i][keyName] = inputConfig[keyName]
     end
   end
-  return inputConfigs
+  return result
 end
 
 for i = 1, inputManager.maxConfigurations do

--- a/save.lua
+++ b/save.lua
@@ -15,7 +15,7 @@ function write_key_file()
     function()
       local file = love.filesystem.newFile("keysV3.txt")
       file:open("w")
-      file:write(json.encode(inputManager.inputConfigurations))
+      file:write(json.encode(inputManager:getSaveKeyMap()))
       file:close()
     end
   )


### PR DESCRIPTION
Fixes #1070 

We were saving the entire input config which has tons of functions and other things on it that wouldn't encode. Instead only encode the key constants.
Also did some cleanup.
We need to keep v3 as the controller name and hats have been changed slightly.