### PR TITLE
Revert stick physics

### DIFF
--- a/client/src/Game.lua
+++ b/client/src/Game.lua
@@ -48,7 +48,7 @@ local Game = class(
     self.server_queue = ServerQueue()
     self.main_menu_screen_pos = {consts.CANVAS_WIDTH / 2 - 108 + 50, consts.CANVAS_HEIGHT / 2 - 111}
     self.config = config
-    self.localization = Localization()
+    self.localization = Localization
     self.replay = {}
     self.currently_paused_tracks = {} -- list of tracks currently paused
     self.rich_presence = RichPresence()
@@ -106,7 +106,8 @@ end
 function Game:setupRoutine()
   -- loading various assets into the game
   coroutine.yield("Loading localization...")
-  Localization.init(localization)
+  Localization:init()
+  self.setLanguage(config.language_code)
   fileUtils.copyFile("docs/puzzles.txt", "puzzles/README.txt")
   
   coroutine.yield(loc("ld_theme"))
@@ -521,7 +522,7 @@ function Game:refreshCanvasAndImagesForNewScale()
   characters_reload_graphics()
   
   -- Reload loc to get the new font
-  localization:set_language(config.language_code)
+  self.setLanguage(config.language_code)
 end
 
 -- Transform from window coordinates to game coordinates
@@ -538,6 +539,28 @@ function Game:drawLoadingString(loadingString)
   local backgroundPadding = 10
   GraphicsUtil.drawRectangle("fill", consts.CANVAS_WIDTH / 2 - (textMaxWidth / 2) , y - backgroundPadding, textMaxWidth, textHeight, 0, 0, 0, 0.5)
   GraphicsUtil.printf(loadingString, x, y, consts.CANVAS_WIDTH, "center", nil, nil, 10)
+end
+
+function Game.setLanguage(lang_code)
+  for i, v in ipairs(Localization.codes) do
+    if v == lang_code then
+      Localization.lang_index = i
+      break
+    end
+  end
+  config.language_code = Localization.codes[Localization.lang_index]
+
+  if themes[config.theme] and themes[config.theme].font and themes[config.theme].font.path then
+    GraphicsUtil.setGlobalFont(themes[config.theme].font.path, themes[config.theme].font.size)
+  elseif config.language_code == "JP" then
+    GraphicsUtil.setGlobalFont("client/assets/fonts/jp.ttf", 14)
+  elseif config.language_code == "TH" then
+    GraphicsUtil.setGlobalFont("client/assets/fonts/th.otf", 14)
+  else
+    GraphicsUtil.setGlobalFont(nil, 12)
+  end
+
+  Localization:refresh_global_strings()
 end
 
 return Game

--- a/client/src/localization.lua
+++ b/client/src/localization.lua
@@ -5,18 +5,13 @@ local GraphicsUtil = require("client.src.graphics.graphics_util")
 local class = require("common.lib.class")
 
 -- Holds all the data for localizing the game
-Localization =
-  class(
-  function(self)
-    self.data = {}
-    self.langs = {}
-    self.codes = {}
-    self.lang_index = 1
-    self.init = false
-  end
-)
-
-localization = Localization()
+Localization = {
+    data = {},
+    langs = {},
+    codes = {},
+    lang_index = 1,
+    init = false,
+}
 
 function Localization.get_list_codes(self)
   return self.codes
@@ -28,28 +23,6 @@ end
 
 function Localization.refresh_global_strings(self)
   join_community_msg = loc("join_community") .. "\ndiscord." .. consts.SERVER_LOCATION
-end
-
-function Localization.set_language(self, lang_code)
-  for i, v in ipairs(self.codes) do
-    if v == lang_code then
-      self.lang_index = i
-      break
-    end
-  end
-  config.language_code = self.codes[self.lang_index]
-
-  if themes[config.theme] and themes[config.theme].font and themes[config.theme].font.path then
-    GraphicsUtil.setGlobalFont(themes[config.theme].font.path, themes[config.theme].font.size)
-  elseif config.language_code == "JP" then
-    GraphicsUtil.setGlobalFont("client/assets/fonts/jp.ttf", 14)
-  elseif config.language_code == "TH" then
-    GraphicsUtil.setGlobalFont("client/assets/fonts/th.otf", 14)
-  else
-    GraphicsUtil.setGlobalFont(nil, 12)
-  end
-
-  self:refresh_global_strings()
 end
 
 function Localization.init(self)
@@ -167,21 +140,19 @@ function Localization.init(self)
         print(a..": "..b)
       end
     end--]]
