### PR TITLE
Challenge mode fixes

### DIFF
--- a/ChallengeMode.lua
+++ b/ChallengeMode.lua
@@ -168,9 +168,7 @@ function ChallengeMode:recordStageResult(winners, gameLength)
     end
   elseif #winners == 2 then
     -- tie, stay on the same stage
-    -- but since the player didn't lose, they shouldn't have to pay the timer
-    stage.expendedTime = stage.expendedTime - gameLength
-    self.expendedTime = self.expendedTime - gameLength
+    -- they don't lose a continue but their time still counts
   elseif #winners == 0 then
     -- this means an abort which is a LOSS because it's a local game and only manual abort is possible
     self.continues = self.continues + 1

--- a/ChallengeMode.lua
+++ b/ChallengeMode.lua
@@ -178,17 +178,18 @@ function ChallengeMode:recordStageResult(winners, gameLength)
 end
 
 function ChallengeMode:onMatchEnded(match)
-  -- TODO: call recordStageResult on top of what the regular BattleRoom does
   self.matchesPlayed = self.matchesPlayed + 1
 
   local winners = match:getWinners()
   -- an abort is always the responsibility of the local player in challenge mode
   -- so always record the result, even if it may have been an abort
-  local gameTime = match.clock
-  if match.doCountdown then
-    gameTime = gameTime - (consts.COUNTDOWN_START  + consts.COUNTDOWN_LENGTH)
+  local gameTime = 0
+  local stack = match.stacks[1]
+  if stack ~= nil and stack.game_stopwatch then
+    gameTime = stack.game_stopwatch
   end
   self:recordStageResult(winners, gameTime)
+
   if self.online and match:hasLocalPlayer() then
     self:reportLocalGameResult(winners)
   end

--- a/ChallengeMode.lua
+++ b/ChallengeMode.lua
@@ -144,7 +144,7 @@ function ChallengeMode:getAttackSettings(difficulty, stageIndex)
   return attackFile
 end
 
-function ChallengeMode:recordStageResult(winners, gameLength)
+function ChallengeMode:recordStageResult(winners, gameLength, aborted)
   local stage = self.stages[self.stageIndex]
   stage.expendedTime = stage.expendedTime + gameLength
   self.expendedTime = self.expendedTime + gameLength
@@ -167,8 +167,11 @@ function ChallengeMode:recordStageResult(winners, gameLength)
       end
     end
   elseif #winners == 2 then
-    -- tie, stay on the same stage
-    -- they don't lose a continue but their time still counts
+    -- tie, stay on the same stage and their time counts
+    if aborted then
+      -- they only lose a continue if the aborted, a real tie doesn't use a continue
+      self.continues = self.continues + 1
+    end
   elseif #winners == 0 then
     -- this means an abort which is a LOSS because it's a local game and only manual abort is possible
     self.continues = self.continues + 1
@@ -186,7 +189,7 @@ function ChallengeMode:onMatchEnded(match)
   if stack ~= nil and stack.game_stopwatch then
     gameTime = stack.game_stopwatch
   end
-  self:recordStageResult(winners, gameTime)
+  self:recordStageResult(winners, gameTime, match.aborted)
 
   if self.online and match:hasLocalPlayer() then
     self:reportLocalGameResult(winners)


### PR DESCRIPTION
Fix time going negative [#1133](https://github.com/panel-attack/panel-attack/issues/1133)

Keep time spent when you tie
From a speedrunning perspective I don't see any reason why you should get your time back and this was the previous behavior.

Fix not losing continues for abort