-  self:set_language(config.language_code)
 end
 
 -- Gets the localized string for a loc key
 function loc(text_key, ...)
-  local self = localization
-  local code = self.codes[self.lang_index]
+  local code = Localization.codes[Localization.lang_index]
 
-  if not code or not self.data[code] then
-    code = self.codes[1]
+  if not code or not Localization.data[code] then
+    code = Localization.codes[1]
   end
 
   local ret = nil
-  if self.init then
-    ret = self.data[code][text_key]
+  if Localization.init then
+    ret = Localization.data[code][text_key]
   end
 
   if ret then
@@ -198,3 +169,5 @@ function loc(text_key, ...)
 
   return ret
 end
+
+return Localization

--- a/client/src/scenes/OptionsMenu.lua
+++ b/client/src/scenes/OptionsMenu.lua
@@ -152,18 +152,18 @@ end
 function OptionsMenu:loadBaseMenu()
   local languageNumber
   local languageName = {}
-  for k, v in ipairs(localization:get_list_codes()) do
-    languageName[#languageName + 1] = {v, localization.data[v]["LANG"]}
-    if localization:get_language() == v then
+  for k, v in ipairs(Localization:get_list_codes()) do
+    languageName[#languageName + 1] = {v, Localization.data[v]["LANG"]}
+    if Localization:get_language() == v then
       languageNumber = k
     end
   end
   local languageLabels = {}
   for k, v in ipairs(languageName) do
     local lang = config.language_code
-    localization:set_language(v[1])
+    GAME.setLanguage(v[1])
     languageLabels[#languageLabels + 1] = Label({text = v[2], translate = false, width = 70, height = 25})
-    localization:set_language(lang)
+    GAME.setLanguage(lang)
   end
 
   local languageStepper = Stepper({
@@ -172,7 +172,7 @@ function OptionsMenu:loadBaseMenu()
     selectedIndex = languageNumber,
     onChange = function(value)
       GAME.theme:playMoveSfx()
-      localization:set_language(value[1])
+      GAME.setLanguage(value[1])
       self:updateMenuLanguage()
     end
   })

--- a/client/src/scenes/StartUp.lua
+++ b/client/src/scenes/StartUp.lua
@@ -2,8 +2,6 @@ local class = require("common.lib.class")
 local Scene = require("client.src.scenes.Scene")
 local consts = require("common.engine.consts")
 local GraphicsUtil = require("client.src.graphics.graphics_util")
-local TitleScreen = require("client.src.scenes.TitleScreen")
-local MainMenu = require("client.src.scenes.MainMenu")
 local logger = require("common.lib.logger")
 local fileUtils = require("client.src.FileUtils")
 
@@ -51,10 +49,11 @@ function StartUp:update(dt)
 
     if coroutine.status(self.setupRoutine) == "dead" then
       love.graphics.setFont(GraphicsUtil.getGlobalFont())
+      -- we need the indirection for the scenes here because startup initializes localization which following scenes need
       if themes[config.theme].images.bg_title then
-        GAME.navigationStack:replace(TitleScreen())
+        GAME.navigationStack:replace(require("client.src.scenes.TitleScreen")())
       else
-        GAME.navigationStack:replace(MainMenu())
+        GAME.navigationStack:replace(require("client.src.scenes.MainMenu")())
       end
     end
   end

--- a/common/engine/GameModes.lua
+++ b/common/engine/GameModes.lua
@@ -1,6 +1,3 @@
--- TODO: need to inverse this dependency, rich presence should instead be able to pull a loc based on game mode
-require("client.src.localization")
-
 local TIME_ATTACK_TIME = 120
 
 local GameModes = {}
@@ -23,7 +20,7 @@ local OnePlayerVsSelf = {
   style = Styles.MODERN,
   gameScene = "VsSelfGame",
   setupScene = "CharacterSelectVsSelf",
-  richPresenceLabel = loc("mm_1_vs"),
+  richPresenceLabel = "1p vs self", -- loc("mm_1_vs"),
 
   -- already known match properties
   playerCount = 1,
@@ -37,7 +34,7 @@ local OnePlayerTimeAttack = {
   style = Styles.CHOOSE,
   gameScene = "TimeAttackGame",
   setupScene = "TimeAttackMenu",
-  richPresenceLabel = loc("mm_1_time"),
+  richPresenceLabel = "Time Attack", -- loc("mm_1_time"),
 
   -- already known match properties
   playerCount = 1,
@@ -52,7 +49,7 @@ local OnePlayerEndless = {
   style = Styles.CHOOSE,
   gameScene = "EndlessGame",
   setupScene = "EndlessMenu",
-  richPresenceLabel = loc("mm_1_endless"),
+  richPresenceLabel = "Endless", -- loc("mm_1_endless"),
 
   -- already known match properties
   playerCount = 1,
@@ -66,7 +63,7 @@ local OnePlayerTraining = {
   style = Styles.MODERN,
   gameScene = "Game1pTraining",
   setupScene = "CharacterSelectVsSelf",
-  richPresenceLabel = loc("mm_1_training"),
+  richPresenceLabel = "Training", -- loc("mm_1_training"),
 
   -- already known match properties
   playerCount = 1,
@@ -79,7 +76,7 @@ local OnePlayerTraining = {
 local OnePlayerPuzzle = {
   -- flags for battleRoom to evaluate and in some cases offer UI for
   style = Styles.MODERN,
-  richPresenceLabel = loc("mm_1_puzzle"),
+  richPresenceLabel = "Puzzle", -- loc("mm_1_puzzle"),
   gameScene = "PuzzleGame",
   setupScene = "PuzzleMenu",
 
@@ -97,7 +94,7 @@ local OnePlayerChallenge = {
   style = Styles.MODERN,
   gameScene = "Game1pChallenge",
   setupScene = "CharacterSelectChallenge",
-  richPresenceLabel = loc("mm_1_challenge_mode"),
+  richPresenceLabel = "Challenge Mode", -- loc("mm_1_challenge_mode"),
 
   -- already known match properties
   playerCount = 1,
@@ -111,7 +108,7 @@ local TwoPlayerVersus = {
   style = Styles.MODERN,
   gameScene = "Game2pVs",
   setupScene = "CharacterSelect2p",
-  richPresenceLabel = loc("mm_2_vs"),
+  richPresenceLabel = "2p versus", -- loc("mm_2_vs"),
 
   -- already known match properties
   playerCount = 2,

--- a/common/engine/Replay.lua
+++ b/common/engine/Replay.lua
@@ -1,8 +1,6 @@
 local logger = require("common.lib.logger")
 local GameModes = require("common.engine.GameModes")
 local consts = require("common.engine.consts")
-local ReplayV1 = require("common.engine.replayV1")
-local ReplayV2 = require("common.engine.replayV2")
 local utf8 = require("common.lib.utf8Additions")
 local class = require("common.lib.class")
 require("common.lib.timezones")
@@ -90,9 +88,9 @@ function Replay.load(jsonData)
       jsonData.engineVersion = "046"
     end
     if not jsonData.replayVersion then
-      replay = ReplayV1.transform(jsonData)
+      replay = require("common.engine.replayV1").transform(jsonData)
     else
-      replay = ReplayV2.transform(jsonData)
+      replay = require("common.engine.replayV2").transform(jsonData)
     end
     replay.loadedFromFile = true
   end

--- a/common/lib/inputManager.lua
+++ b/common/lib/inputManager.lua
@@ -95,25 +95,61 @@ function inputManager:joystickReleased(joystick, button)
   self.allKeys.isUp[key] = KEY_CHANGE.DETECTED
 end
 
--- maps joysticks' analog sticks state to the appropriate input maps
-function inputManager:joystickToButtons()
-  for _, joystick in ipairs(love.joystick.getJoysticks()) do
-    for axisIndex = 1, joystick:getAxisCount() / 2 do
-      local dpadState = joystickManager:joystickToDPad(joystick, axisIndex * 2 - 1, axisIndex * 2)
-      for key, isPressed in pairs(dpadState) do
-        if isPressed then
-          if not self.allKeys.isDown[key] and not self.allKeys.isPressed[key] then
-            self.allKeys.isDown[key] = KEY_CHANGE.DETECTED
-          end
-        else
-          if self.allKeys.isDown[key] or self.allKeys.isPressed[key] then
-            self.allKeys.isUp[key] = KEY_CHANGE.DETECTED
-          end
-        end
-      end
+function inputManager:joystickaxis(joystick, axisIndex, value)
+  local stickIndex = math.floor((1 + axisIndex) / 2)
+  local direction
+
+  if axisIndex % 2 then
+    direction = "y"
+  else
+    direction = "x"
+  end
+
+  direction = direction .. stickIndex
+
+  local positiveKeybind = joystickManager:getJoystickButtonName(joystick, "+" .. direction)
+  local negativeKeybind = joystickManager:getJoystickButtonName(joystick, "-" .. direction)
+
+  if value > 0.5 then
+    if not self.allKeys.isDown[positiveKeybind] and not self.allKeys.isPressed[positiveKeybind] then
+      self.allKeys.isDown[positiveKeybind] = KEY_CHANGE.DETECTED
+    end
+  else
+    if self.allKeys.isDown[positiveKeybind] or self.allKeys.isPressed[positiveKeybind] then
+      self.allKeys.isUp[positiveKeybind] = KEY_CHANGE.DETECTED
+    end
+  end
+
+  if value < -0.5 then
+    if not self.allKeys.isDown[negativeKeybind] and not self.allKeys.isPressed[negativeKeybind] then
+      self.allKeys.isDown[negativeKeybind] = KEY_CHANGE.DETECTED
+    end
+  else
+    if self.allKeys.isDown[negativeKeybind] or self.allKeys.isPressed[negativeKeybind] then
+      self.allKeys.isUp[negativeKeybind] = KEY_CHANGE.DETECTED
     end
   end
 end
+
+-- maps joysticks' analog sticks state to the appropriate input maps
+-- function inputManager:joystickToButtons()
+--   for _, joystick in ipairs(love.joystick.getJoysticks()) do
+--     for axisIndex = 1, joystick:getAxisCount() / 2 do
+--       local dpadState = joystickManager:joystickToDPad(joystick, axisIndex * 2 - 1, axisIndex * 2)
+--       for key, isPressed in pairs(dpadState) do
+--         if isPressed then
+--           if not self.allKeys.isDown[key] and not self.allKeys.isPressed[key] then
+--             self.allKeys.isDown[key] = KEY_CHANGE.DETECTED
+--           end
+--         else
+--           if self.allKeys.isDown[key] or self.allKeys.isPressed[key] then
+--             self.allKeys.isUp[key] = KEY_CHANGE.DETECTED
+--           end
+--         end
+--       end
+--     end
+--   end
+-- end
 
 -- maps joysticks' dpad to the appropriate input maps
 function inputManager:dPadToButtons()
@@ -245,7 +281,7 @@ function inputManager:updateKeyMaps()
 end
 
 function inputManager:update(dt)
-  self:joystickToButtons()
+  --self:joystickToButtons()
   self:dPadToButtons()
   self:updateKeyStates(dt, self.allKeys)
   self:updateKeyStates(dt, self.mouse)

--- a/common/lib/inputManager.lua
+++ b/common/lib/inputManager.lua
@@ -99,7 +99,7 @@ function inputManager:joystickaxis(joystick, axisIndex, value)
   local stickIndex = math.floor((1 + axisIndex) / 2)
   local direction
 
-  if axisIndex % 2 then
+  if axisIndex % 2 == 0 then
     direction = "y"
   else
     direction = "x"

--- a/common/lib/joystickManager.lua
+++ b/common/lib/joystickManager.lua
@@ -42,17 +42,9 @@ local joystickHatToDirs = {
   rd = {"right", "down"}
 }
 
-function joystickManager:getJoystickButtonName(joystick, button) 
-  if not guidsToJoysticks[joystick:getGUID()] then 
-    guidsToJoysticks[joystick:getGUID()] = {} 
-    self.guidToName[joystick:getGUID()] = joystick:getName() 
-  end 
-  if not guidsToJoysticks[joystick:getGUID()][joystick:getID()] then 
-    guidsToJoysticks[joystick:getGUID()][joystick:getID()] = tableUtils.length(guidsToJoysticks[joystick:getGUID()]) 
-  end
-
+function joystickManager:getJoystickButtonName(joystick, button)
   return string.format("%s:%s:%s", joystick:getGUID(), guidsToJoysticks[joystick:getGUID()][joystick:getID()], button)
-end 
+end
 
 function joystickManager:recordDefaultAxis(joystick)
   if joystickToDefaultAxisPositions[joystick] == nil then
@@ -64,50 +56,50 @@ function joystickManager:recordDefaultAxis(joystick)
   end
 end
 
--- maps joysticks to buttons by converting the {x, y} axis values to {direction, magnitude} pair
--- this will give more even mapping along the diagonals when thresholded by a single value (joystickSensitivity)
-function joystickManager:joystickToDPad(joystick, xAxisIndex, yAxisIndex)
-  self:recordDefaultAxis(joystick)
+-- -- maps joysticks to buttons by converting the {x, y} axis values to {direction, magnitude} pair
+-- -- this will give more even mapping along the diagonals when thresholded by a single value (joystickSensitivity)
+-- function joystickManager:joystickToDPad(joystick, xAxisIndex, yAxisIndex)
+--   self:recordDefaultAxis(joystick)
 
-  local axis = yAxisIndex/2
-  local x = "x"..axis
-  local y = "y"..axis
+--   local axis = yAxisIndex/2
+--   local x = "x"..axis
+--   local y = "y"..axis
 
-  local dpadState = {
-    [joystickManager:getJoystickButtonName(joystick, "+"..x)] = false,
-    [joystickManager:getJoystickButtonName(joystick, "-"..x)] = false,
-    [joystickManager:getJoystickButtonName(joystick, "+"..y)] = false,
-    [joystickManager:getJoystickButtonName(joystick, "-"..y)] = false
-  }
+--   local dpadState = {
+--     [joystickManager:getJoystickButtonName(joystick, "+"..x)] = false,
+--     [joystickManager:getJoystickButtonName(joystick, "-"..x)] = false,
+--     [joystickManager:getJoystickButtonName(joystick, "+"..y)] = false,
+--     [joystickManager:getJoystickButtonName(joystick, "-"..y)] = false
+--   }
   
-  local xValue = joystickToDefaultAxisPositions[joystick][xAxisIndex] - joystick:getAxis(xAxisIndex)
-  local yValue = joystickToDefaultAxisPositions[joystick][yAxisIndex] - joystick:getAxis(yAxisIndex)
+--   local xValue = joystickToDefaultAxisPositions[joystick][xAxisIndex] - joystick:getAxis(xAxisIndex)
+--   local yValue = joystickToDefaultAxisPositions[joystick][yAxisIndex] - joystick:getAxis(yAxisIndex)
 
-  -- not taking the square root to get the magnitude since it's it more expensive than squaring the joystickSensitivity
-  local magSquared = xValue * xValue + yValue * yValue
-  local dir = math.atan2(yValue, xValue) * 180.0 / math.pi
-  -- atan2 maps to [-180, 180] the quantizedDir equation prefers positive numbers (due to modulo) so mapping to [0, 360]
-  dir = dir + 180
-  -- number of segments we are quantizing the joystick values to
-  local numDirSegments = #stickMap
-  -- the minimum angle we care to detect
-  local quantizationAngle = 360.0 / numDirSegments
-  -- if we quantized the raw direction the direction wouldn't register until you are greater than the direction
-  -- Ex: quantizedDir would be 0 (left) until you hit exactly 45deg before it changes to 1 (left, up) and would stay there until you are at 90deg
-  -- adding this offset so the transition is equidistant from both sides of the direction
-  -- Ex: quantizedDir is 1 (left, up) from the range [22.5, 67.5]
-  local angleOffset = quantizationAngle / 2
-  -- convert the continuous direction value into 8 quantized values which map to the stickMap indexes
-  local quantizedDir = math.floor(((dir + angleOffset) / quantizationAngle) % numDirSegments) + 1 
+--   -- not taking the square root to get the magnitude since it's it more expensive than squaring the joystickSensitivity
+--   local magSquared = xValue * xValue + yValue * yValue
+--   local dir = math.atan2(yValue, xValue) * 180.0 / math.pi
+--   -- atan2 maps to [-180, 180] the quantizedDir equation prefers positive numbers (due to modulo) so mapping to [0, 360]
+--   dir = dir + 180
+--   -- number of segments we are quantizing the joystick values to
+--   local numDirSegments = #stickMap
+--   -- the minimum angle we care to detect
+--   local quantizationAngle = 360.0 / numDirSegments
+--   -- if we quantized the raw direction the direction wouldn't register until you are greater than the direction
+--   -- Ex: quantizedDir would be 0 (left) until you hit exactly 45deg before it changes to 1 (left, up) and would stay there until you are at 90deg
+--   -- adding this offset so the transition is equidistant from both sides of the direction
+--   -- Ex: quantizedDir is 1 (left, up) from the range [22.5, 67.5]
+--   local angleOffset = quantizationAngle / 2
+--   -- convert the continuous direction value into 8 quantized values which map to the stickMap indexes
+--   local quantizedDir = math.floor(((dir + angleOffset) / quantizationAngle) % numDirSegments) + 1 
 
-  for _, button in ipairs(stickMap[quantizedDir]) do
-    local key = joystickManager:getJoystickButtonName(joystick, button..axis)
-    if magSquared > self.joystickSensitivity * self.joystickSensitivity then
-      dpadState[key] = true
-    end
-  end
-  return dpadState
-end
+--   for _, button in ipairs(stickMap[quantizedDir]) do
+--     local key = joystickManager:getJoystickButtonName(joystick, button..axis)
+--     if magSquared > self.joystickSensitivity * self.joystickSensitivity then
+--       dpadState[key] = true
+--     end
+--   end
+--   return dpadState
+-- end
 
 -- maps dpad dir to buttons
 function joystickManager:getDPadState(joystick, hatIndex)
@@ -119,7 +111,39 @@ function joystickManager:getDPadState(joystick, hatIndex)
     [joystickManager:getJoystickButtonName(joystick, "left"..hatIndex)] = tableUtils.contains(activeButtons, "left"),
     [joystickManager:getJoystickButtonName(joystick, "right"..hatIndex)] = tableUtils.contains(activeButtons, "right")
   }
-end 
+end
 
+function love.joystickadded(joystick)
+  -- GUID identifies the device type, 2 controllers of the same type will have a matching GUID
+  -- the GUID is consistent across sessions
+  local guid = joystick:getGUID()
+  -- ID is a per-session identifier for each controller regardless of type
+  local id = joystick:getID()
+
+  if not guidsToJoysticks[guid] then
+    guidsToJoysticks[guid] = {}
+    joystickManager.guidToName[guid] = joystick:getName()
+  end
+
+  local guidSticks = guidsToJoysticks[guid]
+
+  if not guidSticks[id] then
+    guidSticks[id] = #guidSticks + 1
+  end
+end
+
+function love.joystickremoved(joystick)
+  -- GUID identifies the device type, 2 controllers of the same type will have a matching GUID
+  -- the GUID is consistent across sessions
+  local guid = joystick:getGUID()
+  -- ID is a per-session identifier for each controller regardless of type
+  local id = joystick:getID()
+
+  guidsToJoysticks[guid][id] = nil
+
+  if tableUtils.length(guidsToJoysticks[guid]) == 0 then
+    guidsToJoysticks[guid] = nil
+  end
+end
 
 return joystickManager

--- a/main.lua
+++ b/main.lua
@@ -318,3 +318,7 @@ end
 function love.keyreleased(key, unicode)
   inputManager:keyReleased(key, unicode)
 end
+
+function love.joystickaxis(joystick, axisIndex, value)
+  inputManager:joystickaxis(joystick, axisIndex, value)
+end

--- a/serverLauncher.lua
+++ b/serverLauncher.lua
@@ -1,5 +1,9 @@
+if arg[1] == "debug" then
+  -- for debugging in visual studio code
+  pcall(function() require("lldebugger").start() end)
+end
+
 -- We must launch the server from the root directory so all the requires are the right path relatively.
-require("client.src.developer") -- Require developer here so we can debug if the debug flag is set
 require("server.server_globals")
 local util = require("common.lib.util")
 util.addToCPath("./common/lib/??")


### PR DESCRIPTION
Fixes #1214 
This reverts the 8-directional stick physics by Sankyr back to 4-directional stick physics causing the diagonals to only actuate for one or both directions if that direction on its own is actuated sufficiently far.

This also implements partway of #1154 because it turned out that was one of the ways that did not screw with the existing code.

Note that this is untested because I do not own a controller.